### PR TITLE
feat: allow enabling the ratelimiter

### DIFF
--- a/api/v1alpha1/pocketidinstance_types.go
+++ b/api/v1alpha1/pocketidinstance_types.go
@@ -600,6 +600,11 @@ type PocketIDInstanceSpec struct {
 	// +optional
 	VersionCheckDisabled bool `json:"versionCheckDisabled,omitempty"`
 
+	// Enable Pocket-ID's built-in rate limiting. Disabled by default.
+	// +kubebuilder:default=false
+	// +optional
+	RateLimiting bool `json:"rateLimiting,omitempty"`
+
 	// Internal base URL for OIDC .well-known endpoints (for split-horizon DNS)
 	// +optional
 	InternalAppURL string `json:"internalAppUrl,omitempty"`

--- a/config/crd/bases/pocketid.internal_pocketidinstances.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidinstances.yaml
@@ -1826,6 +1826,11 @@ spec:
                   Pod template to merge with the operator-built pod spec.
                   Operator-managed fields including the pocket-id container always take precedence.
                 x-kubernetes-preserve-unknown-fields: true
+              rateLimiting:
+                default: false
+                description: Enable Pocket-ID's built-in rate limiting. Disabled by
+                  default.
+                type: boolean
               readinessProbe:
                 description: Readiness probe configuration
                 properties:

--- a/dist/chart/crds/pocketid.internal_pocketidinstances.yaml
+++ b/dist/chart/crds/pocketid.internal_pocketidinstances.yaml
@@ -1826,6 +1826,11 @@ spec:
                   Pod template to merge with the operator-built pod spec.
                   Operator-managed fields including the pocket-id container always take precedence.
                 x-kubernetes-preserve-unknown-fields: true
+              rateLimiting:
+                default: false
+                description: Enable Pocket-ID's built-in rate limiting. Disabled by
+                  default.
+                type: boolean
               readinessProbe:
                 description: Readiness probe configuration
                 properties:

--- a/dist/chart/values.schema.json
+++ b/dist/chart/values.schema.json
@@ -2483,6 +2483,14 @@
                 "description": "Pod template to merge with the operator-built pod spec.\nOperator-managed fields including the pocket-id container always take precedence.",
                 "x-kubernetes-preserve-unknown-fields": true
               },
+              "rateLimiting": {
+                "default": false,
+                "description": "Enable Pocket-ID's built-in rate limiting. Disabled by default.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
               "readinessProbe": {
                 "additionalProperties": false,
                 "description": "Readiness probe configuration",

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1834,6 +1834,11 @@ spec:
                   Pod template to merge with the operator-built pod spec.
                   Operator-managed fields including the pocket-id container always take precedence.
                 x-kubernetes-preserve-unknown-fields: true
+              rateLimiting:
+                default: false
+                description: Enable Pocket-ID's built-in rate limiting. Disabled by
+                  default.
+                type: boolean
               readinessProbe:
                 description: Readiness probe configuration
                 properties:

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -3388,6 +3388,14 @@
                         "description": "Pod template to merge with the operator-built pod spec.\nOperator-managed fields including the pocket-id container always take precedence.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
+                      "rateLimiting": {
+                        "default": false,
+                        "description": "Enable Pocket-ID's built-in rate limiting. Disabled by default.",
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      },
                       "readinessProbe": {
                         "additionalProperties": false,
                         "description": "Readiness probe configuration",

--- a/dist/schemas/pocketidinstance_v1alpha1.json
+++ b/dist/schemas/pocketidinstance_v1alpha1.json
@@ -2431,6 +2431,14 @@
           "description": "Pod template to merge with the operator-built pod spec.\nOperator-managed fields including the pocket-id container always take precedence.",
           "x-kubernetes-preserve-unknown-fields": true
         },
+        "rateLimiting": {
+          "default": false,
+          "description": "Enable Pocket-ID's built-in rate limiting. Disabled by default.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "readinessProbe": {
           "additionalProperties": false,
           "description": "Readiness probe configuration",

--- a/docs/pocketidinstance.md
+++ b/docs/pocketidinstance.md
@@ -549,7 +549,6 @@ spec:
 - Environment variables always set by the operator (managed instances only):
   - `ENCRYPTION_KEY` (from `spec.encryptionKey`)
   - `TRUST_PROXY=true`
-  - `DISABLE_RATE_LIMITING=true`
   - `STATIC_API_KEY` (secret reference)
 - Conditionally set from spec fields:
   - `UI_CONFIG_DISABLED=true` (when `spec.ui`, `spec.userManagement`, `spec.smtp`, `spec.emailNotifications`, or `spec.ldap` is configured)
@@ -571,6 +570,7 @@ spec:
   - `LOCAL_IPV6_RANGES` (from `spec.localIPv6Ranges`)
   - `S3_DISABLE_DEFAULT_INTEGRITY_CHECKS` (from `spec.s3.disableDefaultIntegrityChecks`)
   - `AUDIT_LOG_RETENTION_DAYS`, `ANALYTICS_DISABLED`, `VERSION_CHECK_DISABLED`
+  - `DISABLE_RATE_LIMITING=true` (set unless `spec.rateLimiting` is enabled)
   - Any additional values from `spec.env` (applied last, can override anything above)
 
 *Note:* For all options and an up-to-date spec `kubectl explain PocketIDInstance`

--- a/internal/controller/instance/env.go
+++ b/internal/controller/instance/env.go
@@ -48,7 +48,10 @@ func buildCoreEnv(instance *pocketidinternalv1alpha1.PocketIDInstance) []corev1.
 		env = append(env, corev1.EnvVar{Name: envAppURL, Value: instance.Spec.AppURL})
 	}
 
-	env = append(env, corev1.EnvVar{Name: "DISABLE_RATE_LIMITING", Value: "true"})
+	// Rate limiting is off by default; opt in via spec.rateLimiting.
+	if !instance.Spec.RateLimiting {
+		env = append(env, corev1.EnvVar{Name: "DISABLE_RATE_LIMITING", Value: "true"})
+	}
 	if needsUIConfigDisabled(instance) {
 		env = append(env, corev1.EnvVar{Name: "UI_CONFIG_DISABLED", Value: "true"})
 	}

--- a/internal/controller/instance/env_test.go
+++ b/internal/controller/instance/env_test.go
@@ -77,6 +77,14 @@ func TestBuildEnvVars_CoreAlwaysSet(t *testing.T) {
 	requireEnvFromSecret(t, env, "STATIC_API_KEY", "test-instance-static-api-key", "token")
 }
 
+func TestBuildEnvVars_RateLimitingEnabled(t *testing.T) {
+	inst := minimalInstance()
+	inst.Spec.RateLimiting = true
+
+	env := buildEnvVars(inst)
+	requireEnvAbsent(t, env, "DISABLE_RATE_LIMITING")
+}
+
 func TestBuildEnvVars_EncryptionKeyAbsentWhenNil(t *testing.T) {
 	inst := minimalInstance()
 	inst.Spec.EncryptionKey = nil


### PR DESCRIPTION
Pocket-id's ratelimiter was disabled here since it would throw 429s on each restart of the operator for several minutes in my home cluster. They recently changed the behavior of it to allow bursts, it makes sense to allow enabling it for a cluster where the operator doesn't manage many resources.

closes https://github.com/aclerici38/pocket-id-operator/issues/457