### PR TITLE
fix: remove predicate on oidcclient annotations

### DIFF
--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -56,6 +56,9 @@ const (
 	// (which gates the per-client interval) but deliberately leave this one untouched, so an
 	// out-of-band rotation never perturbs the instance's scheduled-rotation spacing.
 	lastScheduledRotationAtAnnotation = "pocketid.internal/last-scheduled-rotation-at"
+	// regenerateClientSecretAnnotation is set by a user to force an immediate secret
+	// rotation, bypassing the scheduled-rotation gates.
+	regenerateClientSecretAnnotation = "pocketid.internal/regenerate-client-secret"
 
 	defaultLogoTemplate     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}.png"
 	defaultDarkLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}-dark.png"
@@ -199,7 +202,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: common.Requeue}, nil
 	}
 
-	if removed, err := helpers.CheckAndRemoveAnnotation(ctx, r.Client, oidcClient, "pocketid.internal/regenerate-client-secret", "true"); err != nil {
+	if removed, err := helpers.CheckAndRemoveAnnotation(ctx, r.Client, oidcClient, regenerateClientSecretAnnotation, "true"); err != nil {
 		log.Error(err, "Failed to remove regenerate-client-secret annotation")
 		return ctrl.Result{RequeueAfter: common.Requeue}, nil
 	} else if removed {
@@ -1149,7 +1152,7 @@ func (r *Reconciler) secretRegenDecision(ctx context.Context, oidcClient *pocket
 		d.regenerate, d.trigger = true, "initial"
 		return d, nil
 	}
-	if helpers.HasAnnotation(oidcClient, "pocketid.internal/regenerate-client-secret", "true") {
+	if helpers.HasAnnotation(oidcClient, regenerateClientSecretAnnotation, "true") {
 		d.regenerate, d.trigger = true, "manual"
 		return d, nil
 	}
@@ -1364,6 +1367,15 @@ func (r *Reconciler) requestsForUserGroup(ctx context.Context, obj client.Object
 	return requests
 }
 
+// oidcClientPredicate gates which events enqueue a reconcile. GenerationChangedPredicate
+// alone drops annotation-only edits (annotations don't bump metadata.generation), which
+// would delay a manual regenerate-client-secret request until the next periodic resync.
+// Or-ing in AnnotationChangedPredicate lets the annotation force an immediate rotation
+// while still filtering out status-only updates.
+func oidcClientPredicate() predicate.Predicate {
+	return predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
@@ -1394,7 +1406,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&pocketidinternalv1alpha1.PocketIDOIDCClient{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&pocketidinternalv1alpha1.PocketIDOIDCClient{}, builder.WithPredicates(oidcClientPredicate())).
 		Watches(
 			&pocketidinternalv1alpha1.PocketIDUserGroup{},
 			handler.EnqueueRequestsFromMapFunc(r.requestsForUserGroup),

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
 	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
@@ -1705,5 +1706,60 @@ func TestReconcileSCIM_TokenFromSecret_MissingKey_ReturnsError(t *testing.T) {
 	err := r.ReconcileSCIM(ctx, oidcClient, api)
 	if err == nil {
 		t.Fatal("expected error for missing key, got nil")
+	}
+}
+
+// TestOidcClientPredicate_ManualRotationEnqueues guards the manual-rotation trigger:
+// setting the regenerate-client-secret annotation must enqueue a reconcile even though
+// annotations do not bump metadata.generation. Without this the rotation would not fire
+// until the next periodic resync, so a manual annotation would not "force" a rotation.
+func TestOidcClientPredicate_ManualRotationEnqueues(t *testing.T) {
+	pred := oidcClientPredicate()
+
+	obj := func(gen int64, annotations map[string]string) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+		return &pocketidinternalv1alpha1.PocketIDOIDCClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "trek",
+				Namespace:   testNamespace,
+				Generation:  gen,
+				Annotations: annotations,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		old, new *pocketidinternalv1alpha1.PocketIDOIDCClient
+		want     bool
+	}{
+		{
+			name: "regenerate annotation added without a generation bump",
+			old:  obj(2, nil),
+			new:  obj(2, map[string]string{regenerateClientSecretAnnotation: "true"}),
+			want: true,
+		},
+		{
+			name: "spec change bumps generation",
+			old:  obj(2, nil),
+			new:  obj(3, nil),
+			want: true,
+		},
+		{
+			// Guards against simply dropping the predicate, which would reconcile on
+			// every status write and resync (the rate-limiting the predicate prevents).
+			name: "no generation or annotation change",
+			old:  obj(2, map[string]string{regenerateClientSecretAnnotation: "true"}),
+			new:  obj(2, map[string]string{regenerateClientSecretAnnotation: "true"}),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pred.Update(event.UpdateEvent{ObjectOld: tc.old, ObjectNew: tc.new})
+			if got != tc.want {
+				t.Errorf("predicate.Update() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Thought there was a bug because manual annotations weren't working, I think it's just this. It should only reconcile when annotations are changed and not status. This code hasn't changed in months but maybe it's always been this way?