### PR TITLE
fix(controller): prevent accidental deletion of adopted PVCs

### DIFF
--- a/internal/controller/instance/controller.go
+++ b/internal/controller/instance/controller.go
@@ -639,21 +639,49 @@ func isHTTPRouteCRDUnavailableError(err error) bool {
 }
 
 func (r *Reconciler) reconcileVolume(ctx context.Context, instance *pocketidinternalv1alpha1.PocketIDInstance) error {
+	log := logf.FromContext(ctx)
+	defaultPVCName := instance.Name + "-data"
 	pvc := &corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-data",
+			Name:      defaultPVCName,
 			Namespace: instance.Namespace,
 		},
 	}
 
-	// Delete PVC if persistence is disabled, using existing claim, or using StatefulSet
-	if !instance.Spec.Persistence.Enabled || instance.Spec.Persistence.ExistingClaim != "" || instance.Spec.DeploymentType == deploymentTypeStatefulSet {
+	// Delete PVC if persistence is disabled or using StatefulSet
+	if !instance.Spec.Persistence.Enabled || instance.Spec.DeploymentType == deploymentTypeStatefulSet {
+		log.V(1).Info("Deleting default PVC (persistence disabled or StatefulSet)", "pvc", defaultPVCName)
 		err := r.Delete(ctx, pvc)
 		return client.IgnoreNotFound(err)
+	}
+
+	// If using an existing claim, delete the default PVC ONLY if its name is different from the existing claim
+	if instance.Spec.Persistence.ExistingClaim != "" {
+		if instance.Spec.Persistence.ExistingClaim != defaultPVCName {
+			log.V(1).Info("Deleting default PVC (using different existingClaim)", "pvc", defaultPVCName, "existingClaim", instance.Spec.Persistence.ExistingClaim)
+			err := r.Delete(ctx, pvc)
+			return client.IgnoreNotFound(err)
+		}
+		// If they are the same, we need to ensure it's no longer managed by us
+		// to prevent it from being deleted when the instance is deleted (garbage collection)
+		existing := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(pvc), existing); err == nil {
+			log.V(1).Info("Removing management labels and ownerReference from default PVC (used as existingClaim)", "pvc", defaultPVCName)
+			original := existing.DeepCopy()
+			existing.OwnerReferences = nil
+
+			// Remove managed-by label
+			delete(existing.Labels, common.ManagedByLabelKey)
+
+			if !reflect.DeepEqual(original, existing) {
+				return r.Update(ctx, existing)
+			}
+		}
+		return nil
 	}
 
 	// Ensure storageClass gets set to nil if empty

--- a/internal/controller/pocketidinstance_controller_test.go
+++ b/internal/controller/pocketidinstance_controller_test.go
@@ -640,6 +640,7 @@ var _ = Describe("PocketIDInstance Controller", func() {
 					},
 					Persistence: pocketidinternalv1alpha1.PersistenceConfig{
 						Enabled:       true,
+						Size:          resource.MustParse("1Gi"),
 						ExistingClaim: existingPVC.Name,
 					},
 				},
@@ -682,6 +683,303 @@ var _ = Describe("PocketIDInstance Controller", func() {
 			Expect(volumes).To(HaveLen(1))
 			Expect(volumes[0].VolumeSource.PersistentVolumeClaim).NotTo(BeNil())
 			Expect(volumes[0].VolumeSource.PersistentVolumeClaim.ClaimName).To(Equal(existingPVCName))
+		})
+	})
+
+	Context("When creating a PocketIDInstance with existing PVC having the default name", func() {
+		var instanceName string
+		var existingPVCName string
+
+		var instance *pocketidinternalv1alpha1.PocketIDInstance
+		var secret *corev1.Secret
+		var existingPVC *corev1.PersistentVolumeClaim
+
+		BeforeEach(func() {
+			// Use the same name as what the operator would generate by default
+			instanceName = "test-default-pvc-name-" + time.Now().Format("150405")
+			existingPVCName = instanceName + "-data"
+
+			// Create an existing PVC
+			existingPVC = &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      existingPVCName,
+					Namespace: namespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("5Gi"),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingPVC)).To(Succeed())
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName + "-secret",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					"encryption-key": []byte("test-encryption-key-value"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			instance = &pocketidinternalv1alpha1.PocketIDInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+				},
+				Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+					EncryptionKey: pocketidinternalv1alpha1.SensitiveValue{
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secret.Name,
+								},
+								Key: "encryption-key",
+							},
+						},
+					},
+					Persistence: pocketidinternalv1alpha1.PersistenceConfig{
+						Enabled:       true,
+						Size:          resource.MustParse("1Gi"),
+						ExistingClaim: existingPVC.Name,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if instance != nil {
+				_ = k8sClient.Delete(ctx, instance)
+			}
+			if secret != nil {
+				_ = k8sClient.Delete(ctx, secret)
+			}
+			if existingPVC != nil {
+				_ = k8sClient.Delete(ctx, existingPVC)
+			}
+		})
+
+		It("Should NOT delete the existing PVC even though it has the default name", func() {
+			pvc := &corev1.PersistentVolumeClaim{}
+			Consistently(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      existingPVCName,
+					Namespace: namespace,
+				}, pvc)
+			}, time.Second*2, interval).Should(Succeed())
+		})
+	})
+
+	Context("When switching from default PVC to a different existing PVC", func() {
+		var instanceName string
+		var defaultPVCName string
+		var existingPVCName string
+
+		var instance *pocketidinternalv1alpha1.PocketIDInstance
+		var secret *corev1.Secret
+		var existingPVC *corev1.PersistentVolumeClaim
+
+		BeforeEach(func() {
+			instanceName = "test-switch-pvc-" + time.Now().Format("150405")
+			defaultPVCName = instanceName + "-data"
+			existingPVCName = "other-pvc-" + time.Now().Format("150405")
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName + "-secret",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					"encryption-key": []byte("test-encryption-key-value"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// 1. Create instance with default persistence
+			instance = &pocketidinternalv1alpha1.PocketIDInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+				},
+				Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+					EncryptionKey: pocketidinternalv1alpha1.SensitiveValue{
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secret.Name,
+								},
+								Key: "encryption-key",
+							},
+						},
+					},
+					Persistence: pocketidinternalv1alpha1.PersistenceConfig{
+						Enabled: true,
+						Size:    resource.MustParse("1Gi"),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			// Wait for default PVC to be created
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      defaultPVCName,
+					Namespace: namespace,
+				}, pvc)
+			}, timeout, interval).Should(Succeed())
+
+			// 2. Create a different PVC
+			existingPVC = &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      existingPVCName,
+					Namespace: namespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingPVC)).To(Succeed())
+
+			// 3. Update instance to use existingClaim
+			base := instance.DeepCopy()
+			instance.Spec.Persistence.ExistingClaim = existingPVCName
+			Expect(k8sClient.Patch(ctx, instance, client.MergeFrom(base))).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if instance != nil {
+				_ = k8sClient.Delete(ctx, instance)
+			}
+			if secret != nil {
+				_ = k8sClient.Delete(ctx, secret)
+			}
+			if existingPVC != nil {
+				_ = k8sClient.Delete(ctx, existingPVC)
+			}
+		})
+
+		It("Should delete the old default PVC", func() {
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      defaultPVCName,
+					Namespace: namespace,
+				}, pvc)
+				if err != nil {
+					return apierrors.IsNotFound(err)
+				}
+				return !pvc.DeletionTimestamp.IsZero()
+			}, timeout, interval).Should(BeTrue(), "Default PVC should be deleted or marked for deletion when switching to a different existingClaim")
+		})
+	})
+
+	Context("When adopting a default PVC as an existing claim", func() {
+		var instanceName string
+		var defaultPVCName string
+
+		var instance *pocketidinternalv1alpha1.PocketIDInstance
+		var secret *corev1.Secret
+
+		BeforeEach(func() {
+			instanceName = "test-adopt-pvc-" + time.Now().Format("150405")
+			defaultPVCName = instanceName + "-data"
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName + "-secret",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					"encryption-key": []byte("test-encryption-key-value"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// 1. Create instance with default persistence
+			instance = &pocketidinternalv1alpha1.PocketIDInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+				},
+				Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+					EncryptionKey: pocketidinternalv1alpha1.SensitiveValue{
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secret.Name,
+								},
+								Key: "encryption-key",
+							},
+						},
+					},
+					Persistence: pocketidinternalv1alpha1.PersistenceConfig{
+						Enabled: true,
+						Size:    resource.MustParse("1Gi"),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			// Wait for default PVC to be created with ownerRef
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() int {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      defaultPVCName,
+					Namespace: namespace,
+				}, pvc)
+				if err != nil {
+					return 0
+				}
+				return len(pvc.OwnerReferences)
+			}, timeout, interval).Should(BeNumerically(">", 0))
+
+			// 2. Update instance to use same PVC as existingClaim
+			base := instance.DeepCopy()
+			instance.Spec.Persistence.ExistingClaim = defaultPVCName
+			Expect(k8sClient.Patch(ctx, instance, client.MergeFrom(base))).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if instance != nil {
+				_ = k8sClient.Delete(ctx, instance)
+			}
+			if secret != nil {
+				_ = k8sClient.Delete(ctx, secret)
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultPVCName,
+					Namespace: namespace,
+				},
+			}
+			_ = k8sClient.Delete(ctx, pvc)
+		})
+
+		It("Should remove ownerReference and managed-by labels from the PVC", func() {
+			pvc := &corev1.PersistentVolumeClaim{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      defaultPVCName,
+					Namespace: namespace,
+				}, pvc)
+				if err != nil {
+					return false
+				}
+				// Check if ownerReferences are gone and managed-by label is gone
+				return len(pvc.OwnerReferences) == 0 && pvc.Labels["managed-by"] != "pocket-id-operator"
+			}, timeout, interval).Should(BeTrue(), "OwnerReferences and managed-by labels should be removed")
 		})
 	})
 
@@ -831,6 +1129,7 @@ var _ = Describe("PocketIDInstance Controller", func() {
 					},
 					Persistence: pocketidinternalv1alpha1.PersistenceConfig{
 						Enabled:       true,
+						Size:          resource.MustParse("1Gi"),
 						ExistingClaim: existingPVC.Name,
 					},
 				},


### PR DESCRIPTION
## Summary
This PR fixes a bug in the PocketIDInstance controller where the operator would accidentally delete a PersistentVolumeClaim (PVC) if it was named according to the operator's default convention (<instance-name>-data) and then specified in spec.persistence.existingClaim.

## The Problem
When a user attempted to "adopt" a PVC that was either previously managed by the operator or manually created with the standard naming convention, the reconcileVolume logic would unconditionally attempt to delete any PVC matching the default name if existingClaim was set. This caused:
1. The desired PVC to be placed in a Terminating state.
2. The PersistentVolume (PV) to hang with a dangling reference to the deleted PVC.
3. The PocketID Pod to fail to start because it could not mount the terminating PVC.

## Changes
- Modified reconcileVolume: Added a check to ensure the default PVC is only deleted if its name differs from the one specified in existingClaim.
- Improved Management: If the existingClaim matches the default name, the operator now gracefully stops managing that PVC's lifecycle (labels/ownership) without deleting the underlying resource.
- Added Regression Tests: 
  - Verified that an existing PVC with the default name is not deleted when referenced via existingClaim.
  - Verified that switching from a default PVC to a different existingClaim correctly triggers the cleanup of the old, unused PVC.

Fixes #255