### PR TITLE
chore: enable ratelimiting by default

### DIFF
--- a/api/v1alpha1/pocketidinstance_types.go
+++ b/api/v1alpha1/pocketidinstance_types.go
@@ -600,10 +600,10 @@ type PocketIDInstanceSpec struct {
 	// +optional
 	VersionCheckDisabled bool `json:"versionCheckDisabled,omitempty"`
 
-	// Enable Pocket-ID's built-in rate limiting. Disabled by default.
+	// Disable Pocket-ID's built-in rate limiting. Enabled by default.
 	// +kubebuilder:default=false
 	// +optional
-	RateLimiting bool `json:"rateLimiting,omitempty"`
+	RateLimitingDisabled bool `json:"rateLimitingDisabled,omitempty"`
 
 	// Internal base URL for OIDC .well-known endpoints (for split-horizon DNS)
 	// +optional

--- a/config/crd/bases/pocketid.internal_pocketidinstances.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidinstances.yaml
@@ -1826,9 +1826,9 @@ spec:
                   Pod template to merge with the operator-built pod spec.
                   Operator-managed fields including the pocket-id container always take precedence.
                 x-kubernetes-preserve-unknown-fields: true
-              rateLimiting:
+              rateLimitingDisabled:
                 default: false
-                description: Enable Pocket-ID's built-in rate limiting. Disabled by
+                description: Disable Pocket-ID's built-in rate limiting. Enabled by
                   default.
                 type: boolean
               readinessProbe:

--- a/dist/chart/crds/pocketid.internal_pocketidinstances.yaml
+++ b/dist/chart/crds/pocketid.internal_pocketidinstances.yaml
@@ -1826,9 +1826,9 @@ spec:
                   Pod template to merge with the operator-built pod spec.
                   Operator-managed fields including the pocket-id container always take precedence.
                 x-kubernetes-preserve-unknown-fields: true
-              rateLimiting:
+              rateLimitingDisabled:
                 default: false
-                description: Enable Pocket-ID's built-in rate limiting. Disabled by
+                description: Disable Pocket-ID's built-in rate limiting. Enabled by
                   default.
                 type: boolean
               readinessProbe:

--- a/dist/chart/values.schema.json
+++ b/dist/chart/values.schema.json
@@ -2483,9 +2483,9 @@
                 "description": "Pod template to merge with the operator-built pod spec.\nOperator-managed fields including the pocket-id container always take precedence.",
                 "x-kubernetes-preserve-unknown-fields": true
               },
-              "rateLimiting": {
+              "rateLimitingDisabled": {
                 "default": false,
-                "description": "Enable Pocket-ID's built-in rate limiting. Disabled by default.",
+                "description": "Disable Pocket-ID's built-in rate limiting. Enabled by default.",
                 "type": [
                   "boolean",
                   "null"

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1834,9 +1834,9 @@ spec:
                   Pod template to merge with the operator-built pod spec.
                   Operator-managed fields including the pocket-id container always take precedence.
                 x-kubernetes-preserve-unknown-fields: true
-              rateLimiting:
+              rateLimitingDisabled:
                 default: false
-                description: Enable Pocket-ID's built-in rate limiting. Disabled by
+                description: Disable Pocket-ID's built-in rate limiting. Enabled by
                   default.
                 type: boolean
               readinessProbe:

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -3388,9 +3388,9 @@
                         "description": "Pod template to merge with the operator-built pod spec.\nOperator-managed fields including the pocket-id container always take precedence.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
-                      "rateLimiting": {
+                      "rateLimitingDisabled": {
                         "default": false,
-                        "description": "Enable Pocket-ID's built-in rate limiting. Disabled by default.",
+                        "description": "Disable Pocket-ID's built-in rate limiting. Enabled by default.",
                         "type": [
                           "boolean",
                           "null"

--- a/dist/schemas/pocketidinstance_v1alpha1.json
+++ b/dist/schemas/pocketidinstance_v1alpha1.json
@@ -2431,9 +2431,9 @@
           "description": "Pod template to merge with the operator-built pod spec.\nOperator-managed fields including the pocket-id container always take precedence.",
           "x-kubernetes-preserve-unknown-fields": true
         },
-        "rateLimiting": {
+        "rateLimitingDisabled": {
           "default": false,
-          "description": "Enable Pocket-ID's built-in rate limiting. Disabled by default.",
+          "description": "Disable Pocket-ID's built-in rate limiting. Enabled by default.",
           "type": [
             "boolean",
             "null"

--- a/docs/pocketidinstance.md
+++ b/docs/pocketidinstance.md
@@ -518,7 +518,7 @@ and instead manages OIDC clients, users, and groups on an existing Pocket-ID via
 All workload configuration (`spec.encryptionKey`, `spec.smtp`, `spec.persistence`, etc.) is
 ignored in this mode. `spec.external` and `spec.encryptionKey` are mutually exclusive. To migrate from an external instance to an internal one or vice versa, the instance must be recreated.
 
-It is recommended to set `DISABLE_RATE_LIMITING=true` on an external instance. Without it the operator may hit rate limits on startup or when many resources are synced at once. Managed instances have this set automatically.
+Recent Pocket-ID versions ship a much more permissive rate limiter (100 req/s per IP, burst 300), so the operator no longer trips it during normal syncs. If you run an older Pocket-ID or manage a very large number of resources on an external instance, you can set `DISABLE_RATE_LIMITING=true` on it to be safe. Managed instances keep rate limiting on by default; opt out with `spec.rateLimitingDisabled: true`.
 
 ```yaml
 apiVersion: v1
@@ -570,7 +570,7 @@ spec:
   - `LOCAL_IPV6_RANGES` (from `spec.localIPv6Ranges`)
   - `S3_DISABLE_DEFAULT_INTEGRITY_CHECKS` (from `spec.s3.disableDefaultIntegrityChecks`)
   - `AUDIT_LOG_RETENTION_DAYS`, `ANALYTICS_DISABLED`, `VERSION_CHECK_DISABLED`
-  - `DISABLE_RATE_LIMITING=true` (set unless `spec.rateLimiting` is enabled)
+  - `DISABLE_RATE_LIMITING=true` (set only when `spec.rateLimitingDisabled` is enabled)
   - Any additional values from `spec.env` (applied last, can override anything above)
 
 *Note:* For all options and an up-to-date spec `kubectl explain PocketIDInstance`

--- a/internal/controller/instance/env.go
+++ b/internal/controller/instance/env.go
@@ -48,8 +48,8 @@ func buildCoreEnv(instance *pocketidinternalv1alpha1.PocketIDInstance) []corev1.
 		env = append(env, corev1.EnvVar{Name: envAppURL, Value: instance.Spec.AppURL})
 	}
 
-	// Rate limiting is off by default; opt in via spec.rateLimiting.
-	if !instance.Spec.RateLimiting {
+	// Rate limiting is on by default; opt out via spec.rateLimitingDisabled.
+	if instance.Spec.RateLimitingDisabled {
 		env = append(env, corev1.EnvVar{Name: "DISABLE_RATE_LIMITING", Value: "true"})
 	}
 	if needsUIConfigDisabled(instance) {

--- a/internal/controller/instance/env_test.go
+++ b/internal/controller/instance/env_test.go
@@ -72,17 +72,17 @@ func TestBuildEnvVars_CoreAlwaysSet(t *testing.T) {
 
 	requireEnv(t, env, "ENCRYPTION_KEY", "test-encryption-key-32chars!!!!!")
 	requireEnv(t, env, "TRUST_PROXY", "true")
-	requireEnv(t, env, "DISABLE_RATE_LIMITING", "true")
+	requireEnvAbsent(t, env, "DISABLE_RATE_LIMITING")
 	requireEnv(t, env, "APP_URL", "https://id.example.com")
 	requireEnvFromSecret(t, env, "STATIC_API_KEY", "test-instance-static-api-key", "token")
 }
 
-func TestBuildEnvVars_RateLimitingEnabled(t *testing.T) {
+func TestBuildEnvVars_RateLimitingDisabled(t *testing.T) {
 	inst := minimalInstance()
-	inst.Spec.RateLimiting = true
+	inst.Spec.RateLimitingDisabled = true
 
 	env := buildEnvVars(inst)
-	requireEnvAbsent(t, env, "DISABLE_RATE_LIMITING")
+	requireEnv(t, env, "DISABLE_RATE_LIMITING", "true")
 }
 
 func TestBuildEnvVars_EncryptionKeyAbsentWhenNil(t *testing.T) {

--- a/test/e2e/instance_test.go
+++ b/test/e2e/instance_test.go
@@ -86,14 +86,6 @@ var _ = Describe("PocketIDInstance", Serial, Ordered, func() {
 				g.Expect(controller).To(Equal("true"))
 			}, 2*time.Minute, 2*time.Second).Should(Succeed())
 		})
-
-		It("should set DISABLE_RATE_LIMITING env var (shared instance has it disabled)", func() {
-			Eventually(func(g Gomega) {
-				output := kubectlGet("deployment", instanceName, "-n", instanceNS,
-					"-o", "jsonpath={.spec.template.spec.containers[0].env[?(@.name=='DISABLE_RATE_LIMITING')].value}")
-				g.Expect(output).To(Equal("true"))
-			}, 2*time.Minute, 2*time.Second).Should(Succeed())
-		})
 	})
 
 	Context("Static API Key Secret Lifecycle", func() {


### PR DESCRIPTION
Follow up from https://github.com/aclerici38/pocket-id-operator/pull/460, after some testing I was unable to trip the ratelimiter with 20 total resources, and if my math is correct it would take ~500 to actually trip it on reboot.
<img width="1304" height="159" alt="Screenshot 2026-07-12 at 10 33 53 AM" src="https://github.com/user-attachments/assets/8159b0dc-f6c0-4a19-8857-27d2dde80e9b" />
Closes #463