### PR TITLE
fix(chart): cleanup helm labels to align with helm create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,9 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	@rm -rf dist/chart/crds
 	@mkdir -p dist/chart/crds
 	@cp config/crd/bases/*.yaml dist/chart/crds/
-	@cp config/rbac/role.yaml dist/chart/templates/rbac/manager-role.yaml
+	@sed '/^metadata:$$/a\
+\  labels:\
+\    {{- include "chart.labels" . | nindent 4 }}' config/rbac/role.yaml > dist/chart/templates/rbac/manager-role.yaml
 
 .PHONY: generate-schemas
 generate-schemas: manifests ## Generate JSON schemas from CRDs for yaml-language-server support.

--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -3,15 +3,7 @@ Chart name based on project name.
 Truncated to 63 characters for Kubernetes compatibility.
 */}}
 {{- define "chart.name" -}}
-{{- if .Chart }}
-  {{- if .Chart.Name }}
-    {{- .Chart.Name | trunc 63 | trimSuffix "-" }}
-  {{- else }}
-    pocket-id-operator
-  {{- end }}
-{{- else }}
-  pocket-id-operator
-{{- end }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -53,18 +45,21 @@ If fullname + suffix exceeds 63 chars, truncates fullname to 45 chars.
 {{- end }}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Common labels for Helm charts.
-Includes app version, chart version, app name, instance, and managed-by labels.
 */}}
 {{- define "chart.labels" -}}
-{{- if .Chart.AppVersion -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Chart.Version }}
-helm.sh/chart: {{ .Chart.Version | quote }}
-{{- end }}
-app.kubernetes.io/name: {{ include "chart.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/dist/chart/templates/instance/instance-servicemonitor.yaml
+++ b/dist/chart/templates/instance/instance-servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Values.instance.name | default "pocket-id" }}
   namespace: {{ .Release.Namespace }}
   labels:
+    helm.sh/chart: {{ include "chart.chart" . }}
     app.kubernetes.io/name: pocket-id
     app.kubernetes.io/instance: {{ .Values.instance.name | default "pocket-id" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/dist/chart/templates/instance/pocketidinstance.yaml
+++ b/dist/chart/templates/instance/pocketidinstance.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ .Values.instance.name | default "pocket-id" }}
   namespace: {{ .Release.Namespace }}
   labels:
+    helm.sh/chart: {{ include "chart.chart" . }}
     app.kubernetes.io/name: pocket-id
     app.kubernetes.io/instance: {{ .Values.instance.name | default "pocket-id" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "chart.name" . }}
     {{- with .Values.instance.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/dist/chart/templates/metrics/metrics-service.yaml
+++ b/dist/chart/templates/metrics/metrics-service.yaml
@@ -2,18 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-    labels:
-        {{- include "chart.labels" . | nindent 8 }}
-        control-plane: controller-manager
-    name: pocket-id-operator-metrics-service
-    namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
+  name: pocket-id-operator-metrics-service
+  namespace: {{ .Release.Namespace }}
 spec:
-    ports:
-        - name: http
-          port: {{ .Values.metrics.port }}
-          protocol: TCP
-          targetPort: {{ .Values.metrics.port }}
-    selector:
-        app.kubernetes.io/name: pocket-id-operator
-        control-plane: controller-manager
+  ports:
+    - name: http
+      port: {{ .Values.metrics.port }}
+      protocol: TCP
+      targetPort: {{ .Values.metrics.port }}
+  selector:
+    app.kubernetes.io/name: pocket-id-operator
+    control-plane: controller-manager
 {{- end }}

--- a/dist/chart/templates/metrics/metrics-service.yaml
+++ b/dist/chart/templates/metrics/metrics-service.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
     labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: pocket-id-operator
+        {{- include "chart.labels" . | nindent 8 }}
         control-plane: controller-manager
     name: pocket-id-operator-metrics-service
     namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/monitoring/servicemonitor.yaml
+++ b/dist/chart/templates/monitoring/servicemonitor.yaml
@@ -15,5 +15,6 @@ spec:
       honorLabels: true
   selector:
     matchLabels:
+      app.kubernetes.io/name: pocket-id-operator
       control-plane: controller-manager
 {{- end }}

--- a/dist/chart/templates/operator/manager.yaml
+++ b/dist/chart/templates/operator/manager.yaml
@@ -1,103 +1,100 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    labels:
-        {{- include "chart.labels" . | nindent 8 }}
-        control-plane: controller-manager
-    name: pocket-id-operator
-    namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
+  name: pocket-id-operator
+  namespace: {{ .Release.Namespace }}
 spec:
-    replicas: 1
-    selector:
-        matchLabels:
-            app.kubernetes.io/name: pocket-id-operator
-            control-plane: controller-manager
-    template:
-        metadata:
-            annotations:
-                kubectl.kubernetes.io/default-container: operator
-            labels:
-                app.kubernetes.io/name: pocket-id-operator
-                control-plane: controller-manager
-        spec:
-            affinity:
-                nodeAffinity:
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                        nodeSelectorTerms:
-                            - matchExpressions:
-                                - key: kubernetes.io/arch
-                                  operator: In
-                                  values:
-                                    - amd64
-                                    - arm64
-                                - key: kubernetes.io/os
-                                  operator: In
-                                  values:
-                                    - linux
-            containers:
-                - args:
-                    {{- if and .Values.metrics .Values.metrics.enabled }}
-                    - --metrics-bind-address=:{{ .Values.metrics.port }}
-                    {{- else }}
-                    # Bind to :0 to disable the controller-runtime managed metrics server
-                    - --metrics-bind-address=0
-                    {{- end }}
-                    - --health-probe-bind-address=:8081
-                    - --leader-elect
-                    {{- range .Values.operator.args }}
-                    - {{ . }}
-                    {{- end }}
-                  env:
-                    - name: AUTOGENERATE_LOGOS
-                      value: {{ .Values.operator.autoGenerateLogos | quote }}
-                    {{- if .Values.operator.defaultLogoUrl }}
-                    - name: DEFAULT_LOGO_URL
-                      value: {{ .Values.operator.defaultLogoUrl | quote }}
-                    {{- end }}
-                    {{- if .Values.operator.defaultDarkLogoUrl }}
-                    - name: DEFAULT_DARK_LOGO_URL
-                      value: {{ .Values.operator.defaultDarkLogoUrl | quote }}
-                    {{- end }}
-                    {{- range .Values.operator.env }}
-                    - {{- toYaml . | nindent 22 }}
-                    {{- end }}
-                  command:
-                    - /manager
-                  image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
-                  imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
-                  livenessProbe:
-                    httpGet:
-                        path: /healthz
-                        port: 8081
-                    initialDelaySeconds: 15
-                    periodSeconds: 20
-                  name: operator
-                  ports: []
-                  readinessProbe:
-                    httpGet:
-                        path: /readyz
-                        port: 8081
-                    initialDelaySeconds: 5
-                    periodSeconds: 10
-                  resources:
-                    {{- if .Values.operator.resources }}
-                    {{- toYaml .Values.operator.resources | nindent 20 }}
-                    {{- else }}
-                    {}
-                    {{- end }}
-                  securityContext:
-                    {{- if .Values.operator.securityContext }}
-                    {{- toYaml .Values.operator.securityContext | nindent 20 }}
-                    {{- else }}
-                    {}
-                    {{- end }}
-                  volumeMounts: []
-            securityContext:
-              {{- if .Values.operator.podSecurityContext }}
-              {{- toYaml .Values.operator.podSecurityContext | nindent 14 }}
-              {{- else }}
-              {}
-              {{- end }}
-            serviceAccountName: pocket-id-operator
-            terminationGracePeriodSeconds: 10
-            volumes: []
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pocket-id-operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: operator
+      labels:
+        app.kubernetes.io/name: pocket-id-operator
+        control-plane: controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - args:
+            {{- if and .Values.metrics .Values.metrics.enabled }}
+            - --metrics-bind-address=:{{ .Values.metrics.port }}
+            {{- else }}
+            # Bind to :0 to disable the controller-runtime managed metrics server
+            - --metrics-bind-address=0
+            {{- end }}
+            - --health-probe-bind-address=:8081
+            - --leader-elect
+            {{- range .Values.operator.args }}
+            - {{ . }}
+            {{- end }}
+          env:
+            - name: AUTOGENERATE_LOGOS
+              value: {{ .Values.operator.autoGenerateLogos | quote }}
+            {{- if .Values.operator.defaultLogoUrl }}
+            - name: DEFAULT_LOGO_URL
+              value: {{ .Values.operator.defaultLogoUrl | quote }}
+            {{- end }}
+            {{- if .Values.operator.defaultDarkLogoUrl }}
+            - name: DEFAULT_DARK_LOGO_URL
+              value: {{ .Values.operator.defaultDarkLogoUrl | quote }}
+            {{- end }}
+            {{- range .Values.operator.env }}
+            - {{- toYaml . | nindent 14 }}
+            {{- end }}
+          command:
+            - /manager
+          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: operator
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- if .Values.operator.resources }}
+            {{- toYaml .Values.operator.resources | nindent 12 }}
+            {{- else }}
+            {}
+            {{- end }}
+          securityContext:
+            {{- if .Values.operator.securityContext }}
+            {{- toYaml .Values.operator.securityContext | nindent 12 }}
+            {{- else }}
+            {}
+            {{- end }}
+      securityContext:
+        {{- if .Values.operator.podSecurityContext }}
+        {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
+        {{- else }}
+        {}
+        {{- end }}
+      serviceAccountName: pocket-id-operator
+      terminationGracePeriodSeconds: 10

--- a/dist/chart/templates/operator/manager.yaml
+++ b/dist/chart/templates/operator/manager.yaml
@@ -2,8 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
     labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: pocket-id-operator
+        {{- include "chart.labels" . | nindent 8 }}
         control-plane: controller-manager
     name: pocket-id-operator
     namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/leader-election-role.yaml
+++ b/dist/chart/templates/rbac/leader-election-role.yaml
@@ -1,39 +1,39 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-    labels:
-        {{- include "chart.labels" . | nindent 8 }}
-    name: pocket-id-operator-leader-election-role
-    namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: pocket-id-operator-leader-election-role
+  namespace: {{ .Release.Namespace }}
 rules:
-    - apiGroups:
-        - ""
-      resources:
-        - configmaps
-      verbs:
-        - get
-        - list
-        - watch
-        - create
-        - update
-        - patch
-        - delete
-    - apiGroups:
-        - coordination.k8s.io
-      resources:
-        - leases
-      verbs:
-        - get
-        - list
-        - watch
-        - create
-        - update
-        - patch
-        - delete
-    - apiGroups:
-        - ""
-      resources:
-        - events
-      verbs:
-        - create
-        - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/dist/chart/templates/rbac/leader-election-role.yaml
+++ b/dist/chart/templates/rbac/leader-election-role.yaml
@@ -2,8 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
     labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: pocket-id-operator
+        {{- include "chart.labels" . | nindent 8 }}
     name: pocket-id-operator-leader-election-role
     namespace: {{ .Release.Namespace }}
 rules:

--- a/dist/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/dist/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -2,8 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: pocket-id-operator
+        {{- include "chart.labels" . | nindent 8 }}
     name: pocket-id-operator-leader-election-rolebinding
     namespace: {{ .Release.Namespace }}
 roleRef:

--- a/dist/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/dist/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-    labels:
-        {{- include "chart.labels" . | nindent 8 }}
-    name: pocket-id-operator-leader-election-rolebinding
-    namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: pocket-id-operator-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
 roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: pocket-id-operator-leader-election-role
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pocket-id-operator-leader-election-role
 subjects:
-    - kind: ServiceAccount
-      name: pocket-id-operator
-      namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: pocket-id-operator
+    namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -2,8 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    {{- include "chart.labels" . | nindent 4 }}
   name: pocket-id-operator-manager-role
 rules:
 - apiGroups:

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -2,6 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
   name: pocket-id-operator-manager-role
 rules:
 - apiGroups:

--- a/dist/chart/templates/rbac/manager-rolebinding.yaml
+++ b/dist/chart/templates/rbac/manager-rolebinding.yaml
@@ -2,8 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: pocket-id-operator
+        {{- include "chart.labels" . | nindent 8 }}
     name: pocket-id-operator-manager-rolebinding
 roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/dist/chart/templates/rbac/manager-rolebinding.yaml
+++ b/dist/chart/templates/rbac/manager-rolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-    labels:
-        {{- include "chart.labels" . | nindent 8 }}
-    name: pocket-id-operator-manager-rolebinding
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: pocket-id-operator-manager-rolebinding
 roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: pocket-id-operator-manager-role
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pocket-id-operator-manager-role
 subjects:
-    - kind: ServiceAccount
-      name: pocket-id-operator
-      namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: pocket-id-operator
+    namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/pocket-id-operator.yaml
+++ b/dist/chart/templates/rbac/pocket-id-operator.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: pocket-id-operator
+        {{- include "chart.labels" . | nindent 8 }}
     name: pocket-id-operator
     namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/pocket-id-operator.yaml
+++ b/dist/chart/templates/rbac/pocket-id-operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    labels:
-        {{- include "chart.labels" . | nindent 8 }}
-    name: pocket-id-operator
-    namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: pocket-id-operator
+  namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/usergroups/pocketidusergroup.yaml
+++ b/dist/chart/templates/usergroups/pocketidusergroup.yaml
@@ -6,10 +6,10 @@ metadata:
   name: {{ .name }}
   namespace: {{ $.Release.Namespace }}
   labels:
+    helm.sh/chart: {{ include "chart.chart" $ }}
     app.kubernetes.io/name: pocket-id-usergroup
     app.kubernetes.io/instance: {{ .name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    helm.sh/chart: {{ include "chart.name" $ }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/dist/chart/templates/users/pocketiduser.yaml
+++ b/dist/chart/templates/users/pocketiduser.yaml
@@ -6,10 +6,10 @@ metadata:
   name: {{ .name }}
   namespace: {{ $.Release.Namespace }}
   labels:
+    helm.sh/chart: {{ include "chart.chart" $ }}
     app.kubernetes.io/name: pocket-id-user
     app.kubernetes.io/instance: {{ .name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    helm.sh/chart: {{ include "chart.name" $ }}
     {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Fixes https://github.com/aclerici38/pocket-id-operator/pull/270

chart was initially created and maintained with the kubebuilder helm plugin which deviated from `helm create` defaults for some reason