### PR TITLE
fix: key resource deletion on name + labels

### DIFF
--- a/internal/controller/common/labels.go
+++ b/internal/controller/common/labels.go
@@ -1,6 +1,10 @@
 package common
 
-import "maps"
+import (
+	"maps"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	ManagedByLabelKey   = "managed-by"
@@ -12,4 +16,12 @@ func ManagedByLabels(labels map[string]string) map[string]string {
 	maps.Copy(merged, labels)
 	merged[ManagedByLabelKey] = ManagedByLabelValue
 	return merged
+}
+
+// IsManagedByOperator reports whether obj was created and is managed by this
+// operator. The operator stamps every resource it creates with the managed-by
+// label, so its absence means the resource was created by someone else (e.g. a
+// user's own same-named resource) and must not be deleted during cleanup.
+func IsManagedByOperator(obj metav1.Object) bool {
+	return obj.GetLabels()[ManagedByLabelKey] == ManagedByLabelValue
 }

--- a/internal/controller/common/labels_test.go
+++ b/internal/controller/common/labels_test.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsManagedByOperator(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name:   "managed-by label with operator value",
+			labels: map[string]string{ManagedByLabelKey: ManagedByLabelValue},
+			want:   true,
+		},
+		{
+			name:   "managed-by label among other labels",
+			labels: map[string]string{"app": "x", ManagedByLabelKey: ManagedByLabelValue},
+			want:   true,
+		},
+		{
+			name:   "nil labels",
+			labels: nil,
+			want:   false,
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+			want:   false,
+		},
+		{
+			name:   "managed-by label with a different value",
+			labels: map[string]string{ManagedByLabelKey: "someone-else"},
+			want:   false,
+		},
+		{
+			name:   "unrelated labels only",
+			labels: map[string]string{"app": "x", "managed-by-something": ManagedByLabelValue},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &metav1.ObjectMeta{Labels: tt.labels}
+			if got := IsManagedByOperator(obj); got != tt.want {
+				t.Errorf("IsManagedByOperator(%v) = %v, want %v", tt.labels, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/helpers/secrets.go
+++ b/internal/controller/helpers/secrets.go
@@ -6,17 +6,20 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
 )
 
-// DeleteSecretIfExists deletes a secret, ignoring NotFound errors
-func DeleteSecretIfExists(ctx context.Context, c client.Client, namespace, name string) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+// DeleteSecretIfManaged deletes a secret by name only if it exists and is
+// managed by the operator
+func DeleteSecretIfManaged(ctx context.Context, c client.Client, namespace, name string) error {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !common.IsManagedByOperator(secret) {
+		return nil
 	}
 	if err := c.Delete(ctx, secret); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete secret %s: %w", name, err)
@@ -24,10 +27,11 @@ func DeleteSecretIfExists(ctx context.Context, c client.Client, namespace, name 
 	return nil
 }
 
-// DeleteSecretsIfExist deletes multiple secrets, ignoring NotFound errors
-func DeleteSecretsIfExist(ctx context.Context, c client.Client, namespace string, secretNames []string) error {
+// DeleteSecretsIfManaged deletes multiple operator-managed secrets by name,
+// skipping any that the operator does not own. See DeleteSecretIfManaged.
+func DeleteSecretsIfManaged(ctx context.Context, c client.Client, namespace string, secretNames []string) error {
 	for _, name := range secretNames {
-		if err := DeleteSecretIfExists(ctx, c, namespace, name); err != nil {
+		if err := DeleteSecretIfManaged(ctx, c, namespace, name); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/helpers/secrets_test.go
+++ b/internal/controller/helpers/secrets_test.go
@@ -1,0 +1,123 @@
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
+)
+
+func secretsTestClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+}
+
+func managedSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{common.ManagedByLabelKey: common.ManagedByLabelValue},
+		},
+	}
+}
+
+func unmanagedSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+}
+
+func secretExists(t *testing.T, c client.Client, name string) bool {
+	t.Helper()
+	err := c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, &corev1.Secret{})
+	if err == nil {
+		return true
+	}
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+	t.Fatalf("unexpected error getting secret %s: %v", name, err)
+	return false
+}
+
+func TestDeleteSecretIfManaged_DeletesManagedSecret(t *testing.T) {
+	c := secretsTestClient(t, managedSecret("managed"))
+
+	if err := DeleteSecretIfManaged(context.Background(), c, "default", "managed"); err != nil {
+		t.Fatalf("DeleteSecretIfManaged returned error: %v", err)
+	}
+	if secretExists(t, c, "managed") {
+		t.Fatal("expected managed secret to be deleted")
+	}
+}
+
+func TestDeleteSecretIfManaged_PreservesUnmanagedSecret(t *testing.T) {
+	c := secretsTestClient(t, unmanagedSecret("user-owned"))
+
+	if err := DeleteSecretIfManaged(context.Background(), c, "default", "user-owned"); err != nil {
+		t.Fatalf("DeleteSecretIfManaged returned error: %v", err)
+	}
+	if !secretExists(t, c, "user-owned") {
+		t.Fatal("expected unmanaged (user-owned) secret to be preserved")
+	}
+}
+
+func TestDeleteSecretIfManaged_PreservesSecretWithWrongManagedByValue(t *testing.T) {
+	s := unmanagedSecret("other-operator")
+	s.Labels = map[string]string{common.ManagedByLabelKey: "another-operator"}
+	c := secretsTestClient(t, s)
+
+	if err := DeleteSecretIfManaged(context.Background(), c, "default", "other-operator"); err != nil {
+		t.Fatalf("DeleteSecretIfManaged returned error: %v", err)
+	}
+	if !secretExists(t, c, "other-operator") {
+		t.Fatal("expected secret managed by a different operator to be preserved")
+	}
+}
+
+func TestDeleteSecretIfManaged_MissingSecretIsNoOp(t *testing.T) {
+	c := secretsTestClient(t)
+
+	if err := DeleteSecretIfManaged(context.Background(), c, "default", "does-not-exist"); err != nil {
+		t.Fatalf("DeleteSecretIfManaged returned error for missing secret: %v", err)
+	}
+}
+
+func TestDeleteSecretsIfManaged_DeletesOnlyManaged(t *testing.T) {
+	c := secretsTestClient(t,
+		managedSecret("managed-a"),
+		unmanagedSecret("user-owned-b"),
+		managedSecret("managed-c"),
+	)
+
+	names := []string{"managed-a", "user-owned-b", "managed-c", "missing-d"}
+	if err := DeleteSecretsIfManaged(context.Background(), c, "default", names); err != nil {
+		t.Fatalf("DeleteSecretsIfManaged returned error: %v", err)
+	}
+
+	if secretExists(t, c, "managed-a") {
+		t.Fatal("expected managed-a to be deleted")
+	}
+	if secretExists(t, c, "managed-c") {
+		t.Fatal("expected managed-c to be deleted")
+	}
+	if !secretExists(t, c, "user-owned-b") {
+		t.Fatal("expected user-owned-b to be preserved")
+	}
+}

--- a/internal/controller/instance/controller.go
+++ b/internal/controller/instance/controller.go
@@ -564,8 +564,18 @@ func (r *Reconciler) reconcileHTTPRoute(ctx context.Context, instance *pocketidi
 
 	if instance.Spec.Route == nil || !instance.Spec.Route.Enabled {
 		existing := &gatewayv1.HTTPRoute{}
-		existing.Name = routeName
-		existing.Namespace = instance.Namespace
+		if err := r.Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: routeName}, existing); err != nil {
+			if isHTTPRouteCRDUnavailableError(err) {
+				return nil
+			}
+			return client.IgnoreNotFound(err)
+		}
+		// Only delete the route if the operator created it
+		if !common.IsManagedByOperator(existing) {
+			logf.FromContext(ctx).Info("Skipping deletion of HTTPRoute not managed by operator",
+				"name", routeName, "namespace", instance.Namespace)
+			return nil
+		}
 		err := r.Delete(ctx, existing)
 		if isHTTPRouteCRDUnavailableError(err) {
 			return nil
@@ -673,6 +683,22 @@ func isHTTPRouteCRDUnavailableError(err error) bool {
 	return strings.Contains(err.Error(), "the server could not find the requested resource")
 }
 
+// deleteIfManaged fetches obj and deletes it only if it is managed by the
+// operator. This prevents cleanup logic from removing a same-named resource
+// that a user created and the operator does not own.
+func (r *Reconciler) deleteIfManaged(ctx context.Context, obj client.Object) error {
+	key := client.ObjectKeyFromObject(obj)
+	if err := r.Get(ctx, key, obj); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !common.IsManagedByOperator(obj) {
+		logf.FromContext(ctx).Info("Skipping deletion of resource not managed by operator",
+			"kind", obj.GetObjectKind().GroupVersionKind().Kind, "name", key.Name, "namespace", key.Namespace)
+		return nil
+	}
+	return client.IgnoreNotFound(r.Delete(ctx, obj))
+}
+
 func (r *Reconciler) reconcileVolume(ctx context.Context, instance *pocketidinternalv1alpha1.PocketIDInstance) error {
 	log := logf.FromContext(ctx)
 	defaultPVCName := instance.Name + "-data"
@@ -690,16 +716,14 @@ func (r *Reconciler) reconcileVolume(ctx context.Context, instance *pocketidinte
 	// Delete PVC if persistence is disabled or using StatefulSet
 	if !instance.Spec.Persistence.Enabled || instance.Spec.DeploymentType == "StatefulSet" {
 		log.V(1).Info("Deleting default PVC (persistence disabled or StatefulSet)", "pvc", defaultPVCName)
-		err := r.Delete(ctx, pvc)
-		return client.IgnoreNotFound(err)
+		return r.deleteIfManaged(ctx, pvc)
 	}
 
 	// If using an existing claim, delete the default PVC ONLY if its name is different from the existing claim
 	if instance.Spec.Persistence.ExistingClaim != "" {
 		if instance.Spec.Persistence.ExistingClaim != defaultPVCName {
 			log.V(1).Info("Deleting default PVC (using different existingClaim)", "pvc", defaultPVCName, "existingClaim", instance.Spec.Persistence.ExistingClaim)
-			err := r.Delete(ctx, pvc)
-			return client.IgnoreNotFound(err)
+			return r.deleteIfManaged(ctx, pvc)
 		}
 		// If they are the same, we need to ensure it's no longer managed by us
 		// to prevent it from being deleted when the instance is deleted (garbage collection)

--- a/internal/controller/instance/volume_cleanup_test.go
+++ b/internal/controller/instance/volume_cleanup_test.go
@@ -23,10 +23,15 @@ func volumeTestReconciler(t *testing.T, objs ...client.Object) *Reconciler {
 	return &Reconciler{Client: fc, APIReader: fc, Scheme: s}
 }
 
-func dataPVC(instanceName string, managed bool) *corev1.PersistentVolumeClaim {
+const (
+	volumeTestInstance = "inst"
+	volumeTestPVCName  = volumeTestInstance + "-data"
+)
+
+func dataPVC(managed bool) *corev1.PersistentVolumeClaim {
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instanceName + "-data",
+			Name:      volumeTestPVCName,
 			Namespace: "default",
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -42,57 +47,57 @@ func dataPVC(instanceName string, managed bool) *corev1.PersistentVolumeClaim {
 	return pvc
 }
 
-func pvcExists(t *testing.T, r *Reconciler, name string) bool {
+func pvcExists(t *testing.T, r *Reconciler) bool {
 	t.Helper()
-	err := r.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, &corev1.PersistentVolumeClaim{})
+	err := r.Get(context.Background(), types.NamespacedName{Name: volumeTestPVCName, Namespace: "default"}, &corev1.PersistentVolumeClaim{})
 	if err == nil {
 		return true
 	}
 	if apierrors.IsNotFound(err) {
 		return false
 	}
-	t.Fatalf("unexpected error getting pvc %s: %v", name, err)
+	t.Fatalf("unexpected error getting pvc %s: %v", volumeTestPVCName, err)
 	return false
 }
 
 // --- deleteIfManaged ---
 
 func TestDeleteIfManaged_DeletesManagedObject(t *testing.T) {
-	pvc := dataPVC("inst", true)
+	pvc := dataPVC(true)
 	r := volumeTestReconciler(t, pvc)
 
 	if err := r.deleteIfManaged(context.Background(), pvc.DeepCopy()); err != nil {
 		t.Fatalf("deleteIfManaged returned error: %v", err)
 	}
-	if pvcExists(t, r, "inst-data") {
+	if pvcExists(t, r) {
 		t.Fatal("expected managed PVC to be deleted")
 	}
 }
 
 func TestDeleteIfManaged_PreservesUnmanagedObject(t *testing.T) {
-	pvc := dataPVC("inst", false)
+	pvc := dataPVC(false)
 	r := volumeTestReconciler(t, pvc)
 
 	if err := r.deleteIfManaged(context.Background(), pvc.DeepCopy()); err != nil {
 		t.Fatalf("deleteIfManaged returned error: %v", err)
 	}
-	if !pvcExists(t, r, "inst-data") {
+	if !pvcExists(t, r) {
 		t.Fatal("expected unmanaged (user-owned) PVC to be preserved")
 	}
 }
 
 func TestDeleteIfManaged_MissingObjectIsNoOp(t *testing.T) {
 	r := volumeTestReconciler(t)
-	if err := r.deleteIfManaged(context.Background(), dataPVC("inst", true)); err != nil {
+	if err := r.deleteIfManaged(context.Background(), dataPVC(true)); err != nil {
 		t.Fatalf("deleteIfManaged returned error for missing object: %v", err)
 	}
 }
 
 // --- reconcileVolume cleanup branches must not delete user-owned PVCs ---
 
-func instanceForVolume(name string, mutate func(*pocketidinternalv1alpha1.PocketIDInstanceSpec)) *pocketidinternalv1alpha1.PocketIDInstance {
+func instanceForVolume(mutate func(*pocketidinternalv1alpha1.PocketIDInstanceSpec)) *pocketidinternalv1alpha1.PocketIDInstance {
 	inst := &pocketidinternalv1alpha1.PocketIDInstance{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: volumeTestInstance, Namespace: "default"},
 		Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
 			Persistence: pocketidinternalv1alpha1.PersistenceConfig{
 				Enabled: true,
@@ -105,61 +110,61 @@ func instanceForVolume(name string, mutate func(*pocketidinternalv1alpha1.Pocket
 }
 
 func TestReconcileVolume_PersistenceDisabledPreservesUserPVC(t *testing.T) {
-	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+	inst := instanceForVolume(func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
 		s.Persistence.Enabled = false
 	})
-	userPVC := dataPVC("inst", false)
+	userPVC := dataPVC(false)
 	r := volumeTestReconciler(t, inst, userPVC)
 
 	if err := r.reconcileVolume(context.Background(), inst); err != nil {
 		t.Fatalf("reconcileVolume returned error: %v", err)
 	}
-	if !pvcExists(t, r, "inst-data") {
+	if !pvcExists(t, r) {
 		t.Fatal("expected user-owned PVC to be preserved when persistence is disabled")
 	}
 }
 
 func TestReconcileVolume_PersistenceDisabledDeletesManagedPVC(t *testing.T) {
-	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+	inst := instanceForVolume(func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
 		s.Persistence.Enabled = false
 	})
-	managedPVC := dataPVC("inst", true)
+	managedPVC := dataPVC(true)
 	r := volumeTestReconciler(t, inst, managedPVC)
 
 	if err := r.reconcileVolume(context.Background(), inst); err != nil {
 		t.Fatalf("reconcileVolume returned error: %v", err)
 	}
-	if pvcExists(t, r, "inst-data") {
+	if pvcExists(t, r) {
 		t.Fatal("expected operator-managed PVC to be deleted when persistence is disabled")
 	}
 }
 
 func TestReconcileVolume_StatefulSetPreservesUserPVC(t *testing.T) {
-	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+	inst := instanceForVolume(func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
 		s.DeploymentType = "StatefulSet"
 	})
-	userPVC := dataPVC("inst", false)
+	userPVC := dataPVC(false)
 	r := volumeTestReconciler(t, inst, userPVC)
 
 	if err := r.reconcileVolume(context.Background(), inst); err != nil {
 		t.Fatalf("reconcileVolume returned error: %v", err)
 	}
-	if !pvcExists(t, r, "inst-data") {
+	if !pvcExists(t, r) {
 		t.Fatal("expected user-owned PVC to be preserved for StatefulSet deployment")
 	}
 }
 
 func TestReconcileVolume_DifferentExistingClaimPreservesUserPVC(t *testing.T) {
-	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+	inst := instanceForVolume(func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
 		s.Persistence.ExistingClaim = "some-other-claim"
 	})
-	userPVC := dataPVC("inst", false)
+	userPVC := dataPVC(false)
 	r := volumeTestReconciler(t, inst, userPVC)
 
 	if err := r.reconcileVolume(context.Background(), inst); err != nil {
 		t.Fatalf("reconcileVolume returned error: %v", err)
 	}
-	if !pvcExists(t, r, "inst-data") {
+	if !pvcExists(t, r) {
 		t.Fatal("expected user-owned default-named PVC to be preserved when a different existingClaim is set")
 	}
 }

--- a/internal/controller/instance/volume_cleanup_test.go
+++ b/internal/controller/instance/volume_cleanup_test.go
@@ -1,0 +1,165 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
+)
+
+func volumeTestReconciler(t *testing.T, objs ...client.Object) *Reconciler {
+	t.Helper()
+	s := externalTestScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	return &Reconciler{Client: fc, APIReader: fc, Scheme: s}
+}
+
+func dataPVC(instanceName string, managed bool) *corev1.PersistentVolumeClaim {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName + "-data",
+			Namespace: "default",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+		},
+	}
+	if managed {
+		pvc.Labels = map[string]string{common.ManagedByLabelKey: common.ManagedByLabelValue}
+	}
+	return pvc
+}
+
+func pvcExists(t *testing.T, r *Reconciler, name string) bool {
+	t.Helper()
+	err := r.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, &corev1.PersistentVolumeClaim{})
+	if err == nil {
+		return true
+	}
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+	t.Fatalf("unexpected error getting pvc %s: %v", name, err)
+	return false
+}
+
+// --- deleteIfManaged ---
+
+func TestDeleteIfManaged_DeletesManagedObject(t *testing.T) {
+	pvc := dataPVC("inst", true)
+	r := volumeTestReconciler(t, pvc)
+
+	if err := r.deleteIfManaged(context.Background(), pvc.DeepCopy()); err != nil {
+		t.Fatalf("deleteIfManaged returned error: %v", err)
+	}
+	if pvcExists(t, r, "inst-data") {
+		t.Fatal("expected managed PVC to be deleted")
+	}
+}
+
+func TestDeleteIfManaged_PreservesUnmanagedObject(t *testing.T) {
+	pvc := dataPVC("inst", false)
+	r := volumeTestReconciler(t, pvc)
+
+	if err := r.deleteIfManaged(context.Background(), pvc.DeepCopy()); err != nil {
+		t.Fatalf("deleteIfManaged returned error: %v", err)
+	}
+	if !pvcExists(t, r, "inst-data") {
+		t.Fatal("expected unmanaged (user-owned) PVC to be preserved")
+	}
+}
+
+func TestDeleteIfManaged_MissingObjectIsNoOp(t *testing.T) {
+	r := volumeTestReconciler(t)
+	if err := r.deleteIfManaged(context.Background(), dataPVC("inst", true)); err != nil {
+		t.Fatalf("deleteIfManaged returned error for missing object: %v", err)
+	}
+}
+
+// --- reconcileVolume cleanup branches must not delete user-owned PVCs ---
+
+func instanceForVolume(name string, mutate func(*pocketidinternalv1alpha1.PocketIDInstanceSpec)) *pocketidinternalv1alpha1.PocketIDInstance {
+	inst := &pocketidinternalv1alpha1.PocketIDInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+			Persistence: pocketidinternalv1alpha1.PersistenceConfig{
+				Enabled: true,
+				Size:    resource.MustParse("1Gi"),
+			},
+		},
+	}
+	mutate(&inst.Spec)
+	return inst
+}
+
+func TestReconcileVolume_PersistenceDisabledPreservesUserPVC(t *testing.T) {
+	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+		s.Persistence.Enabled = false
+	})
+	userPVC := dataPVC("inst", false)
+	r := volumeTestReconciler(t, inst, userPVC)
+
+	if err := r.reconcileVolume(context.Background(), inst); err != nil {
+		t.Fatalf("reconcileVolume returned error: %v", err)
+	}
+	if !pvcExists(t, r, "inst-data") {
+		t.Fatal("expected user-owned PVC to be preserved when persistence is disabled")
+	}
+}
+
+func TestReconcileVolume_PersistenceDisabledDeletesManagedPVC(t *testing.T) {
+	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+		s.Persistence.Enabled = false
+	})
+	managedPVC := dataPVC("inst", true)
+	r := volumeTestReconciler(t, inst, managedPVC)
+
+	if err := r.reconcileVolume(context.Background(), inst); err != nil {
+		t.Fatalf("reconcileVolume returned error: %v", err)
+	}
+	if pvcExists(t, r, "inst-data") {
+		t.Fatal("expected operator-managed PVC to be deleted when persistence is disabled")
+	}
+}
+
+func TestReconcileVolume_StatefulSetPreservesUserPVC(t *testing.T) {
+	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+		s.DeploymentType = "StatefulSet"
+	})
+	userPVC := dataPVC("inst", false)
+	r := volumeTestReconciler(t, inst, userPVC)
+
+	if err := r.reconcileVolume(context.Background(), inst); err != nil {
+		t.Fatalf("reconcileVolume returned error: %v", err)
+	}
+	if !pvcExists(t, r, "inst-data") {
+		t.Fatal("expected user-owned PVC to be preserved for StatefulSet deployment")
+	}
+}
+
+func TestReconcileVolume_DifferentExistingClaimPreservesUserPVC(t *testing.T) {
+	inst := instanceForVolume("inst", func(s *pocketidinternalv1alpha1.PocketIDInstanceSpec) {
+		s.Persistence.ExistingClaim = "some-other-claim"
+	})
+	userPVC := dataPVC("inst", false)
+	r := volumeTestReconciler(t, inst, userPVC)
+
+	if err := r.reconcileVolume(context.Background(), inst); err != nil {
+		t.Fatalf("reconcileVolume returned error: %v", err)
+	}
+	if !pvcExists(t, r, "inst-data") {
+		t.Fatal("expected user-owned default-named PVC to be preserved when a different existingClaim is set")
+	}
+}

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -881,10 +881,15 @@ func (r *Reconciler) ReconcileSecret(ctx context.Context, oidcClient *pocketidin
 	secretName := r.GetSecretName(oidcClient)
 
 	if !enabled {
-		// Delete the secret if it exists but is now disabled
+		// Delete the secret if it exists but is now disabled. Only delete a
+		// secret the operator manages: a user may point spec.secret.name at a
+		// secret they own, and we must never delete a resource we don't manage.
 		secret := &corev1.Secret{}
 		err := r.Get(ctx, client.ObjectKey{Name: secretName, Namespace: oidcClient.Namespace}, secret)
 		if err == nil {
+			if !common.IsManagedByOperator(secret) {
+				return nil
+			}
 			if err := r.Delete(ctx, secret); err != nil {
 				return fmt.Errorf("failed to delete disabled secret: %w", err)
 			}

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
 	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
 )
 
@@ -315,6 +316,9 @@ func TestReconcileSecret_DeleteWhenDisabled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-disabled-secret-oidc-credentials",
 			Namespace: testNamespace,
+			// The operator stamps this label on every secret it creates; a
+			// secret it manages must be deleted when the secret is disabled.
+			Labels: map[string]string{common.ManagedByLabelKey: common.ManagedByLabelValue},
 		},
 		Data: map[string][]byte{
 			"client_id": []byte("client-123"),

--- a/internal/controller/oidcclient/secret_cleanup_test.go
+++ b/internal/controller/oidcclient/secret_cleanup_test.go
@@ -1,0 +1,89 @@
+package oidcclient
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
+)
+
+func secretCleanupReconciler(t *testing.T, objs ...client.Object) *Reconciler {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := pocketidinternalv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add pocketid scheme: %v", err)
+	}
+	fc := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	r := &Reconciler{Client: fc, APIReader: fc, Scheme: s}
+	r.EnsureClient(fc)
+	return r
+}
+
+func TestReconcileSecret_DisabledDeletesManagedSecret(t *testing.T) {
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-client", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			Secret: &pocketidinternalv1alpha1.OIDCClientSecretSpec{Enabled: boolPtr(false)},
+		},
+	}
+	managed := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-client-oidc-credentials",
+			Namespace: testNamespace,
+			Labels:    map[string]string{common.ManagedByLabelKey: common.ManagedByLabelValue},
+		},
+	}
+
+	r := secretCleanupReconciler(t, oidcClient, managed)
+
+	// instance and apiClient are unused by the disabled-secret branch.
+	if err := r.ReconcileSecret(context.Background(), oidcClient, nil, nil); err != nil {
+		t.Fatalf("ReconcileSecret returned error: %v", err)
+	}
+
+	err := r.Get(context.Background(), types.NamespacedName{Name: managed.Name, Namespace: testNamespace}, &corev1.Secret{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected managed secret to be deleted, got err=%v", err)
+	}
+}
+
+func TestReconcileSecret_DisabledPreservesUserOwnedSecret(t *testing.T) {
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-client", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			Secret: &pocketidinternalv1alpha1.OIDCClientSecretSpec{
+				Enabled: boolPtr(false),
+				Name:    "user-owned-oidc",
+			},
+		},
+	}
+	// A secret the user created and named, with no managed-by label.
+	userOwned := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-owned-oidc",
+			Namespace: testNamespace,
+		},
+	}
+
+	r := secretCleanupReconciler(t, oidcClient, userOwned)
+
+	if err := r.ReconcileSecret(context.Background(), oidcClient, nil, nil); err != nil {
+		t.Fatalf("ReconcileSecret returned error: %v", err)
+	}
+
+	if err := r.Get(context.Background(), types.NamespacedName{Name: userOwned.Name, Namespace: testNamespace}, &corev1.Secret{}); err != nil {
+		t.Fatalf("expected user-owned secret to be preserved, got err=%v", err)
+	}
+}

--- a/internal/controller/pocketidinstance_controller_test.go
+++ b/internal/controller/pocketidinstance_controller_test.go
@@ -33,6 +33,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
 )
 
 // Environment variable names used in tests (mirrors instance controller constants)
@@ -330,6 +331,88 @@ var _ = Describe("PocketIDInstance Controller", func() {
 				}, &gatewayv1.HTTPRoute{})
 				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When a user-managed HTTPRoute shares the default route name", func() {
+		var instanceName string
+		var instance *pocketidinternalv1alpha1.PocketIDInstance
+		var secret *corev1.Secret
+		var userRoute *gatewayv1.HTTPRoute
+
+		BeforeEach(func() {
+			instanceName = "test-unmanaged-route-" + time.Now().Format("150405")
+
+			// A user's own HTTPRoute, named like the operator's default
+			// (instance.Name) but NOT carrying the managed-by label.
+			userRoute = &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname("user.example.com")},
+				},
+			}
+			Expect(k8sClient.Create(ctx, userRoute)).To(Succeed())
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName + "-secret",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					"encryption-key": []byte("test-encryption-key-value"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// Instance with the operator-managed route disabled.
+			instance = &pocketidinternalv1alpha1.PocketIDInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+				},
+				Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+					DeploymentType: "Deployment",
+					EncryptionKey: &pocketidinternalv1alpha1.SensitiveValue{
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secret.Name,
+								},
+								Key: "encryption-key",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if instance != nil {
+				_ = k8sClient.Delete(ctx, instance)
+			}
+			if secret != nil {
+				_ = k8sClient.Delete(ctx, secret)
+			}
+			if userRoute != nil {
+				_ = k8sClient.Delete(ctx, userRoute)
+			}
+		})
+
+		It("Should NOT delete the user-managed HTTPRoute it does not own", func() {
+			route := &gatewayv1.HTTPRoute{}
+			Consistently(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instanceName,
+					Namespace: namespace,
+				}, route)
+			}, time.Second*2, interval).Should(Succeed())
+
+			Expect(route.Labels).NotTo(HaveKeyWithValue(common.ManagedByLabelKey, common.ManagedByLabelValue))
+			Expect(route.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("user.example.com")))
 		})
 	})
 

--- a/internal/controller/user/controller.go
+++ b/internal/controller/user/controller.go
@@ -317,7 +317,7 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, user *pocketidinternal
 			secretNames = append(secretNames, keyStatus.SecretName)
 		}
 	}
-	if err := helpers.DeleteSecretsIfExist(ctx, r.Client, user.Namespace, secretNames); err != nil {
+	if err := helpers.DeleteSecretsIfManaged(ctx, r.Client, user.Namespace, secretNames); err != nil {
 		log.Error(err, "Failed to delete secrets")
 	}
 
@@ -558,13 +558,7 @@ func (r *Reconciler) updateUserStatus(ctx context.Context, user *pocketidinterna
 		oldSecretName := latest.Status.UserInfoSecretName
 		secretName := userInfoOutputSecretName(latest.Name)
 		if oldSecretName != "" && oldSecretName != secretName {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      oldSecretName,
-					Namespace: latest.Namespace,
-				},
-			}
-			if err := r.Delete(ctx, secret); err != nil && !errors.IsNotFound(err) {
+			if err := helpers.DeleteSecretIfManaged(ctx, r.Client, latest.Namespace, oldSecretName); err != nil {
 				return fmt.Errorf("delete old user info secret %s: %w", oldSecretName, err)
 			}
 		}
@@ -762,7 +756,7 @@ func (r *Reconciler) reconcileAPIKeys(ctx context.Context, user *pocketidinterna
 
 		// Delete secret
 		if keyStatus.SecretName != "" {
-			if err := helpers.DeleteSecretIfExists(ctx, r.Client, user.Namespace, keyStatus.SecretName); err != nil {
+			if err := helpers.DeleteSecretIfManaged(ctx, r.Client, user.Namespace, keyStatus.SecretName); err != nil {
 				log.Error(err, "Failed to delete secret", "name", keyStatus.SecretName)
 			}
 		}

--- a/internal/controller/user/finalizer_test.go
+++ b/internal/controller/user/finalizer_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
 )
 
 func TestReconcileUserFinalizers_AddsAuthFinalizer(t *testing.T) {
@@ -244,6 +245,65 @@ func TestReconcileDelete_BlocksWhenUserGroupReferences(t *testing.T) {
 	}
 	if !containsFinalizer(updatedUser.Finalizers, UserGroupUserFinalizer) {
 		t.Fatalf("expected user-group finalizer to remain, got %v", updatedUser.Finalizers)
+	}
+}
+
+// TestReconcileDelete_PreservesAdoptedAPIKeySecret verifies that deleting a
+// PocketIDUser removes the API key secrets the operator created but never
+// touches a user-provided secret adopted via secretRef.
+func TestReconcileDelete_PreservesAdoptedAPIKeySecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	now := metav1.NewTime(time.Now())
+	user := &pocketidinternalv1alpha1.PocketIDUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "secret-cleanup-user",
+			Namespace:         "default",
+			Finalizers:        []string{UserFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Status: pocketidinternalv1alpha1.PocketIDUserStatus{
+			APIKeys: []pocketidinternalv1alpha1.APIKeyStatus{
+				{Name: "generated", SecretName: "generated-key-secret"},
+				{Name: "adopted", SecretName: "user-owned-secret"},
+			},
+		},
+	}
+
+	// Operator-created API key secret (carries the managed-by label).
+	managed := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "generated-key-secret",
+			Namespace: "default",
+			Labels:    map[string]string{common.ManagedByLabelKey: common.ManagedByLabelValue},
+		},
+	}
+	// User-provided secret adopted via secretRef (no managed-by label).
+	adopted := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-owned-secret",
+			Namespace: "default",
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user, managed, adopted).
+		WithStatusSubresource(user).
+		Build()
+
+	reconciler := &Reconciler{Client: client, APIReader: client, Scheme: scheme}
+	if _, err := reconciler.ReconcileDelete(context.Background(), user); err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "generated-key-secret", Namespace: "default"}, &corev1.Secret{}); !errors.IsNotFound(err) {
+		t.Fatalf("expected operator-managed API key secret to be deleted, got err=%v", err)
+	}
+	if err := client.Get(context.Background(), types.NamespacedName{Name: "user-owned-secret", Namespace: "default"}, &corev1.Secret{}); err != nil {
+		t.Fatalf("expected adopted user-owned secret to be preserved, got err=%v", err)
 	}
 }
 


### PR DESCRIPTION
Currently the operator manages garbage collection of most resources just by name instead of the managed-by labels, leading to scenarios like https://github.com/mrwulf/home-cluster/commit/ead92fd07b8fb89dbc3bb902b6d5671600e500e2 and https://github.com/aclerici38/pocket-id-operator/pull/256

this changes the behavior to always add the managed-by labels and key ALL deletions off those + name rather than just name. 

fixes https://github.com/aclerici38/pocket-id-operator/issues/400