### PR TITLE
fix: make clientId immutable

### DIFF
--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -142,6 +142,7 @@ type OIDCClientSecretKeys struct {
 }
 
 // PocketIDOIDCClientSpec defines the desired state of PocketIDOIDCClient
+// +kubebuilder:validation:XValidation:rule="has(self.clientId) == has(oldSelf.clientId) && (!has(self.clientId) || self.clientId == oldSelf.clientId)",message="clientId is immutable"
 type PocketIDOIDCClientSpec struct {
 	// InstanceSelector selects the PocketIDInstance to reconcile against.
 	// If omitted, the controller expects exactly one instance in the cluster.
@@ -149,6 +150,7 @@ type PocketIDOIDCClientSpec struct {
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector,omitempty"`
 
 	// ClientID is the optional OIDC client ID to use instead of a generated one
+	// The Client ID is immutable and cannot be changed once the oidc client is created
 	// +kubebuilder:validation:MinLength=2
 	// +kubebuilder:validation:MaxLength=128
 	// +optional

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -66,8 +66,9 @@ spec:
                   type: string
                 type: array
               clientId:
-                description: ClientID is the optional OIDC client ID to use instead
-                  of a generated one
+                description: |-
+                  ClientID is the optional OIDC client ID to use instead of a generated one
+                  The Client ID is immutable and cannot be changed once the oidc client is created
                 maxLength: 128
                 minLength: 2
                 type: string
@@ -253,6 +254,10 @@ spec:
                     type: string
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: clientId is immutable
+              rule: has(self.clientId) == has(oldSelf.clientId) && (!has(self.clientId)
+                || self.clientId == oldSelf.clientId)
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:


### PR DESCRIPTION
The client id is not changeable in pocket-id, reflect that in the CRD as well
closes https://github.com/aclerici38/pocket-id-operator/issues/5