### PR TITLE
fix: k8s version label is invalid

### DIFF
--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -58,7 +58,7 @@ Includes app version, chart version, app name, instance, and managed-by labels.
 */}}
 {{- define "chart.labels" -}}
 {{- if .Chart.AppVersion -}}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" | quote }}
 {{- end }}
 {{- if .Chart.Version }}
 helm.sh/chart: {{ .Chart.Version | quote }}


### PR DESCRIPTION
Bit of a weird one, i'm not 100% sure if this is right. 

So i'm trying to get a flux HelmRelease going for this operator and i'm bumping into the following:

```
failed to create resource: PrometheusRule.monitoring.coreos.com "pocket-id-operator" is invalid: metadata.labels: Invalid value: "0.5.1+1d22aa02fbee": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

It seems like a commit is appended to the chart version, which breaks the labels in the chart. 

Good thing is, this label is only used in the PrometheusRule template. 

I copied this fix from: [bitnami/charts#36324](https://github.com/bitnami/charts/pull/36324) which should make the label valid. 

Only thing i'm sure of is, the helm chart is auto-generated right? Maybe this change will be overridden in the future?