### PR TITLE
chore!: match upstream's TRUST_PROXY behavior

### DIFF
--- a/api/v1alpha1/pocketidinstance_types.go
+++ b/api/v1alpha1/pocketidinstance_types.go
@@ -413,16 +413,19 @@ type HTTPRouteConfig struct {
 // TrustedProxiesConfig configures which upstream proxies Pocket-ID trusts for
 // X-Forwarded-* headers (the TRUST_PROXY environment variable). This determines the
 // client IP Pocket-ID sees, which feeds rate limiting, audit-log IPs, and GeoIP.
+//
+// When this section is omitted, the operator sets TRUST_PROXY=false unless it manages the instance's route (spec.route.enabled),
+// in which case it trusts the private/loopback ranges where a Gateway's ip would be.
 type TrustedProxiesConfig struct {
 	// Enabled turns on trust of X-Forwarded-* headers.
-	// When false, TRUST_PROXY is set to "false"
+	// When false, TRUST_PROXY is set to "false".
 	// +kubebuilder:default=false
 	Enabled bool `json:"enabled"`
 
 	// CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.
-	// When empty, the operator trusts the private/loopback ranges
-	// (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).
-	// To trust all sources, set this to ["0.0.0.0/0", "::/0"].
+	// When empty, TRUST_PROXY is set to "true", trusting all upstream sources
+	// To restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's
+	// published ranges when it connects directly to the pod.
 	// +optional
 	CIDRs []string `json:"cidrs,omitempty"`
 }

--- a/charts/pocket-id-instance/values.schema.json
+++ b/charts/pocket-id-instance/values.schema.json
@@ -3635,7 +3635,7 @@
                 "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                 "properties": {
                   "cidrs": {
-                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
+                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\nTo restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                     "items": {
                       "type": "string"
                     },

--- a/charts/pocket-id-instance/values.schema.json
+++ b/charts/pocket-id-instance/values.schema.json
@@ -3635,7 +3635,7 @@
                 "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                 "properties": {
                   "cidrs": {
-                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, the operator trusts the private/loopback ranges\n(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).\nTo trust all sources, set this to [\"0.0.0.0/0\", \"::/0\"].",
+                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                     "items": {
                       "type": "string"
                     },
@@ -3646,7 +3646,7 @@
                   },
                   "enabled": {
                     "default": false,
-                    "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\"",
+                    "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\".",
                     "type": "boolean"
                   }
                 },

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
@@ -2753,9 +2753,10 @@ spec:
                   cidrs:
                     description: |-
                       CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.
-                      When empty, the operator trusts the private/loopback ranges
-                      (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).
-                      To trust all sources, set this to ["0.0.0.0/0", "::/0"].
+                      When empty, TRUST_PROXY is set to "true", trusting all upstream sources
+                      (matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,
+                      list explicit ranges — e.g. the in-cluster gateway network, or a CDN's
+                      published ranges when it connects directly to the pod.
                     items:
                       type: string
                     type: array
@@ -2763,7 +2764,7 @@ spec:
                     default: false
                     description: |-
                       Enabled turns on trust of X-Forwarded-* headers.
-                      When false, TRUST_PROXY is set to "false"
+                      When false, TRUST_PROXY is set to "false".
                     type: boolean
                 required:
                 - enabled

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
@@ -2754,8 +2754,7 @@ spec:
                     description: |-
                       CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.
                       When empty, TRUST_PROXY is set to "true", trusting all upstream sources
-                      (matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,
-                      list explicit ranges — e.g. the in-cluster gateway network, or a CDN's
+                      To restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's
                       published ranges when it connects directly to the pod.
                     items:
                       type: string

--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -3641,7 +3641,7 @@
                     "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                     "properties": {
                       "cidrs": {
-                        "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, the operator trusts the private/loopback ranges\n(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).\nTo trust all sources, set this to [\"0.0.0.0/0\", \"::/0\"].",
+                        "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                         "items": {
                           "type": "string"
                         },
@@ -3652,7 +3652,7 @@
                       },
                       "enabled": {
                         "default": false,
-                        "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\"",
+                        "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\".",
                         "type": "boolean"
                       }
                     },
@@ -8938,7 +8938,7 @@
                 "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                 "properties": {
                   "cidrs": {
-                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, the operator trusts the private/loopback ranges\n(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).\nTo trust all sources, set this to [\"0.0.0.0/0\", \"::/0\"].",
+                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                     "items": {
                       "type": "string"
                     },
@@ -8949,7 +8949,7 @@
                   },
                   "enabled": {
                     "default": false,
-                    "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\"",
+                    "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\".",
                     "type": "boolean"
                   }
                 },

--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -3641,7 +3641,7 @@
                     "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                     "properties": {
                       "cidrs": {
-                        "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
+                        "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\nTo restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                         "items": {
                           "type": "string"
                         },
@@ -8938,7 +8938,7 @@
                 "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                 "properties": {
                   "cidrs": {
-                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
+                    "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\nTo restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                     "items": {
                       "type": "string"
                     },

--- a/config/crd/bases/pocketid.internal_pocketidinstances.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidinstances.yaml
@@ -2753,9 +2753,10 @@ spec:
                   cidrs:
                     description: |-
                       CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.
-                      When empty, the operator trusts the private/loopback ranges
-                      (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).
-                      To trust all sources, set this to ["0.0.0.0/0", "::/0"].
+                      When empty, TRUST_PROXY is set to "true", trusting all upstream sources
+                      (matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,
+                      list explicit ranges — e.g. the in-cluster gateway network, or a CDN's
+                      published ranges when it connects directly to the pod.
                     items:
                       type: string
                     type: array
@@ -2763,7 +2764,7 @@ spec:
                     default: false
                     description: |-
                       Enabled turns on trust of X-Forwarded-* headers.
-                      When false, TRUST_PROXY is set to "false"
+                      When false, TRUST_PROXY is set to "false".
                     type: boolean
                 required:
                 - enabled

--- a/config/crd/bases/pocketid.internal_pocketidinstances.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidinstances.yaml
@@ -2754,8 +2754,7 @@ spec:
                     description: |-
                       CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.
                       When empty, TRUST_PROXY is set to "true", trusting all upstream sources
-                      (matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,
-                      list explicit ranges — e.g. the in-cluster gateway network, or a CDN's
+                      To restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's
                       published ranges when it connects directly to the pod.
                     items:
                       type: string

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3021,9 +3021,9 @@ spec:
                   cidrs:
                     description: |-
                       CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.
-                      When empty, the operator trusts the private/loopback ranges
-                      (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).
-                      To trust all sources, set this to ["0.0.0.0/0", "::/0"].
+                      When empty, TRUST_PROXY is set to "true", trusting all upstream sources
+                      To restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's
+                      published ranges when it connects directly to the pod.
                     items:
                       type: string
                     type: array
@@ -3031,7 +3031,7 @@ spec:
                     default: false
                     description: |-
                       Enabled turns on trust of X-Forwarded-* headers.
-                      When false, TRUST_PROXY is set to "false"
+                      When false, TRUST_PROXY is set to "false".
                     type: boolean
                 required:
                 - enabled

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -4546,7 +4546,7 @@
                             "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                             "properties": {
                               "cidrs": {
-                                "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
+                                "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\nTo restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                                 "items": {
                                   "type": "string"
                                 },
@@ -9843,7 +9843,7 @@
                         "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                         "properties": {
                           "cidrs": {
-                            "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
+                            "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\nTo restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                             "items": {
                               "type": "string"
                             },

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -4546,7 +4546,7 @@
                             "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                             "properties": {
                               "cidrs": {
-                                "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, the operator trusts the private/loopback ranges\n(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).\nTo trust all sources, set this to [\"0.0.0.0/0\", \"::/0\"].",
+                                "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                                 "items": {
                                   "type": "string"
                                 },
@@ -4557,7 +4557,7 @@
                               },
                               "enabled": {
                                 "default": false,
-                                "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\"",
+                                "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\".",
                                 "type": "boolean"
                               }
                             },
@@ -9843,7 +9843,7 @@
                         "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
                         "properties": {
                           "cidrs": {
-                            "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, the operator trusts the private/loopback ranges\n(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).\nTo trust all sources, set this to [\"0.0.0.0/0\", \"::/0\"].",
+                            "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
                             "items": {
                               "type": "string"
                             },
@@ -9854,7 +9854,7 @@
                           },
                           "enabled": {
                             "default": false,
-                            "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\"",
+                            "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\".",
                             "type": "boolean"
                           }
                         },

--- a/dist/schemas/pocketidinstance_v1alpha1.json
+++ b/dist/schemas/pocketidinstance_v1alpha1.json
@@ -3580,7 +3580,7 @@
           "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
           "properties": {
             "cidrs": {
-              "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, the operator trusts the private/loopback ranges\n(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8).\nTo trust all sources, set this to [\"0.0.0.0/0\", \"::/0\"].",
+              "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
               "items": {
                 "type": "string"
               },
@@ -3591,7 +3591,7 @@
             },
             "enabled": {
               "default": false,
-              "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\"",
+              "description": "Enabled turns on trust of X-Forwarded-* headers.\nWhen false, TRUST_PROXY is set to \"false\".",
               "type": "boolean"
             }
           },

--- a/dist/schemas/pocketidinstance_v1alpha1.json
+++ b/dist/schemas/pocketidinstance_v1alpha1.json
@@ -3580,7 +3580,7 @@
           "description": "TrustedProxies configures which proxies Pocket-ID trusts for X-Forwarded-* headers\n(sets TRUST_PROXY). When unset, the operator trusts the private/loopback ranges if\nspec.route.enabled is set.",
           "properties": {
             "cidrs": {
-              "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\n(matching Pocket-ID's own TRUST_PROXY=true semantics). To restrict trust,\nlist explicit ranges — e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
+              "description": "CIDRs is the list of trusted proxy IPs/CIDRs. Only used when enabled is true.\nWhen empty, TRUST_PROXY is set to \"true\", trusting all upstream sources\nTo restrict trust, list explicit ranges: e.g. the in-cluster gateway network, or a CDN's\npublished ranges when it connects directly to the pod.",
               "items": {
                 "type": "string"
               },

--- a/docs/pocketidinstance.md
+++ b/docs/pocketidinstance.md
@@ -383,27 +383,29 @@ client IP Pocket-ID sees, which feeds rate limiting, audit-log IPs, and GeoIP.
 | Spec | Resulting `TRUST_PROXY` |
 |---|---|
 | unset, `spec.route.enabled: true` | private/loopback ranges (see below) |
-| unset, no managed route | *unset* — Pocket-ID's default (trust nothing) |
+| unset, no managed route | `false` — Pocket-ID's default (trust nothing) |
 | `{enabled: false}` | `false` (overrides the route-derived default) |
-| `{enabled: true}` | private/loopback ranges |
+| `{enabled: true}` | `true` — trust every upstream (matches Pocket-ID's own `TRUST_PROXY=true`) |
 | `{enabled: true, cidrs: [...]}` | the listed CIDRs |
-| `{enabled: true, cidrs: ["0.0.0.0/0", "::/0"]}` | trust all sources |
 
-The private/loopback default is
+`enabled: true` maps to `TRUST_PROXY=true`. To restrict trust, list explicit `cidrs`.
+
+When the operator manages the route (`spec.route.enabled: true`) and you leave
+`trustedProxies` unset, it defaults to the private/loopback ranges
 `10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 100.64.0.0/10, 127.0.0.1/32, ::1/128, fd00::/8`.
-An in-cluster Gateway forwards from a private pod IP, so its headers are honored,
-while a client reaching the pod directly over a public path cannot spoof them.
-
-Note that `enabled: true` on its own trusts the private ranges, **not** every source —
-trusting all sources is deliberate and requires listing `0.0.0.0/0` (and `::/0`) explicitly.
+The pod's immediate upstream is then the in-cluster Gateway, which always forwards
+from a private pod IP, so its headers are honored while a client reaching the pod
+directly over a public path cannot spoof them.
 
 ```yaml
 spec:
-  # Trust a specific upstream proxy CIDR instead of the private-range default
+  # Pod is exposed directly to Cloudflare (no operator-managed gateway in front)
   trustedProxies:
     enabled: true
     cidrs:
-      - "10.42.0.0/16"
+      - "173.245.48.0/20"
+      - "103.21.244.0/22"
+      # ... rest of https://www.cloudflare.com/ips/
 ```
 
 > **Behavior change:** older operator releases always set `TRUST_PROXY=true`. If you run

--- a/internal/controller/instance/env.go
+++ b/internal/controller/instance/env.go
@@ -16,11 +16,16 @@ import (
 // networks fall within.
 const defaultTrustProxyRanges = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10,127.0.0.1/32,::1/128,fd00::/8"
 
-// effectiveTrustProxy resolves the TRUST_PROXY value from spec.trustedProxies:
-//   - unset: private-range default when the operator manages the route, else unset
-//     (Pocket-ID's own default of trusting nothing applies)
-//   - enabled=false: "false" (explicit off, overrides any route-derived default)
-//   - enabled=true, no CIDRs: the private-range default
+// effectiveTrustProxy resolves the TRUST_PROXY value from spec.trustedProxies.
+// The operator defaults to "false" (Pocket-ID's own default of trusting no proxy
+// headers), with one exception:
+// When the operator manages the route, the pod's immediate upstream is the in-cluster
+// gateway, so it defaults to the private ranges. Explicit spec.trustedProxies
+// always wins:
+//   - unset, operator-managed route: the private-range default
+//   - unset, no managed route: "false"
+//   - enabled=false: "false"
+//   - enabled=true, no CIDRs: "true" (trust all upstreams)
 //   - enabled=true, with CIDRs: the CIDRs joined by comma
 func effectiveTrustProxy(instance *pocketidinternalv1alpha1.PocketIDInstance) string {
 	tp := instance.Spec.TrustedProxies
@@ -28,13 +33,13 @@ func effectiveTrustProxy(instance *pocketidinternalv1alpha1.PocketIDInstance) st
 		if instance.Spec.Route != nil && instance.Spec.Route.Enabled {
 			return defaultTrustProxyRanges
 		}
-		return ""
+		return "false"
 	}
 	if !tp.Enabled {
 		return "false"
 	}
 	if len(tp.CIDRs) == 0 {
-		return defaultTrustProxyRanges
+		return "true"
 	}
 	return strings.Join(tp.CIDRs, ",")
 }
@@ -67,9 +72,7 @@ func buildCoreEnv(instance *pocketidinternalv1alpha1.PocketIDInstance) []corev1.
 	if instance.Spec.EncryptionKey != nil {
 		env = append(env, sensitiveValueToEnvVar(envEncryptionKey, instance.Spec.EncryptionKey))
 	}
-	if tp := effectiveTrustProxy(instance); tp != "" {
-		env = append(env, corev1.EnvVar{Name: envTrustProxy, Value: tp})
-	}
+	env = append(env, corev1.EnvVar{Name: envTrustProxy, Value: effectiveTrustProxy(instance)})
 
 	if instance.Spec.DatabaseUrl != nil {
 		env = append(env, sensitiveValueToEnvVar(envDBConnectionString, instance.Spec.DatabaseUrl))

--- a/internal/controller/instance/env_test.go
+++ b/internal/controller/instance/env_test.go
@@ -71,9 +71,10 @@ func TestBuildEnvVars_CoreAlwaysSet(t *testing.T) {
 	env := buildEnvVars(inst)
 
 	requireEnv(t, env, "ENCRYPTION_KEY", "test-encryption-key-32chars!!!!!")
-	// TRUST_PROXY is not set unless the instance is behind an operator-managed route
-	// or explicitly configured via spec.trustedProxies.
-	requireEnvAbsent(t, env, "TRUST_PROXY")
+	// TRUST_PROXY defaults to "false" (Pocket-ID's own default) unless the instance
+	// is behind an operator-managed route or explicitly configured via
+	// spec.trustedProxies.
+	requireEnv(t, env, "TRUST_PROXY", "false")
 	requireEnvAbsent(t, env, "DISABLE_RATE_LIMITING")
 	requireEnv(t, env, "APP_URL", "https://id.example.com")
 	requireEnvFromSecret(t, env, "STATIC_API_KEY", "test-instance-static-api-key", "token")
@@ -87,19 +88,19 @@ func TestBuildEnvVars_TrustProxyDefaultsToPrivateRangesWithRoute(t *testing.T) {
 	requireEnv(t, env, "TRUST_PROXY", defaultTrustProxyRanges)
 }
 
-func TestBuildEnvVars_TrustProxyAbsentWhenRouteDisabled(t *testing.T) {
+func TestBuildEnvVars_TrustProxyFalseWhenRouteDisabled(t *testing.T) {
 	inst := minimalInstance()
 	inst.Spec.Route = &pocketidinternalv1alpha1.HTTPRouteConfig{Enabled: false}
 
 	env := buildEnvVars(inst)
-	requireEnvAbsent(t, env, "TRUST_PROXY")
+	requireEnv(t, env, "TRUST_PROXY", "false")
 }
 
-func TestBuildEnvVars_TrustProxyAbsentByDefault(t *testing.T) {
+func TestBuildEnvVars_TrustProxyFalseByDefault(t *testing.T) {
 	inst := minimalInstance()
 
 	env := buildEnvVars(inst)
-	requireEnvAbsent(t, env, "TRUST_PROXY")
+	requireEnv(t, env, "TRUST_PROXY", "false")
 }
 
 func TestBuildEnvVars_TrustProxyDisabledOverridesRoute(t *testing.T) {
@@ -116,8 +117,10 @@ func TestBuildEnvVars_TrustProxyEnabledNoCIDRs(t *testing.T) {
 	inst := minimalInstance()
 	inst.Spec.TrustedProxies = &pocketidinternalv1alpha1.TrustedProxiesConfig{Enabled: true}
 
+	// enabled=true with no CIDRs maps to "true", matching upstream's trust-all
+	// TRUST_PROXY=true semantics.
 	env := buildEnvVars(inst)
-	requireEnv(t, env, "TRUST_PROXY", defaultTrustProxyRanges)
+	requireEnv(t, env, "TRUST_PROXY", "true")
 }
 
 func TestBuildEnvVars_TrustProxyEnabledWithCIDRs(t *testing.T) {


### PR DESCRIPTION
Aligns https://github.com/aclerici38/pocket-id-operator/pull/473 with the upstream behavior, making it a real breaking change. 

tldr
`TRUST_PROXY` was unconditionally set to `true` in managed instances, this makes it configurable and changes the default to `false` unless `spec.route.enabled` is set, in which case it is set to a list of private subnets that should contain the Gateway's pod IP.