### PR TITLE
fix: add guards and retries to all api calls

### DIFF
--- a/internal/controller/common/base_reconciler.go
+++ b/internal/controller/common/base_reconciler.go
@@ -173,6 +173,10 @@ func (r *BaseReconciler) ReconcileDeleteWithPocketID(
 	// Delete from PocketID
 	logger.Info("Deleting from PocketID", "statusID", statusID)
 	if err := deleteFunc(ctx, apiClient, statusID); err != nil {
+		if IsTransientDependencyError(err) {
+			logger.Info("Pocket-ID is temporarily unavailable for delete, requeuing", "statusID", statusID, "error", err.Error())
+			return ctrl.Result{RequeueAfter: Requeue}, nil
+		}
 		logger.Error(err, "Failed to delete from PocketID")
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/common/constants.go
+++ b/internal/controller/common/constants.go
@@ -9,6 +9,18 @@ const (
 	// Requeue is the standard requeue delay for consistent error handling across controllers
 	Requeue = 5 * time.Second
 
+	// DependencyRequeue is used when waiting on referenced resources to become ready.
+	DependencyRequeue = 20 * time.Second
+
+	// SecretReadRetryAttempts is the number of attempts for important secret reads.
+	SecretReadRetryAttempts = 5
+
+	// SecretReadRetryInitialBackoff is the initial wait between secret read retries.
+	SecretReadRetryInitialBackoff = 200 * time.Millisecond
+
+	// SecretReadRetryMaxBackoff caps exponential backoff for secret reads.
+	SecretReadRetryMaxBackoff = 2 * time.Second
+
 	// OIDCClientAllowedGroupIndexKey is the index key for OIDC client allowed groups
 	OIDCClientAllowedGroupIndexKey = "pocketidoidcclient.allowedGroup"
 

--- a/internal/controller/common/dependency_errors.go
+++ b/internal/controller/common/dependency_errors.go
@@ -1,0 +1,16 @@
+package common
+
+import "strings"
+
+// IsDependencyNotReadyError returns true when reconciliation is blocked on referenced CR readiness.
+func IsDependencyNotReadyError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "is not ready (ready condition not true)") ||
+		strings.Contains(msg, "has no userid in status") ||
+		strings.Contains(msg, "has no groupid in status") ||
+		strings.Contains(msg, "has no clientid in status")
+}

--- a/internal/controller/common/retry.go
+++ b/internal/controller/common/retry.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// RetryKubernetesRead retries Kubernetes read operations for transient failures.
+// NotFound is retried as well to smooth over short creation-order races during startup.
+func RetryKubernetesRead(ctx context.Context, attempts int, fn func() error) error {
+	if attempts <= 0 {
+		attempts = 1
+	}
+
+	backoff := SecretReadRetryInitialBackoff
+	var lastErr error
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return lastErr
+			}
+			return err
+		}
+
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+		if attempt >= attempts || (!apierrors.IsNotFound(err) && !IsTransientKubernetesError(err)) {
+			return err
+		}
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			if lastErr != nil {
+				return lastErr
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		if backoff < SecretReadRetryMaxBackoff {
+			backoff *= 2
+			if backoff > SecretReadRetryMaxBackoff {
+				backoff = SecretReadRetryMaxBackoff
+			}
+		}
+	}
+
+	return lastErr
+}

--- a/internal/controller/common/transient_errors.go
+++ b/internal/controller/common/transient_errors.go
@@ -1,0 +1,99 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
+)
+
+// IsTransientKubernetesError returns true for Kubernetes API errors that should be retried.
+func IsTransientKubernetesError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsUnexpectedServerError(err) ||
+		apierrors.IsResourceExpired(err) {
+		return true
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() || netErr.Temporary() {
+			return true
+		}
+	}
+
+	msg := strings.ToLower(err.Error())
+	retryableFragments := []string{
+		"connection refused",
+		"no such host",
+		"i/o timeout",
+		"context deadline exceeded",
+		"dial tcp",
+		"connection reset by peer",
+		"tls handshake timeout",
+		"temporary failure in name resolution",
+		"eof",
+	}
+	for _, fragment := range retryableFragments {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsTransientDependencyError returns true when an error is a temporary Kubernetes or Pocket-ID dependency issue.
+func IsTransientDependencyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return IsTransientKubernetesError(err) || pocketid.IsTransientError(err)
+}
+
+// HandleTransientDependencyError sets a waiting condition and requeues for temporary dependency failures.
+func (r *BaseReconciler) HandleTransientDependencyError(
+	ctx context.Context,
+	obj ConditionedResource,
+	err error,
+	reason string,
+	message string,
+) (*ctrl.Result, bool) {
+	if !IsTransientDependencyError(err) {
+		return nil, false
+	}
+
+	if reason == "" {
+		reason = "DependencyUnavailable"
+	}
+	if message == "" {
+		message = "Waiting for dependent services to become reachable"
+	}
+
+	logf.FromContext(ctx).Info(
+		"Dependency is temporarily unavailable, requeuing",
+		"reason", reason,
+		"error", err.Error(),
+	)
+	_ = r.SetReadyCondition(ctx, obj, metav1.ConditionFalse, reason, message)
+	return &ctrl.Result{RequeueAfter: Requeue}, true
+}

--- a/internal/controller/helpers/references.go
+++ b/internal/controller/helpers/references.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pocketidv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
 )
 
 // IsResourceReady checks if a resource has the Ready condition set to True
@@ -37,7 +38,14 @@ func ResolveUserReferences(
 		}
 
 		user := &pocketidv1alpha1.PocketIDUser{}
-		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, user); err != nil {
+		if err := common.RetryKubernetesRead(ctx, common.SecretReadRetryAttempts, func() error {
+			current := &pocketidv1alpha1.PocketIDUser{}
+			getErr := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, current)
+			if getErr == nil {
+				user = current
+			}
+			return getErr
+		}); err != nil {
 			return nil, fmt.Errorf("get user %s: %w", ref.Name, err)
 		}
 
@@ -75,7 +83,14 @@ func ResolveOIDCClientReferences(
 		}
 
 		oidcClient := &pocketidv1alpha1.PocketIDOIDCClient{}
-		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, oidcClient); err != nil {
+		if err := common.RetryKubernetesRead(ctx, common.SecretReadRetryAttempts, func() error {
+			current := &pocketidv1alpha1.PocketIDOIDCClient{}
+			getErr := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, current)
+			if getErr == nil {
+				oidcClient = current
+			}
+			return getErr
+		}); err != nil {
 			return nil, fmt.Errorf("get OIDC client %s: %w", ref.Name, err)
 		}
 
@@ -113,7 +128,14 @@ func ResolveUserGroupReferences(
 		}
 
 		group := &pocketidv1alpha1.PocketIDUserGroup{}
-		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, group); err != nil {
+		if err := common.RetryKubernetesRead(ctx, common.SecretReadRetryAttempts, func() error {
+			current := &pocketidv1alpha1.PocketIDUserGroup{}
+			getErr := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, current)
+			if getErr == nil {
+				group = current
+			}
+			return getErr
+		}); err != nil {
 			return nil, fmt.Errorf("get user group %s: %w", ref.Name, err)
 		}
 

--- a/internal/pocketid/errors.go
+++ b/internal/pocketid/errors.go
@@ -2,8 +2,11 @@
 package pocketid
 
 import (
+	"context"
 	"errors"
+	"net"
 	"net/http"
+	"strings"
 
 	"github.com/go-openapi/runtime"
 )
@@ -24,5 +27,52 @@ func IsAlreadyExistsError(err error) bool {
 	if errors.As(err, &apiErr) {
 		return apiErr.IsCode(http.StatusBadRequest) || apiErr.IsCode(http.StatusConflict)
 	}
+	return false
+}
+
+// IsTransientError returns true for temporary/retryable API and network failures.
+func IsTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var apiErr *runtime.APIError
+	if errors.As(err, &apiErr) {
+		// 429 + 5xx are generally retryable.
+		if apiErr.Code == http.StatusTooManyRequests || apiErr.Code >= http.StatusInternalServerError {
+			return true
+		}
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() || netErr.Temporary() {
+			return true
+		}
+	}
+
+	msg := strings.ToLower(err.Error())
+	retryableFragments := []string{
+		"connection refused",
+		"no such host",
+		"i/o timeout",
+		"context deadline exceeded",
+		"dial tcp",
+		"connection reset by peer",
+		"tls handshake timeout",
+		"temporary failure in name resolution",
+		"eof",
+		"you are not signed in",
+	}
+	for _, fragment := range retryableFragments {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+
 	return false
 }


### PR DESCRIPTION
Rollout of the latest version hammered the k8s and pocket-id api a lot more... try to fix that

note: this is all ai generated as a POC