### PR TITLE
feat: allow ignoring an oidcclient's client-secret

### DIFF
--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -80,6 +80,13 @@ type OIDCClientSecretSpec struct {
 	// +optional
 	Name string `json:"name,omitempty"`
 
+	// StoreClientSecret controls whether the client secret is stored in the Secret.
+	// When false, the operator never regenerates the client secret and the Secret
+	// omits the client_secret key. Defaults to true
+	// +kubebuilder:default=true
+	// +optional
+	StoreClientSecret *bool `json:"storeClientSecret,omitempty"`
+
 	// Keys allows customization of the secret keys for each credential field.
 	// +optional
 	Keys *OIDCClientSecretKeys `json:"keys,omitempty"`
@@ -203,6 +210,7 @@ type SCIMSpec struct {
 
 // PocketIDOIDCClientSpec defines the desired state of PocketIDOIDCClient
 // +kubebuilder:validation:XValidation:rule="has(self.clientID) == has(oldSelf.clientID) && (!has(self.clientID) || self.clientID == oldSelf.clientID)",message="clientID is immutable"
+// +kubebuilder:validation:XValidation:rule="!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled || !has(self.secret) || !has(self.secret.storeClientSecret) || self.secret.storeClientSecret",message="clientSecretRotation cannot be enabled when secret.storeClientSecret is false"
 type PocketIDOIDCClientSpec struct {
 	// Name of the oidc client to create in Pocket ID.
 	// If omitted, defaults to metadata.name of the oidcclient resource.

--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -80,9 +80,11 @@ type OIDCClientSecretSpec struct {
 	// +optional
 	Name string `json:"name,omitempty"`
 
-	// StoreClientSecret controls whether the client secret is stored in the Secret.
-	// When false, the operator never regenerates the client secret and the Secret
-	// omits the client_secret key. Defaults to true
+	// StoreClientSecret controls whether the operator manages the client secret.
+	// When false, the operator never regenerates an existing client secret: a client
+	// created by the operator still gets its initial secret minted and stored, while
+	// an adopted client keeps its externally-managed secret and the Secret omits the
+	// client_secret key. Defaults to true
 	// +kubebuilder:default=true
 	// +optional
 	StoreClientSecret *bool `json:"storeClientSecret,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -389,6 +389,11 @@ func (in *OIDCClientSecretSpec) DeepCopyInto(out *OIDCClientSecretSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.StoreClientSecret != nil {
+		in, out := &in.StoreClientSecret, &out.StoreClientSecret
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Keys != nil {
 		in, out := &in.Keys, &out.Keys
 		*out = new(OIDCClientSecretKeys)

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -389,9 +389,11 @@ spec:
                   storeClientSecret:
                     default: true
                     description: |-
-                      StoreClientSecret controls whether the client secret is stored in the Secret.
-                      When false, the operator never regenerates the client secret and the Secret
-                      omits the client_secret key. Defaults to true
+                      StoreClientSecret controls whether the operator manages the client secret.
+                      When false, the operator never regenerates an existing client secret: a client
+                      created by the operator still gets its initial secret minted and stored, while
+                      an adopted client keeps its externally-managed secret and the Secret omits the
+                      client_secret key. Defaults to true
                     type: boolean
                 type: object
             type: object

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -386,12 +386,23 @@ spec:
                       Name is the name of the secret to create.
                       Defaults to metadata.name + "-oidc-credentials"
                     type: string
+                  storeClientSecret:
+                    default: true
+                    description: |-
+                      StoreClientSecret controls whether the client secret is stored in the Secret.
+                      When false, the operator never regenerates the client secret and the Secret
+                      omits the client_secret key. Defaults to true
+                    type: boolean
                 type: object
             type: object
             x-kubernetes-validations:
             - message: clientID is immutable
               rule: has(self.clientID) == has(oldSelf.clientID) && (!has(self.clientID)
                 || self.clientID == oldSelf.clientID)
+            - message: clientSecretRotation cannot be enabled when secret.storeClientSecret
+                is false
+              rule: '!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled
+                || !has(self.secret) || !has(self.secret.storeClientSecret) || self.secret.storeClientSecret'
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:

--- a/dist/chart/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/dist/chart/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -389,9 +389,11 @@ spec:
                   storeClientSecret:
                     default: true
                     description: |-
-                      StoreClientSecret controls whether the client secret is stored in the Secret.
-                      When false, the operator never regenerates the client secret and the Secret
-                      omits the client_secret key. Defaults to true
+                      StoreClientSecret controls whether the operator manages the client secret.
+                      When false, the operator never regenerates an existing client secret: a client
+                      created by the operator still gets its initial secret minted and stored, while
+                      an adopted client keeps its externally-managed secret and the Secret omits the
+                      client_secret key. Defaults to true
                     type: boolean
                 type: object
             type: object

--- a/dist/chart/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/dist/chart/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -386,12 +386,23 @@ spec:
                       Name is the name of the secret to create.
                       Defaults to metadata.name + "-oidc-credentials"
                     type: string
+                  storeClientSecret:
+                    default: true
+                    description: |-
+                      StoreClientSecret controls whether the client secret is stored in the Secret.
+                      When false, the operator never regenerates the client secret and the Secret
+                      omits the client_secret key. Defaults to true
+                    type: boolean
                 type: object
             type: object
             x-kubernetes-validations:
             - message: clientID is immutable
               rule: has(self.clientID) == has(oldSelf.clientID) && (!has(self.clientID)
                 || self.clientID == oldSelf.clientID)
+            - message: clientSecretRotation cannot be enabled when secret.storeClientSecret
+                is false
+              rule: '!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled
+                || !has(self.secret) || !has(self.secret.storeClientSecret) || self.secret.storeClientSecret'
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3287,12 +3287,23 @@ spec:
                       Name is the name of the secret to create.
                       Defaults to metadata.name + "-oidc-credentials"
                     type: string
+                  storeClientSecret:
+                    default: true
+                    description: |-
+                      StoreClientSecret controls whether the client secret is stored in the Secret.
+                      When false, the operator never regenerates the client secret and the Secret
+                      omits the client_secret key. Defaults to true
+                    type: boolean
                 type: object
             type: object
             x-kubernetes-validations:
             - message: clientID is immutable
               rule: has(self.clientID) == has(oldSelf.clientID) && (!has(self.clientID)
                 || self.clientID == oldSelf.clientID)
+            - message: clientSecretRotation cannot be enabled when secret.storeClientSecret
+                is false
+              rule: '!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled
+                || !has(self.secret) || !has(self.secret.storeClientSecret) || self.secret.storeClientSecret'
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3290,9 +3290,11 @@ spec:
                   storeClientSecret:
                     default: true
                     description: |-
-                      StoreClientSecret controls whether the client secret is stored in the Secret.
-                      When false, the operator never regenerates the client secret and the Secret
-                      omits the client_secret key. Defaults to true
+                      StoreClientSecret controls whether the operator manages the client secret.
+                      When false, the operator never regenerates an existing client secret: a client
+                      created by the operator still gets its initial secret minted and stored, while
+                      an adopted client keeps its externally-managed secret and the Secret omits the
+                      client_secret key. Defaults to true
                     type: boolean
                 type: object
             type: object

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -521,7 +521,7 @@
             },
             "storeClientSecret": {
               "default": true,
-              "description": "StoreClientSecret controls whether the client secret is stored in the Secret.\nWhen false, the operator never regenerates the client secret and the Secret\nomits the client_secret key. Defaults to true",
+              "description": "StoreClientSecret controls whether the operator manages the client secret.\nWhen false, the operator never regenerates an existing client secret: a client\ncreated by the operator still gets its initial secret minted and stored, while\nan adopted client keeps its externally-managed secret and the Secret omits the\nclient_secret key. Defaults to true",
               "type": [
                 "boolean",
                 "null"

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -518,6 +518,14 @@
                 "string",
                 "null"
               ]
+            },
+            "storeClientSecret": {
+              "default": true,
+              "description": "StoreClientSecret controls whether the client secret is stored in the Secret.\nWhen false, the operator never regenerates the client secret and the Secret\nomits the client_secret key. Defaults to true",
+              "type": [
+                "boolean",
+                "null"
+              ]
             }
           },
           "type": [
@@ -534,6 +542,10 @@
         {
           "message": "clientID is immutable",
           "rule": "has(self.clientID) == has(oldSelf.clientID) \u0026\u0026 (!has(self.clientID) || self.clientID == oldSelf.clientID)"
+        },
+        {
+          "message": "clientSecretRotation cannot be enabled when secret.storeClientSecret is false",
+          "rule": "!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled || !has(self.secret) || !has(self.secret.storeClientSecret) || self.secret.storeClientSecret"
         }
       ]
     },

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -11,15 +11,15 @@ inconsistent behavior as there is no way for the operator to know whether or not
 it created is up to date with the state of Pocket-ID. 
 
 If the client secret is managed outside the cluster (e.g. pasted into an app's UI), set
-`spec.secret.storeClientSecret: false`. The operator then never regenerates the client secret and
-the Secret omits the `client_secret` key. This is especially useful when adopting an existing
-OIDC client whose secret is already configured in an app, since adoption would otherwise
-regenerate (and invalidate) it.
+`spec.secret.storeClientSecret: false`. The operator then never regenerates an **existing**
+client secret:
 
-- Flipping it to `false` removes the `client_secret` key from the Secret; the value is not
-  recoverable afterward (Pocket-ID only stores a hash). Flipping back to `true` regenerates it.
-- The `pocketid.internal/regenerate-client-secret` annotation is ignored (the regenerated value
-  could not be stored anywhere).
+- When the operator **adopts** an OIDC client that already exists in Pocket-ID, the secret is
+  left alone and the Secret omits the `client_secret` key.
+- When the operator **creates** the OIDC client itself, the initial client secret is still
+  minted and stored. It is never regenerated afterward.
+- The `pocketid.internal/regenerate-client-secret` annotation is ignored. To rotate the
+  secret, flip `storeClientSecret` to `true` first.
 - Enabling `spec.clientSecretRotation` together with `storeClientSecret: false` is rejected at
   admission.
 
@@ -314,8 +314,9 @@ To view the logs add the `--zap-log-level=debug` arg on the operator container.
 ## Generated Secret
 
 - `spec.secret.name`: defaults to `<client>-oidc-credentials`.
-- `spec.secret.storeClientSecret`: set to `false` to omit `client_secret` and never regenerate
-  the client secret (see [Client Secret](#client-secret)). Defaults to `true`.
+- `spec.secret.storeClientSecret`: set to `false` to never regenerate an existing client
+  secret; adopted clients get no `client_secret` key (see [Client Secret](#client-secret)).
+  Defaults to `true`.
 - `spec.secret.keys`: customize secret keys. Defaults are:
   `client_id`, `client_secret`, `issuer_url`, `callback_urls`,
   `logout_callback_urls`, `discovery_url`, `authorization_url`,
@@ -325,7 +326,8 @@ To view the logs add the `--zap-log-level=debug` arg on the operator container.
 
 When enabled, the operator writes a Secret containing:
 - Client ID (always)
-- Client secret (only for non-public clients, unless `storeClientSecret` is `false`)
+- Client secret (only for non-public clients; with `storeClientSecret: false`, only if the
+  operator created the client and minted its initial secret)
 - Issuer URL and discovery endpoints derived from the instance `spec.appUrl`
 - Callback and logout URLs
 

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -10,6 +10,19 @@ creation/adoption of an OIDC Client in order to store it in a Kubernetes Secret.
 inconsistent behavior as there is no way for the operator to know whether or not the client-secret 
 it created is up to date with the state of Pocket-ID. 
 
+If the client secret is managed outside the cluster (e.g. pasted into an app's UI), set
+`spec.secret.storeClientSecret: false`. The operator then never regenerates the client secret and
+the Secret omits the `client_secret` key. This is especially useful when adopting an existing
+OIDC client whose secret is already configured in an app, since adoption would otherwise
+regenerate (and invalidate) it.
+
+- Flipping it to `false` removes the `client_secret` key from the Secret; the value is not
+  recoverable afterward (Pocket-ID only stores a hash). Flipping back to `true` regenerates it.
+- The `pocketid.internal/regenerate-client-secret` annotation is ignored (the regenerated value
+  could not be stored anywhere).
+- Enabling `spec.clientSecretRotation` together with `storeClientSecret: false` is rejected at
+  admission.
+
 ## Regenerating Client Secrets
 
 To regenerate a client-secret set the annotation `pocketid.internal/regenerate-client-secret` to "true". The operator will remove
@@ -301,6 +314,8 @@ To view the logs add the `--zap-log-level=debug` arg on the operator container.
 ## Generated Secret
 
 - `spec.secret.name`: defaults to `<client>-oidc-credentials`.
+- `spec.secret.storeClientSecret`: set to `false` to omit `client_secret` and never regenerate
+  the client secret (see [Client Secret](#client-secret)). Defaults to `true`.
 - `spec.secret.keys`: customize secret keys. Defaults are:
   `client_id`, `client_secret`, `issuer_url`, `callback_urls`,
   `logout_callback_urls`, `discovery_url`, `authorization_url`,
@@ -310,7 +325,7 @@ To view the logs add the `--zap-log-level=debug` arg on the operator container.
 
 When enabled, the operator writes a Secret containing:
 - Client ID (always)
-- Client secret (only for non-public clients)
+- Client secret (only for non-public clients, unless `storeClientSecret` is `false`)
 - Issuer URL and discovery endpoints derived from the instance `spec.appUrl`
 - Callback and logout URLs
 

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -83,6 +83,11 @@ type Reconciler struct {
 	// skipUpdate gates the update phase of reconciliation
 	// and just fetches the state
 	skipUpdate map[types.NamespacedName]bool
+
+	// pendingInitialMint marks clients created (not adopted) by the operator whose client
+	// secret has not yet been stored. It lets storeClientSecret=false permit the one-time
+	// initial mint for brand-new clients while never regenerating pre-existing credentials.
+	pendingInitialMint map[types.NamespacedName]bool
 }
 
 // +kubebuilder:rbac:groups=pocketid.internal,resources=pocketidoidcclients,verbs=get;list;watch;create;update;patch;delete
@@ -106,6 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			metrics.DeleteReadinessGauge("PocketIDOIDCClient", req.Namespace, req.Name)
 			metrics.DeleteOIDCClientAllowedGroupCount(req.Namespace, req.Name)
 			metrics.DeleteOIDCClientRotationMetrics(req.Namespace, req.Name)
+			delete(r.pendingInitialMint, req.NamespacedName)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -344,6 +350,12 @@ func (r *Reconciler) createOrAdoptOIDCClient(ctx context.Context, oidcClient *po
 	operation := "adopted"
 	if result.IsNewlyCreated {
 		operation = "created"
+		// A brand-new client has no externally-managed secret to protect, so the initial
+		// mint is allowed even when storeClientSecret is false.
+		if r.pendingInitialMint == nil {
+			r.pendingInitialMint = make(map[types.NamespacedName]bool)
+		}
+		r.pendingInitialMint[client.ObjectKeyFromObject(oidcClient)] = true
 	}
 	metrics.ResourceOperations.WithLabelValues("PocketIDOIDCClient", operation).Inc()
 
@@ -997,6 +1009,8 @@ func (r *Reconciler) ReconcileSecret(ctx context.Context, oidcClient *pocketidin
 		return fmt.Errorf("failed to create or update secret: %w", err)
 	}
 
+	delete(r.pendingInitialMint, client.ObjectKeyFromObject(oidcClient))
+
 	r.applyRotationStatus(ctx, oidcClient, rotatedAt)
 
 	// Set instance rotation status each reconcile to self-correct
@@ -1129,8 +1143,11 @@ func (r *Reconciler) advanceInstanceRotationStatus(ctx context.Context, instance
 
 // reconcileClientSecretData owns the client_secret key of the credentials Secret: it decides
 // whether the secret must be regenerated, fills secretData accordingly, and maintains the
-// rotation metrics. When storeClientSecret is false the secret is never regenerated and the
-// key is never written. Returns the rotation timestamp (nil when nothing was rotated) and whether the rotation was scheduled.
+// rotation metrics. When storeClientSecret is false the operator never regenerates an existing
+// credential: a previously stored value is carried forward untouched, an adopted client's
+// externally-managed secret is left alone (no client_secret key), and only a client the
+// operator just created may mint and store its initial secret. Returns the rotation timestamp
+// (nil when nothing was rotated) and whether the rotation was scheduled.
 // Extracted to keep ReconcileSecret under the cyclomatic complexity limit.
 func (r *Reconciler) reconcileClientSecretData(
 	ctx context.Context,
@@ -1141,11 +1158,20 @@ func (r *Reconciler) reconcileClientSecretData(
 	keys pocketidinternalv1alpha1.OIDCClientSecretKeys,
 	secretData map[string][]byte,
 ) (rotatedAt *metav1.Time, scheduledRotation bool, err error) {
-	if !storeClientSecret(oidcClient) {
-		// The client secret is never regenerated or stored. Record the rotation schedule
-		// as disabled so gauges from a previously enabled schedule cannot linger when
-		// rotation and storeClientSecret are turned off in the same update.
+	if !storeClientSecret(oidcClient) && !r.pendingInitialMint[client.ObjectKeyFromObject(oidcClient)] {
+		// Record the rotation schedule as disabled so gauges from a previously enabled
+		// schedule cannot linger when rotation and storeClientSecret are turned off in
+		// the same update.
 		r.recordRotationSchedule(oidcClient, rotationEval{})
+
+		// A stored client_secret can only have been minted by the operator (created
+		// client); keep it. Adopted clients never have one.
+		existing := &corev1.Secret{}
+		if err := r.Get(ctx, client.ObjectKey{Name: secretName, Namespace: oidcClient.Namespace}, existing); err == nil {
+			if v, ok := existing.Data[keys.ClientSecret]; ok {
+				secretData[keys.ClientSecret] = v
+			}
+		}
 
 		if helpers.HasAnnotation(oidcClient, regenerateClientSecretAnnotation, "true") {
 			logf.FromContext(ctx).Info("Ignoring regenerate-client-secret annotation: secret.storeClientSecret is false",

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -206,7 +206,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Error(err, "Failed to remove regenerate-client-secret annotation")
 		return ctrl.Result{RequeueAfter: common.Requeue}, nil
 	} else if removed {
-		log.Info("Removed regenerate-client-secret annotation after secret regeneration")
+		// The annotation is removed even when it was ignored (storeClientSecret false),
+		// so it cannot fire unexpectedly if the flag is later flipped back to true.
+		if storeClientSecret(oidcClient) {
+			log.Info("Removed regenerate-client-secret annotation after secret regeneration")
+		} else {
+			log.Info("Removed regenerate-client-secret annotation without regenerating: secret.storeClientSecret is false")
+		}
 	}
 
 	_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionTrue, "Reconciled", "OIDC client is in sync")
@@ -905,47 +911,15 @@ func (r *Reconciler) ReconcileSecret(ctx context.Context, oidcClient *pocketidin
 		secretData[keys.ClientID] = []byte(oidcClient.Status.ClientID)
 	}
 
-	// Include client_secret for non-public clients
-	// Only regenerate if the secret doesn't exist yet or if explicitly requested via annotation
+	// Include client_secret for non-public clients that store it.
+	// Only regenerate if the secret doesn't exist yet or if explicitly requested via annotation.
 	var rotatedAt *metav1.Time
 	var scheduledRotation bool
 	if !oidcClient.Spec.IsPublic && oidcClient.Status.ClientID != "" {
-		// Seed the rotation counters at 0 so this client's first rotation of each kind registers
-		// as a visible 0→1 step for increase()/rate() rather than a dropped first sample.
-		metrics.InitOIDCClientRotationCounters(oidcClient.Namespace, oidcClient.Name)
-
-		decision, err := r.secretRegenDecision(ctx, oidcClient, instance, secretName)
+		var err error
+		rotatedAt, scheduledRotation, err = r.reconcileClientSecretData(ctx, oidcClient, instance, apiClient, secretName, keys, secretData)
 		if err != nil {
 			return err
-		}
-		scheduledRotation = decision.scheduled
-
-		// Refresh the schedule gauges from the evaluation so the dashboard reflects the
-		// current state even on reconciles that do not rotate.
-		if decision.evaluated {
-			r.recordRotationSchedule(oidcClient, decision.eval)
-		}
-
-		if decision.regenerate {
-			if apiClient == nil {
-				return fmt.Errorf("apiClient is required to regenerate client secret")
-			}
-
-			logf.FromContext(ctx).Info("Rotating client secret",
-				"name", oidcClient.Name, "clientID", oidcClient.Status.ClientID, "trigger", decision.trigger)
-
-			clientSecret, err := apiClient.RegenerateOIDCClientSecret(ctx, oidcClient.Status.ClientID)
-			if err != nil {
-				metrics.OIDCClientSecretRotations.WithLabelValues(oidcClient.Namespace, oidcClient.Name, "error", decision.trigger).Inc()
-				return fmt.Errorf("failed to get client secret: %w", err)
-			}
-			metrics.OIDCClientSecretRotations.WithLabelValues(oidcClient.Namespace, oidcClient.Name, "success", decision.trigger).Inc()
-			secretData[keys.ClientSecret] = []byte(clientSecret)
-			now := metav1.NewTime(time.Now())
-			rotatedAt = &now
-		} else {
-			// update existing secret
-			secretData[keys.ClientSecret] = decision.existing.Data[keys.ClientSecret]
 		}
 	}
 
@@ -1153,6 +1127,73 @@ func (r *Reconciler) advanceInstanceRotationStatus(ctx context.Context, instance
 	return nil
 }
 
+// reconcileClientSecretData owns the client_secret key of the credentials Secret: it decides
+// whether the secret must be regenerated, fills secretData accordingly, and maintains the
+// rotation metrics. When storeClientSecret is false the secret is never regenerated and the
+// key is never written. Returns the rotation timestamp (nil when nothing was rotated) and whether the rotation was scheduled.
+// Extracted to keep ReconcileSecret under the cyclomatic complexity limit.
+func (r *Reconciler) reconcileClientSecretData(
+	ctx context.Context,
+	oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient,
+	instance *pocketidinternalv1alpha1.PocketIDInstance,
+	apiClient *pocketid.Client,
+	secretName string,
+	keys pocketidinternalv1alpha1.OIDCClientSecretKeys,
+	secretData map[string][]byte,
+) (rotatedAt *metav1.Time, scheduledRotation bool, err error) {
+	if !storeClientSecret(oidcClient) {
+		// The client secret is never regenerated or stored. Record the rotation schedule
+		// as disabled so gauges from a previously enabled schedule cannot linger when
+		// rotation and storeClientSecret are turned off in the same update.
+		r.recordRotationSchedule(oidcClient, rotationEval{})
+
+		if helpers.HasAnnotation(oidcClient, regenerateClientSecretAnnotation, "true") {
+			logf.FromContext(ctx).Info("Ignoring regenerate-client-secret annotation: secret.storeClientSecret is false",
+				"name", oidcClient.Name)
+		}
+		return nil, false, nil
+	}
+
+	// Seed the rotation counters at 0 so this client's first rotation of each kind registers
+	// as a visible 0→1 step for increase()/rate() rather than a dropped first sample.
+	metrics.InitOIDCClientRotationCounters(oidcClient.Namespace, oidcClient.Name)
+
+	decision, err := r.secretRegenDecision(ctx, oidcClient, instance, secretName)
+	if err != nil {
+		return nil, false, err
+	}
+	scheduledRotation = decision.scheduled
+
+	// Refresh the schedule gauges from the evaluation so the dashboard reflects the
+	// current state even on reconciles that do not rotate.
+	if decision.evaluated {
+		r.recordRotationSchedule(oidcClient, decision.eval)
+	}
+
+	if !decision.regenerate {
+		// update existing secret
+		secretData[keys.ClientSecret] = decision.existing.Data[keys.ClientSecret]
+		return nil, scheduledRotation, nil
+	}
+
+	if apiClient == nil {
+		return nil, false, fmt.Errorf("apiClient is required to regenerate client secret")
+	}
+
+	logf.FromContext(ctx).Info("Rotating client secret",
+		"name", oidcClient.Name, "clientID", oidcClient.Status.ClientID, "trigger", decision.trigger)
+
+	clientSecret, err := apiClient.RegenerateOIDCClientSecret(ctx, oidcClient.Status.ClientID)
+	if err != nil {
+		metrics.OIDCClientSecretRotations.WithLabelValues(oidcClient.Namespace, oidcClient.Name, "error", decision.trigger).Inc()
+		return nil, false, fmt.Errorf("failed to get client secret: %w", err)
+	}
+	metrics.OIDCClientSecretRotations.WithLabelValues(oidcClient.Namespace, oidcClient.Name, "success", decision.trigger).Inc()
+	secretData[keys.ClientSecret] = []byte(clientSecret)
+	now := metav1.NewTime(time.Now())
+	return &now, scheduledRotation, nil
+}
+
 // regenDecision is the outcome of secretRegenDecision: whether to regenerate the client
 // secret, what triggered it, whether it was a scheduled rotation (which drives the instance
 // aggregate), the existing secret, and the rotation evaluation when one was performed.
@@ -1318,6 +1359,15 @@ func (r *Reconciler) rotationDue(ctx context.Context, oidcClient *pocketidintern
 
 	eval.due = true
 	return eval, nil
+}
+
+// storeClientSecret reports whether the client secret should be stored in the
+// Secret (and therefore regenerated when needed). Defaults to true.
+func storeClientSecret(oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) bool {
+	if oidcClient.Spec.Secret != nil && oidcClient.Spec.Secret.StoreClientSecret != nil {
+		return *oidcClient.Spec.Secret.StoreClientSecret
+	}
+	return true
 }
 
 func (r *Reconciler) GetSecretName(oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) string {

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +20,7 @@ import (
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
 	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
+	"github.com/aclerici38/pocket-id-operator/internal/metrics"
 	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
 )
 
@@ -468,6 +470,161 @@ func TestReconcileSecret_CreateForPublicClient(t *testing.T) {
 	}
 	if _, ok := secret.Data["issuer_url"]; !ok {
 		t.Error("expected secret to have issuer_url key")
+	}
+}
+
+// TestReconcileSecret_StoreClientSecretDisabled verifies that storeClientSecret=false
+// skips regeneration entirely (a nil apiClient would error if the regenerate branch ran),
+// omits client_secret from the secret, and drops a pre-existing client_secret key. The
+// manual regenerate annotation must also be ignored rather than regenerating a value
+// that would then be discarded.
+func TestReconcileSecret_StoreClientSecretDisabled(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	for _, tc := range []struct {
+		name            string
+		existingSecret  *corev1.Secret
+		regenAnnotation bool
+	}{
+		{name: "new secret omits client_secret"},
+		{name: "existing client_secret key is dropped", existingSecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-store-oidc-credentials",
+				Namespace: testNamespace,
+				Labels:    common.ManagedByLabels(nil),
+			},
+			Data: map[string][]byte{"client_id": []byte("client-123"), "client_secret": []byte("old-secret")},
+		}},
+		{name: "manual regenerate annotation is ignored", regenAnnotation: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-no-store",
+					Namespace: testNamespace,
+					UID:       "test-uid-no-store",
+				},
+				Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+					CallbackURLs: []string{"https://example.com/callback"},
+					Secret: &pocketidinternalv1alpha1.OIDCClientSecretSpec{
+						StoreClientSecret: boolPtr(false),
+					},
+				},
+				Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
+					ClientID: "client-123",
+				},
+			}
+			if tc.regenAnnotation {
+				oidcClient.Annotations = map[string]string{"pocketid.internal/regenerate-client-secret": "true"}
+			}
+
+			instance := &pocketidinternalv1alpha1.PocketIDInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: testNamespace,
+				},
+				Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+					AppURL:        "http://test.example.com",
+					EncryptionKey: &pocketidinternalv1alpha1.SensitiveValue{Value: "0123456789abcdef"},
+				},
+			}
+
+			objs := []client.Object{oidcClient, instance}
+			if tc.existingSecret != nil {
+				objs = append(objs, tc.existingSecret)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			reconciler := &Reconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			// nil apiClient: regenerating would fail, proving the branch is skipped.
+			if err := reconciler.ReconcileSecret(ctx, oidcClient, instance, nil); err != nil {
+				t.Fatalf("ReconcileSecret returned error: %v", err)
+			}
+
+			secret := &corev1.Secret{}
+			if err := fakeClient.Get(ctx, client.ObjectKey{
+				Name:      "test-no-store-oidc-credentials",
+				Namespace: testNamespace,
+			}, secret); err != nil {
+				t.Fatalf("expected secret to exist: %v", err)
+			}
+
+			if _, ok := secret.Data["client_secret"]; ok {
+				t.Error("expected secret to NOT have client_secret key when storeClientSecret is false")
+			}
+			if _, ok := secret.Data["client_id"]; !ok {
+				t.Error("expected secret to have client_id key")
+			}
+			if _, ok := secret.Data["issuer_url"]; !ok {
+				t.Error("expected secret to have issuer_url key")
+			}
+		})
+	}
+}
+
+// TestReconcileSecret_StoreClientSecretDisabledClearsRotationGauges guards against stale
+// rotation metrics: when rotation and storeClientSecret are turned off in the same update,
+// the regeneration block is skipped entirely, so the skip path itself must record the
+// schedule as disabled and delete the schedule gauges left by the previously enabled config.
+func TestReconcileSecret_StoreClientSecretDisabledClearsRotationGauges(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	const name = "test-no-store-gauges"
+
+	// Simulate gauges left behind by a previously enabled rotation schedule.
+	metrics.SetOIDCClientRotationEnabled(testNamespace, name, true)
+	metrics.SetOIDCClientRotationSchedule(testNamespace, name, 3600, 1_700_000_000, 1_700_003_600)
+
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace, UID: "test-uid-no-store-gauges"},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			CallbackURLs: []string{"https://example.com/callback"},
+			Secret: &pocketidinternalv1alpha1.OIDCClientSecretSpec{
+				StoreClientSecret: boolPtr(false),
+			},
+		},
+		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{ClientID: "client-gauges"},
+	}
+	instance := &pocketidinternalv1alpha1.PocketIDInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-instance", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+			AppURL:        "http://test.example.com",
+			EncryptionKey: &pocketidinternalv1alpha1.SensitiveValue{Value: "0123456789abcdef"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(oidcClient, instance).Build()
+	reconciler := &Reconciler{Client: fakeClient, Scheme: scheme}
+
+	if err := reconciler.ReconcileSecret(ctx, oidcClient, instance, nil); err != nil {
+		t.Fatalf("ReconcileSecret returned error: %v", err)
+	}
+
+	if got := testutil.ToFloat64(metrics.OIDCClientRotationEnabled.WithLabelValues(testNamespace, name)); got != 0 {
+		t.Errorf("expected rotation enabled gauge to be 0, got %v", got)
+	}
+	// DeleteLabelValues reports whether the series existed; the schedule gauges must be gone.
+	if metrics.OIDCClientRotationIntervalSeconds.DeleteLabelValues(testNamespace, name) {
+		t.Error("expected rotation interval gauge to have been deleted")
+	}
+	if metrics.OIDCClientLastRotationTimestamp.DeleteLabelValues(testNamespace, name) {
+		t.Error("expected last rotation timestamp gauge to have been deleted")
+	}
+	if metrics.OIDCClientNextRotationTimestamp.DeleteLabelValues(testNamespace, name) {
+		t.Error("expected next rotation timestamp gauge to have been deleted")
 	}
 }
 

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -473,32 +473,39 @@ func TestReconcileSecret_CreateForPublicClient(t *testing.T) {
 	}
 }
 
-// TestReconcileSecret_StoreClientSecretDisabled verifies that storeClientSecret=false
-// skips regeneration entirely (a nil apiClient would error if the regenerate branch ran),
-// omits client_secret from the secret, and drops a pre-existing client_secret key. The
-// manual regenerate annotation must also be ignored rather than regenerating a value
-// that would then be discarded.
+// TestReconcileSecret_StoreClientSecretDisabled verifies the storeClientSecret=false
+// semantics: an existing credential is never regenerated (a nil apiClient would error if
+// the regenerate branch ran) — adopted clients get no client_secret key, a previously
+// stored key is carried forward untouched, and the manual regenerate annotation is
+// ignored. Only a client the operator just created (pendingInitialMint) mints and stores
+// its initial secret.
 func TestReconcileSecret_StoreClientSecretDisabled(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()
 	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 
+	existingSecretWithKey := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-no-store-oidc-credentials",
+			Namespace: testNamespace,
+			Labels:    common.ManagedByLabels(nil),
+		},
+		Data: map[string][]byte{"client_id": []byte("client-123"), "client_secret": []byte("minted-earlier")},
+	}
+
 	for _, tc := range []struct {
 		name            string
 		existingSecret  *corev1.Secret
 		regenAnnotation bool
+		pendingMint     bool
+		wantKey         string // expected client_secret value; empty means the key must be absent
+		wantRegenCalls  int
 	}{
-		{name: "new secret omits client_secret"},
-		{name: "existing client_secret key is dropped", existingSecret: &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-no-store-oidc-credentials",
-				Namespace: testNamespace,
-				Labels:    common.ManagedByLabels(nil),
-			},
-			Data: map[string][]byte{"client_id": []byte("client-123"), "client_secret": []byte("old-secret")},
-		}},
-		{name: "manual regenerate annotation is ignored", regenAnnotation: true},
+		{name: "adopted client never mints"},
+		{name: "previously stored key is carried forward", existingSecret: existingSecretWithKey, wantKey: "minted-earlier"},
+		{name: "manual regenerate annotation is ignored", existingSecret: existingSecretWithKey.DeepCopy(), regenAnnotation: true, wantKey: "minted-earlier"},
+		{name: "newly created client mints and stores", pendingMint: true, wantKey: "rotated-secret", wantRegenCalls: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
@@ -546,9 +553,34 @@ func TestReconcileSecret_StoreClientSecretDisabled(t *testing.T) {
 				Scheme: scheme,
 			}
 
-			// nil apiClient: regenerating would fail, proving the branch is skipped.
-			if err := reconciler.ReconcileSecret(ctx, oidcClient, instance, nil); err != nil {
+			key := client.ObjectKeyFromObject(oidcClient)
+			if tc.pendingMint {
+				reconciler.pendingInitialMint = map[types.NamespacedName]bool{key: true}
+			}
+
+			// Only the pending-mint case gets a working API client; the others use nil,
+			// which would error if any regenerate branch ran.
+			var apiClient *pocketid.Client
+			regenCalls := 0
+			if tc.pendingMint {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					regenCalls++
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"secret":"rotated-secret"}`))
+				}))
+				defer ts.Close()
+				apiClient, _ = pocketid.NewClient(ts.URL, "")
+			}
+
+			if err := reconciler.ReconcileSecret(ctx, oidcClient, instance, apiClient); err != nil {
 				t.Fatalf("ReconcileSecret returned error: %v", err)
+			}
+
+			if regenCalls != tc.wantRegenCalls {
+				t.Errorf("expected %d regenerate calls, got %d", tc.wantRegenCalls, regenCalls)
+			}
+			if reconciler.pendingInitialMint[key] {
+				t.Error("expected pendingInitialMint to be cleared after the secret write")
 			}
 
 			secret := &corev1.Secret{}
@@ -559,8 +591,8 @@ func TestReconcileSecret_StoreClientSecretDisabled(t *testing.T) {
 				t.Fatalf("expected secret to exist: %v", err)
 			}
 
-			if _, ok := secret.Data["client_secret"]; ok {
-				t.Error("expected secret to NOT have client_secret key when storeClientSecret is false")
+			if got := string(secret.Data["client_secret"]); got != tc.wantKey {
+				t.Errorf("expected client_secret %q, got %q", tc.wantKey, got)
 			}
 			if _, ok := secret.Data["client_id"]; !ok {
 				t.Error("expected secret to have client_id key")
@@ -625,6 +657,79 @@ func TestReconcileSecret_StoreClientSecretDisabledClearsRotationGauges(t *testin
 	}
 	if metrics.OIDCClientNextRotationTimestamp.DeleteLabelValues(testNamespace, name) {
 		t.Error("expected next rotation timestamp gauge to have been deleted")
+	}
+}
+
+// TestCreateOrAdoptOIDCClient_PendingInitialMint verifies the provenance marker that lets
+// storeClientSecret=false mint the initial secret for brand-new clients only: creating a
+// client sets pendingInitialMint, adopting an existing one does not.
+func TestCreateOrAdoptOIDCClient_PendingInitialMint(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	for _, tc := range []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantPending bool
+	}{
+		{
+			name: "created client is marked for initial mint",
+			handler: func(w http.ResponseWriter, req *http.Request) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/api/oidc/clients":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"data":[]}`))
+				case req.Method == http.MethodPost && req.URL.Path == "/api/oidc/clients":
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte(`{"id":"new-id","name":"mint-client","callbackURLs":[],"logoutCallbackURLs":[]}`))
+				default:
+					http.NotFound(w, req)
+				}
+			},
+			wantPending: true,
+		},
+		{
+			name: "adopted client is not marked for initial mint",
+			handler: func(w http.ResponseWriter, req *http.Request) {
+				if req.Method == http.MethodGet && req.URL.Path == "/api/oidc/clients" {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"data":[{"id":"existing-id","name":"mint-client","callbackURLs":[],"logoutCallbackURLs":[]}]}`))
+					return
+				}
+				http.NotFound(w, req)
+			},
+			wantPending: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "mint-client", Namespace: testNamespace},
+				Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+					CallbackURLs: []string{"https://example.com/cb"},
+				},
+			}
+
+			r := newPushStateOIDCReconciler(scheme, oidcClient)
+
+			ts := httptest.NewServer(tc.handler)
+			defer ts.Close()
+			apiClient, _ := pocketid.NewClient(ts.URL, "")
+
+			requeue, err := r.createOrAdoptOIDCClient(ctx, oidcClient, apiClient)
+			if err != nil {
+				t.Fatalf("createOrAdoptOIDCClient returned error: %v", err)
+			}
+			if !requeue {
+				t.Error("expected requeue after create/adopt")
+			}
+
+			key := client.ObjectKeyFromObject(oidcClient)
+			if got := r.pendingInitialMint[key]; got != tc.wantPending {
+				t.Errorf("pendingInitialMint = %v, want %v", got, tc.wantPending)
+			}
+		})
 	}
 }
 

--- a/test/e2e/oidcclient_store_secret_test.go
+++ b/test/e2e/oidcclient_store_secret_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/aclerici38/pocket-id-operator/test/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OIDC Client storeClientSecret Validation", Ordered, func() {
+	// These tests verify the CEL rule that rejects enabling clientSecretRotation
+	// while secret.storeClientSecret is false: a rotation would regenerate a
+	// client secret whose value is then discarded.
+
+	const celMessage = "clientSecretRotation cannot be enabled when secret.storeClientSecret is false"
+
+	storeSecretClientYAML := func(name string, rotationEnabled bool) string {
+		var rotation string
+		if rotationEnabled {
+			rotation = `
+  clientSecretRotation:
+    enabled: true
+    interval: 720h`
+		}
+		return fmt.Sprintf(`apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDOIDCClient
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  callbackUrls:
+  - https://store-secret-test.example.com/callback
+  secret:
+    storeClientSecret: false%s
+`, name, userNS, rotation)
+	}
+
+	apply := func(yaml string) (string, error) {
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(yaml)
+		return utils.Run(cmd)
+	}
+
+	Context("Rotation Enabled With storeClientSecret False", func() {
+		const clientName = "test-store-secret-rejected"
+
+		It("should reject creating a client with rotation enabled and storeClientSecret false", func() {
+			By("applying a PocketIDOIDCClient with clientSecretRotation.enabled and secret.storeClientSecret=false")
+			output, err := apply(storeSecretClientYAML(clientName, true))
+			Expect(err).To(HaveOccurred(), "apply should fail CEL validation")
+			Expect(output).To(ContainSubstring(celMessage),
+				"error should indicate rotation cannot be enabled without storing the client secret")
+		})
+	})
+
+	Context("Enabling Rotation On An Existing storeClientSecret=false Client", func() {
+		const clientName = "test-store-secret-update"
+
+		It("should accept storeClientSecret false without rotation, then reject enabling rotation", func() {
+			By("creating a PocketIDOIDCClient with secret.storeClientSecret=false and no rotation")
+			_, err := apply(storeSecretClientYAML(clientName, false))
+			Expect(err).NotTo(HaveOccurred(), "storeClientSecret=false without rotation should be admitted")
+
+			By("attempting to enable clientSecretRotation on the same client")
+			output, err := apply(storeSecretClientYAML(clientName, true))
+			Expect(err).To(HaveOccurred(), "update should fail CEL validation")
+			Expect(output).To(ContainSubstring(celMessage),
+				"error should indicate rotation cannot be enabled without storing the client secret")
+		})
+
+		AfterAll(func() {
+			kubectlDelete("pocketidoidcclient", clientName, userNS)
+			waitForResourceDeleted("pocketidoidcclient", clientName, userNS)
+		})
+	})
+})


### PR DESCRIPTION
Each time a new oidcclient resource is applied the operator regenerated the client-secret as that is the only way to store it in a k8s secret. This can be problematic in a couple scenarios

- some applications cannot read oidc settings from a k8s secret (Immich if not using a config file)
- basically requires reloader (or a similar tool) to always keep the secret data in sync with the env var/config an app is consuming
- Disallows admins from managing client-secret data external from the operator for operator-managed oidcclients

This adds `spec.secret.storeClientSecret`, when set to false the operator never touches the stored client-secret in pocket-id after it's initially created. If the adoption flow is triggered, the client-secret will not be stored in a k8s secret at all since that would require regenerating it.

closes https://github.com/aclerici38/pocket-id-operator/issues/412