### PR TITLE
feat: add initContainers support to PocketIDInstance spec

### DIFF
--- a/api/v1alpha1/pocketidinstance_types.go
+++ b/api/v1alpha1/pocketidinstance_types.go
@@ -413,6 +413,11 @@ type PocketIDInstanceSpec struct {
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
+	// InitContainers to run before the main pocket-id container.
+	// Useful for database initialization, migrations, or other setup tasks.
+	// +optional
+	InitContainers []corev1.Container `json:"initContainers,omitempty"`
+
 	// Configures persistence for Pocket-ID
 	// Note: Pocket-ID can be run statelessly if using Postgres as a file and db backend
 	// If not enabled mounts an emptydir instead

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -447,6 +447,13 @@ func (in *PocketIDInstanceSpec) DeepCopyInto(out *PocketIDInstanceSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.InitContainers != nil {
+		in, out := &in.InitContainers, &out.InitContainers
+		*out = make([]v1.Container, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Persistence.DeepCopyInto(&out.Persistence)
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext

--- a/internal/controller/instance/controller.go
+++ b/internal/controller/instance/controller.go
@@ -251,6 +251,62 @@ func (r *Reconciler) buildPodTemplate(instance *pocketidinternalv1alpha1.PocketI
 	}
 	podSpec.Containers = []corev1apply.ContainerApplyConfiguration{*container}
 
+	// Add user-defined init containers
+	if len(instance.Spec.InitContainers) > 0 {
+		initContainersApply := make([]corev1apply.ContainerApplyConfiguration, 0, len(instance.Spec.InitContainers))
+		for _, ic := range instance.Spec.InitContainers {
+			icCopy := ic
+			initCfg := corev1apply.Container().
+				WithName(icCopy.Name).
+				WithImage(icCopy.Image)
+			if len(icCopy.Command) > 0 {
+				initCfg.WithCommand(icCopy.Command...)
+			}
+			if len(icCopy.Args) > 0 {
+				initCfg.WithArgs(icCopy.Args...)
+			}
+			if len(icCopy.Env) > 0 {
+				initCfg.Env = envVarApplyConfigurationValues(icCopy.Env)
+			}
+			if len(icCopy.EnvFrom) > 0 {
+				envFromApply := make([]corev1apply.EnvFromSourceApplyConfiguration, 0, len(icCopy.EnvFrom))
+				for _, ef := range icCopy.EnvFrom {
+					efCfg := corev1apply.EnvFromSource()
+					if ef.Prefix != "" {
+						efCfg.WithPrefix(ef.Prefix)
+					}
+					if ef.ConfigMapRef != nil {
+						cmRef := corev1apply.ConfigMapEnvSource().WithName(ef.ConfigMapRef.Name)
+						if ef.ConfigMapRef.Optional != nil {
+							cmRef.WithOptional(*ef.ConfigMapRef.Optional)
+						}
+						efCfg.WithConfigMapRef(cmRef)
+					}
+					if ef.SecretRef != nil {
+						secRef := corev1apply.SecretEnvSource().WithName(ef.SecretRef.Name)
+						if ef.SecretRef.Optional != nil {
+							secRef.WithOptional(*ef.SecretRef.Optional)
+						}
+						efCfg.WithSecretRef(secRef)
+					}
+					envFromApply = append(envFromApply, *efCfg)
+				}
+				initCfg.EnvFrom = envFromApply
+			}
+			if len(icCopy.VolumeMounts) > 0 {
+				initCfg.VolumeMounts = volumeMountApplyConfigurationValues(icCopy.VolumeMounts)
+			}
+			if icCopy.SecurityContext != nil {
+				initCfg.WithSecurityContext(securityContextApplyConfiguration(icCopy.SecurityContext))
+			}
+			if icCopy.Resources.Requests != nil || icCopy.Resources.Limits != nil {
+				initCfg.WithResources(resourceRequirementsApplyConfiguration(icCopy.Resources))
+			}
+			initContainersApply = append(initContainersApply, *initCfg)
+		}
+		podSpec.InitContainers = initContainersApply
+	}
+
 	if len(volumes) > 0 {
 		podSpec.Volumes = volumeApplyConfigurationValues(volumes)
 	}


### PR DESCRIPTION
## Summary

This PR adds `initContainers` support to the `PocketIDInstance` spec, allowing users to define init containers that run before the main `pocket-id` container.

## Motivation

A common use case is running a database initialization container (e.g. creating the Postgres database and user) before Pocket ID starts. Without native `initContainers` support in the operator, users were forced to apply Kustomize JSON patches on top of the operator-managed Deployment — a fragile workaround that fails because GitOps tools like Flux apply patches at render time before the Deployment is actually created by the operator.

## Changes

- **`api/v1alpha1/pocketidinstance_types.go`**: Added `InitContainers []corev1.Container` field to `PocketIDInstanceSpec`
- **`internal/controller/instance/controller.go`**: Updated `buildPodTemplate` to convert and inject user-defined init containers into the pod spec, supporting `env`, `envFrom` (both `secretRef` and `configMapRef`), `volumeMounts`, `securityContext`, and `resources`
- **`api/v1alpha1/zz_generated.deepcopy.go`**: Added deepcopy implementation for the new `InitContainers` field

## Example Usage

```yaml
apiVersion: pocketid.internal/v1alpha1
kind: PocketIDInstance
metadata:
  name: pocket-id
spec:
  initContainers:
    - name: init-db
      image: ghcr.io/home-operations/postgres-init:18
      envFrom:
        - secretRef:
            name: pocket-id-secret
  encryptionKey:
    valueFrom:
      secretKeyRef:
        name: pocket-id-secret
        key: ENCRYPTION_KEY
```

## Notes

- The full `corev1.Container` type is used to keep maximum flexibility without having to maintain a subset type
- No breaking changes — the field is optional and defaults to `nil`