### PR TITLE
fix(tests): prevent dns queries from leaving envtest

### DIFF
--- a/internal/controller/instance/controller.go
+++ b/internal/controller/instance/controller.go
@@ -53,6 +53,7 @@ import (
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
 	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
 	"github.com/aclerici38/pocket-id-operator/internal/metrics"
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
 )
 
 const (
@@ -72,11 +73,30 @@ const (
 	defaultMountPath = "/app/data"
 )
 
+// APIClientFactory builds the Pocket-ID API client used to talk to an instance.
+// It mirrors common.GetAPIClient and exists so tests can inject a client that
+// targets a local server instead of the in-cluster Service DNS name, which is
+// unresolvable under envtest.
+type APIClientFactory func(ctx context.Context, k8sClient client.Client, apiReader client.Reader, instance *pocketidinternalv1alpha1.PocketIDInstance) (*pocketid.Client, error)
+
 // Reconciler reconciles a PocketIDInstance object
 type Reconciler struct {
 	client.Client
 	APIReader client.Reader
 	Scheme    *runtime.Scheme
+
+	// NewAPIClient builds the Pocket-ID API client for an instance. When nil it
+	// defaults to common.GetAPIClient; tests override it to avoid real network I/O.
+	NewAPIClient APIClientFactory
+}
+
+// apiClientFor returns the Pocket-ID API client for the instance, using the
+// injected factory when set and falling back to the production default.
+func (r *Reconciler) apiClientFor(ctx context.Context, instance *pocketidinternalv1alpha1.PocketIDInstance) (*pocketid.Client, error) {
+	if r.NewAPIClient != nil {
+		return r.NewAPIClient(ctx, r.Client, r.APIReader, instance)
+	}
+	return common.GetAPIClient(ctx, r.Client, r.APIReader, instance)
 }
 
 // +kubebuilder:rbac:groups=pocketid.internal,resources=pocketidinstances,verbs=get;list;watch;create;update;patch;delete
@@ -162,7 +182,7 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, instance *pocketidin
 	reason := "Unreachable"
 	var message string
 
-	apiClient, err := common.GetAPIClient(ctx, r.Client, r.APIReader, instance)
+	apiClient, err := r.apiClientFor(ctx, instance)
 	if err != nil {
 		reason = "APIClientError"
 		message = err.Error()
@@ -772,7 +792,7 @@ func (r *Reconciler) reconcileVolume(ctx context.Context, instance *pocketidinte
 }
 
 func (r *Reconciler) reconcileVersion(ctx context.Context, instance *pocketidinternalv1alpha1.PocketIDInstance) error {
-	apiClient, err := common.GetAPIClient(ctx, r.Client, r.APIReader, instance)
+	apiClient, err := r.apiClientFor(ctx, instance)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,6 +45,7 @@ import (
 	"github.com/aclerici38/pocket-id-operator/internal/controller/oidcclient"
 	"github.com/aclerici38/pocket-id-operator/internal/controller/user"
 	"github.com/aclerici38/pocket-id-operator/internal/controller/usergroup"
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -55,6 +58,13 @@ var (
 	testEnv   *envtest.Environment
 	cfg       *rest.Config
 	k8sClient client.Client
+
+	// pocketIDServer stands in for a real Pocket-ID API. envtest has no CoreDNS or
+	// Service endpoints, so the in-cluster URL the instance reconciler would dial
+	// (`*.svc.cluster.local`) is unresolvable; on macOS that name also routes to
+	// mDNS and stalls. The instance reconciler is pointed here instead so version
+	// reconciliation stays hermetic and fast.
+	pocketIDServer *httptest.Server
 )
 
 func TestControllers(t *testing.T) {
@@ -108,10 +118,19 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	pocketIDServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"currentVersion":"2.8.0"}`))
+	}))
+
 	err = (&instance.Reconciler{
 		Client:    k8sManager.GetClient(),
 		APIReader: k8sManager.GetAPIReader(),
 		Scheme:    k8sManager.GetScheme(),
+		// Avoid dialing the in-cluster Service DNS name (unresolvable under envtest).
+		NewAPIClient: func(context.Context, client.Client, client.Reader, *pocketidinternalv1alpha1.PocketIDInstance) (*pocketid.Client, error) {
+			return pocketid.NewClient(pocketIDServer.URL, "test-api-key")
+		},
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -149,6 +168,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
+	if pocketIDServer != nil {
+		pocketIDServer.Close()
+	}
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
macos swallows up *.cluster.local indefinitely, the tests shouldn't be hitting the actual DNS anyways