### PR TITLE
feat: oidcclient reference a userGroup outside the cluster

### DIFF
--- a/.mise-tasks/test-e2e-only
+++ b/.mise-tasks/test-e2e-only
@@ -3,6 +3,15 @@
 #MISE depends=["setup-test-e2e"]
 set -euo pipefail
 
+# Ensure run on correct context (don't ask)
+expected="kind-${KIND_CLUSTER}"
+current="$(kubectl config current-context 2>/dev/null || true)"
+if [ "$current" != "$expected" ]; then
+  echo "refusing to run: kubectl context is '${current:-<none>}', expected '$expected'" >&2
+  echo "run 'kubectl config use-context $expected' first" >&2
+  exit 1
+fi
+
 # IMG and KIND_CLUSTER are read from the environment by the suite.
 # E2E_FOCUS_FILE optionally scopes the run, e.g.
 #   E2E_FOCUS_FILE=test/e2e/httproute_test.go mise run test-e2e-only

--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -24,16 +24,39 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// NamespacedUserGroupReference references a PocketIDUserGroup by name and namespace.
+// NamespacedUserGroupReference selects a Pocket-ID user group, either by the
+// PocketIDUserGroup CR that manages it or, for groups managed outside this cluster,
+// by their name or ID in Pocket-ID.
+// +kubebuilder:validation:XValidation:rule="(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0) + (has(self.groupID) ? 1 : 0) == 1",message="exactly one of name, groupName, or groupID must be set"
+// +kubebuilder:validation:XValidation:rule="!has(self.namespace) || has(self.name)",message="namespace may only be set together with name"
 type NamespacedUserGroupReference struct {
 	// Name is the name of the PocketIDUserGroup CR
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	// +optional
 	Name string `json:"name,omitempty"`
 
 	// Namespace is the namespace of the PocketIDUserGroup CR
 	// Defaults to the PocketIDOIDCClient namespace
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+
+	// GroupName is the name of an existing user group in Pocket-ID, for groups not
+	// managed by a PocketIDUserGroup in this cluster. The operator only resolves the
+	// group to grant this client access and never modifies the group itself.
+	// +kubebuilder:validation:MinLength=2
+	// +kubebuilder:validation:MaxLength=255
+	// +optional
+	GroupName string `json:"groupName,omitempty"`
+
+	// GroupID is the Pocket-ID ID of an existing user group. Like groupName, the
+	// group itself is left untouched.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=64
+	// +optional
+	GroupID string `json:"groupID,omitempty"`
 }
 
 // NamespacedOIDCClientReference references a PocketIDOIDCClient by name and namespace.
@@ -323,7 +346,9 @@ type PocketIDOIDCClientSpec struct {
 	// +optional
 	FederatedIdentities []OIDCClientFederatedIdentity `json:"federatedIdentities,omitempty"`
 
-	// AllowedUserGroups restricts access to the listed PocketIDUserGroups
+	// AllowedUserGroups restricts access to the listed user groups. Each entry names
+	// either a PocketIDUserGroup CR or, for groups managed outside this cluster, an
+	// existing Pocket-ID group by name or ID.
 	// +optional
 	AllowedUserGroups []NamespacedUserGroupReference `json:"allowedUserGroups,omitempty"`
 

--- a/charts/pocket-id-instance/values.schema.json
+++ b/charts/pocket-id-instance/values.schema.json
@@ -4524,13 +4524,33 @@
             "description": "spec defines the desired state of PocketIDOIDCClient",
             "properties": {
               "allowedUserGroups": {
-                "description": "AllowedUserGroups restricts access to the listed PocketIDUserGroups",
+                "description": "AllowedUserGroups restricts access to the listed user groups. Each entry names\neither a PocketIDUserGroup CR or, for groups managed outside this cluster, an\nexisting Pocket-ID group by name or ID.",
                 "items": {
                   "additionalProperties": false,
-                  "description": "NamespacedUserGroupReference references a PocketIDUserGroup by name and namespace.",
+                  "description": "NamespacedUserGroupReference selects a Pocket-ID user group, either by the\nPocketIDUserGroup CR that manages it or, for groups managed outside this cluster,\nby their name or ID in Pocket-ID.",
                   "properties": {
+                    "groupID": {
+                      "description": "GroupID is the Pocket-ID ID of an existing user group. Like groupName, the\ngroup itself is left untouched.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "groupName": {
+                      "description": "GroupName is the name of an existing user group in Pocket-ID, for groups not\nmanaged by a PocketIDUserGroup in this cluster. The operator only resolves the\ngroup to grant this client access and never modifies the group itself.",
+                      "maxLength": 255,
+                      "minLength": 2,
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "name": {
                       "description": "Name is the name of the PocketIDUserGroup CR",
+                      "maxLength": 253,
+                      "minLength": 1,
                       "type": [
                         "string",
                         "null"
@@ -4538,13 +4558,25 @@
                     },
                     "namespace": {
                       "description": "Namespace is the namespace of the PocketIDUserGroup CR\nDefaults to the PocketIDOIDCClient namespace",
+                      "maxLength": 63,
+                      "minLength": 1,
                       "type": [
                         "string",
                         "null"
                       ]
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of name, groupName, or groupID must be set",
+                      "rule": "(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0) + (has(self.groupID) ? 1 : 0) == 1"
+                    },
+                    {
+                      "message": "namespace may only be set together with name",
+                      "rule": "!has(self.namespace) || has(self.name)"
+                    }
+                  ]
                 },
                 "type": [
                   "array",

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -43,20 +43,50 @@ spec:
             description: spec defines the desired state of PocketIDOIDCClient
             properties:
               allowedUserGroups:
-                description: AllowedUserGroups restricts access to the listed PocketIDUserGroups
+                description: |-
+                  AllowedUserGroups restricts access to the listed user groups. Each entry names
+                  either a PocketIDUserGroup CR or, for groups managed outside this cluster, an
+                  existing Pocket-ID group by name or ID.
                 items:
-                  description: NamespacedUserGroupReference references a PocketIDUserGroup
-                    by name and namespace.
+                  description: |-
+                    NamespacedUserGroupReference selects a Pocket-ID user group, either by the
+                    PocketIDUserGroup CR that manages it or, for groups managed outside this cluster,
+                    by their name or ID in Pocket-ID.
                   properties:
+                    groupID:
+                      description: |-
+                        GroupID is the Pocket-ID ID of an existing user group. Like groupName, the
+                        group itself is left untouched.
+                      maxLength: 64
+                      minLength: 1
+                      type: string
+                    groupName:
+                      description: |-
+                        GroupName is the name of an existing user group in Pocket-ID, for groups not
+                        managed by a PocketIDUserGroup in this cluster. The operator only resolves the
+                        group to grant this client access and never modifies the group itself.
+                      maxLength: 255
+                      minLength: 2
+                      type: string
                     name:
                       description: Name is the name of the PocketIDUserGroup CR
+                      maxLength: 253
+                      minLength: 1
                       type: string
                     namespace:
                       description: |-
                         Namespace is the namespace of the PocketIDUserGroup CR
                         Defaults to the PocketIDOIDCClient namespace
+                      maxLength: 63
+                      minLength: 1
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of name, groupName, or groupID must be set
+                    rule: '(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0)
+                      + (has(self.groupID) ? 1 : 0) == 1'
+                  - message: namespace may only be set together with name
+                    rule: '!has(self.namespace) || has(self.name)'
                 type: array
               apiAccess:
                 description: |-

--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -4530,13 +4530,33 @@
                 "description": "spec defines the desired state of PocketIDOIDCClient",
                 "properties": {
                   "allowedUserGroups": {
-                    "description": "AllowedUserGroups restricts access to the listed PocketIDUserGroups",
+                    "description": "AllowedUserGroups restricts access to the listed user groups. Each entry names\neither a PocketIDUserGroup CR or, for groups managed outside this cluster, an\nexisting Pocket-ID group by name or ID.",
                     "items": {
                       "additionalProperties": false,
-                      "description": "NamespacedUserGroupReference references a PocketIDUserGroup by name and namespace.",
+                      "description": "NamespacedUserGroupReference selects a Pocket-ID user group, either by the\nPocketIDUserGroup CR that manages it or, for groups managed outside this cluster,\nby their name or ID in Pocket-ID.",
                       "properties": {
+                        "groupID": {
+                          "description": "GroupID is the Pocket-ID ID of an existing user group. Like groupName, the\ngroup itself is left untouched.",
+                          "maxLength": 64,
+                          "minLength": 1,
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "groupName": {
+                          "description": "GroupName is the name of an existing user group in Pocket-ID, for groups not\nmanaged by a PocketIDUserGroup in this cluster. The operator only resolves the\ngroup to grant this client access and never modifies the group itself.",
+                          "maxLength": 255,
+                          "minLength": 2,
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "name": {
                           "description": "Name is the name of the PocketIDUserGroup CR",
+                          "maxLength": 253,
+                          "minLength": 1,
                           "type": [
                             "string",
                             "null"
@@ -4544,13 +4564,25 @@
                         },
                         "namespace": {
                           "description": "Namespace is the namespace of the PocketIDUserGroup CR\nDefaults to the PocketIDOIDCClient namespace",
+                          "maxLength": 63,
+                          "minLength": 1,
                           "type": [
                             "string",
                             "null"
                           ]
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "exactly one of name, groupName, or groupID must be set",
+                          "rule": "(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0) + (has(self.groupID) ? 1 : 0) == 1"
+                        },
+                        {
+                          "message": "namespace may only be set together with name",
+                          "rule": "!has(self.namespace) || has(self.name)"
+                        }
+                      ]
                     },
                     "type": [
                       "array",

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -43,20 +43,50 @@ spec:
             description: spec defines the desired state of PocketIDOIDCClient
             properties:
               allowedUserGroups:
-                description: AllowedUserGroups restricts access to the listed PocketIDUserGroups
+                description: |-
+                  AllowedUserGroups restricts access to the listed user groups. Each entry names
+                  either a PocketIDUserGroup CR or, for groups managed outside this cluster, an
+                  existing Pocket-ID group by name or ID.
                 items:
-                  description: NamespacedUserGroupReference references a PocketIDUserGroup
-                    by name and namespace.
+                  description: |-
+                    NamespacedUserGroupReference selects a Pocket-ID user group, either by the
+                    PocketIDUserGroup CR that manages it or, for groups managed outside this cluster,
+                    by their name or ID in Pocket-ID.
                   properties:
+                    groupID:
+                      description: |-
+                        GroupID is the Pocket-ID ID of an existing user group. Like groupName, the
+                        group itself is left untouched.
+                      maxLength: 64
+                      minLength: 1
+                      type: string
+                    groupName:
+                      description: |-
+                        GroupName is the name of an existing user group in Pocket-ID, for groups not
+                        managed by a PocketIDUserGroup in this cluster. The operator only resolves the
+                        group to grant this client access and never modifies the group itself.
+                      maxLength: 255
+                      minLength: 2
+                      type: string
                     name:
                       description: Name is the name of the PocketIDUserGroup CR
+                      maxLength: 253
+                      minLength: 1
                       type: string
                     namespace:
                       description: |-
                         Namespace is the namespace of the PocketIDUserGroup CR
                         Defaults to the PocketIDOIDCClient namespace
+                      maxLength: 63
+                      minLength: 1
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of name, groupName, or groupID must be set
+                    rule: '(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0)
+                      + (has(self.groupID) ? 1 : 0) == 1'
+                  - message: namespace may only be set together with name
+                    rule: '!has(self.namespace) || has(self.name)'
                 type: array
               apiAccess:
                 description: |-

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -3230,20 +3230,50 @@ spec:
             description: spec defines the desired state of PocketIDOIDCClient
             properties:
               allowedUserGroups:
-                description: AllowedUserGroups restricts access to the listed PocketIDUserGroups
+                description: |-
+                  AllowedUserGroups restricts access to the listed user groups. Each entry names
+                  either a PocketIDUserGroup CR or, for groups managed outside this cluster, an
+                  existing Pocket-ID group by name or ID.
                 items:
-                  description: NamespacedUserGroupReference references a PocketIDUserGroup
-                    by name and namespace.
+                  description: |-
+                    NamespacedUserGroupReference selects a Pocket-ID user group, either by the
+                    PocketIDUserGroup CR that manages it or, for groups managed outside this cluster,
+                    by their name or ID in Pocket-ID.
                   properties:
+                    groupID:
+                      description: |-
+                        GroupID is the Pocket-ID ID of an existing user group. Like groupName, the
+                        group itself is left untouched.
+                      maxLength: 64
+                      minLength: 1
+                      type: string
+                    groupName:
+                      description: |-
+                        GroupName is the name of an existing user group in Pocket-ID, for groups not
+                        managed by a PocketIDUserGroup in this cluster. The operator only resolves the
+                        group to grant this client access and never modifies the group itself.
+                      maxLength: 255
+                      minLength: 2
+                      type: string
                     name:
                       description: Name is the name of the PocketIDUserGroup CR
+                      maxLength: 253
+                      minLength: 1
                       type: string
                     namespace:
                       description: |-
                         Namespace is the namespace of the PocketIDUserGroup CR
                         Defaults to the PocketIDOIDCClient namespace
+                      maxLength: 63
+                      minLength: 1
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of name, groupName, or groupID must be set
+                    rule: '(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0)
+                      + (has(self.groupID) ? 1 : 0) == 1'
+                  - message: namespace may only be set together with name
+                    rule: '!has(self.namespace) || has(self.name)'
                 type: array
               apiAccess:
                 description: |-

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3239,20 +3239,50 @@ spec:
             description: spec defines the desired state of PocketIDOIDCClient
             properties:
               allowedUserGroups:
-                description: AllowedUserGroups restricts access to the listed PocketIDUserGroups
+                description: |-
+                  AllowedUserGroups restricts access to the listed user groups. Each entry names
+                  either a PocketIDUserGroup CR or, for groups managed outside this cluster, an
+                  existing Pocket-ID group by name or ID.
                 items:
-                  description: NamespacedUserGroupReference references a PocketIDUserGroup
-                    by name and namespace.
+                  description: |-
+                    NamespacedUserGroupReference selects a Pocket-ID user group, either by the
+                    PocketIDUserGroup CR that manages it or, for groups managed outside this cluster,
+                    by their name or ID in Pocket-ID.
                   properties:
+                    groupID:
+                      description: |-
+                        GroupID is the Pocket-ID ID of an existing user group. Like groupName, the
+                        group itself is left untouched.
+                      maxLength: 64
+                      minLength: 1
+                      type: string
+                    groupName:
+                      description: |-
+                        GroupName is the name of an existing user group in Pocket-ID, for groups not
+                        managed by a PocketIDUserGroup in this cluster. The operator only resolves the
+                        group to grant this client access and never modifies the group itself.
+                      maxLength: 255
+                      minLength: 2
+                      type: string
                     name:
                       description: Name is the name of the PocketIDUserGroup CR
+                      maxLength: 253
+                      minLength: 1
                       type: string
                     namespace:
                       description: |-
                         Namespace is the namespace of the PocketIDUserGroup CR
                         Defaults to the PocketIDOIDCClient namespace
+                      maxLength: 63
+                      minLength: 1
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of name, groupName, or groupID must be set
+                    rule: '(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0)
+                      + (has(self.groupID) ? 1 : 0) == 1'
+                  - message: namespace may only be set together with name
+                    rule: '!has(self.namespace) || has(self.name)'
                 type: array
               apiAccess:
                 description: |-

--- a/dist/schemas/helmrelease_v2_pocket-id-instance.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-instance.json
@@ -5445,13 +5445,33 @@
                     "description": "spec defines the desired state of PocketIDOIDCClient",
                     "properties": {
                       "allowedUserGroups": {
-                        "description": "AllowedUserGroups restricts access to the listed PocketIDUserGroups",
+                        "description": "AllowedUserGroups restricts access to the listed user groups. Each entry names\neither a PocketIDUserGroup CR or, for groups managed outside this cluster, an\nexisting Pocket-ID group by name or ID.",
                         "items": {
                           "additionalProperties": false,
-                          "description": "NamespacedUserGroupReference references a PocketIDUserGroup by name and namespace.",
+                          "description": "NamespacedUserGroupReference selects a Pocket-ID user group, either by the\nPocketIDUserGroup CR that manages it or, for groups managed outside this cluster,\nby their name or ID in Pocket-ID.",
                           "properties": {
+                            "groupID": {
+                              "description": "GroupID is the Pocket-ID ID of an existing user group. Like groupName, the\ngroup itself is left untouched.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "groupName": {
+                              "description": "GroupName is the name of an existing user group in Pocket-ID, for groups not\nmanaged by a PocketIDUserGroup in this cluster. The operator only resolves the\ngroup to grant this client access and never modifies the group itself.",
+                              "maxLength": 255,
+                              "minLength": 2,
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
                             "name": {
                               "description": "Name is the name of the PocketIDUserGroup CR",
+                              "maxLength": 253,
+                              "minLength": 1,
                               "type": [
                                 "string",
                                 "null"
@@ -5459,13 +5479,25 @@
                             },
                             "namespace": {
                               "description": "Namespace is the namespace of the PocketIDUserGroup CR\nDefaults to the PocketIDOIDCClient namespace",
+                              "maxLength": 63,
+                              "minLength": 1,
                               "type": [
                                 "string",
                                 "null"
                               ]
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "exactly one of name, groupName, or groupID must be set",
+                              "rule": "(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0) + (has(self.groupID) ? 1 : 0) == 1"
+                            },
+                            {
+                              "message": "namespace may only be set together with name",
+                              "rule": "!has(self.namespace) || has(self.name)"
+                            }
+                          ]
                         },
                         "type": [
                           "array",

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -5451,13 +5451,33 @@
                         "description": "spec defines the desired state of PocketIDOIDCClient",
                         "properties": {
                           "allowedUserGroups": {
-                            "description": "AllowedUserGroups restricts access to the listed PocketIDUserGroups",
+                            "description": "AllowedUserGroups restricts access to the listed user groups. Each entry names\neither a PocketIDUserGroup CR or, for groups managed outside this cluster, an\nexisting Pocket-ID group by name or ID.",
                             "items": {
                               "additionalProperties": false,
-                              "description": "NamespacedUserGroupReference references a PocketIDUserGroup by name and namespace.",
+                              "description": "NamespacedUserGroupReference selects a Pocket-ID user group, either by the\nPocketIDUserGroup CR that manages it or, for groups managed outside this cluster,\nby their name or ID in Pocket-ID.",
                               "properties": {
+                                "groupID": {
+                                  "description": "GroupID is the Pocket-ID ID of an existing user group. Like groupName, the\ngroup itself is left untouched.",
+                                  "maxLength": 64,
+                                  "minLength": 1,
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "groupName": {
+                                  "description": "GroupName is the name of an existing user group in Pocket-ID, for groups not\nmanaged by a PocketIDUserGroup in this cluster. The operator only resolves the\ngroup to grant this client access and never modifies the group itself.",
+                                  "maxLength": 255,
+                                  "minLength": 2,
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
                                 "name": {
                                   "description": "Name is the name of the PocketIDUserGroup CR",
+                                  "maxLength": 253,
+                                  "minLength": 1,
                                   "type": [
                                     "string",
                                     "null"
@@ -5465,13 +5485,25 @@
                                 },
                                 "namespace": {
                                   "description": "Namespace is the namespace of the PocketIDUserGroup CR\nDefaults to the PocketIDOIDCClient namespace",
+                                  "maxLength": 63,
+                                  "minLength": 1,
                                   "type": [
                                     "string",
                                     "null"
                                   ]
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "exactly one of name, groupName, or groupID must be set",
+                                  "rule": "(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0) + (has(self.groupID) ? 1 : 0) == 1"
+                                },
+                                {
+                                  "message": "namespace may only be set together with name",
+                                  "rule": "!has(self.namespace) || has(self.name)"
+                                }
+                              ]
                             },
                             "type": [
                               "array",

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -26,13 +26,33 @@
       "description": "spec defines the desired state of PocketIDOIDCClient",
       "properties": {
         "allowedUserGroups": {
-          "description": "AllowedUserGroups restricts access to the listed PocketIDUserGroups",
+          "description": "AllowedUserGroups restricts access to the listed user groups. Each entry names\neither a PocketIDUserGroup CR or, for groups managed outside this cluster, an\nexisting Pocket-ID group by name or ID.",
           "items": {
             "additionalProperties": false,
-            "description": "NamespacedUserGroupReference references a PocketIDUserGroup by name and namespace.",
+            "description": "NamespacedUserGroupReference selects a Pocket-ID user group, either by the\nPocketIDUserGroup CR that manages it or, for groups managed outside this cluster,\nby their name or ID in Pocket-ID.",
             "properties": {
+              "groupID": {
+                "description": "GroupID is the Pocket-ID ID of an existing user group. Like groupName, the\ngroup itself is left untouched.",
+                "maxLength": 64,
+                "minLength": 1,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "groupName": {
+                "description": "GroupName is the name of an existing user group in Pocket-ID, for groups not\nmanaged by a PocketIDUserGroup in this cluster. The operator only resolves the\ngroup to grant this client access and never modifies the group itself.",
+                "maxLength": 255,
+                "minLength": 2,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "name": {
                 "description": "Name is the name of the PocketIDUserGroup CR",
+                "maxLength": 253,
+                "minLength": 1,
                 "type": [
                   "string",
                   "null"
@@ -40,13 +60,25 @@
               },
               "namespace": {
                 "description": "Namespace is the namespace of the PocketIDUserGroup CR\nDefaults to the PocketIDOIDCClient namespace",
+                "maxLength": 63,
+                "minLength": 1,
                 "type": [
                   "string",
                   "null"
                 ]
               }
             },
-            "type": "object"
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "exactly one of name, groupName, or groupID must be set",
+                "rule": "(has(self.name) ? 1 : 0) + (has(self.groupName) ? 1 : 0) + (has(self.groupID) ? 1 : 0) == 1"
+              },
+              {
+                "message": "namespace may only be set together with name",
+                "rule": "!has(self.namespace) || has(self.name)"
+              }
+            ]
           },
           "type": [
             "array",

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -164,6 +164,13 @@ spec:
 **not** managed by a `PocketIDUserGroup` in this cluster. The operator resolves the
 group only to grant this client access; it never creates, modifies, or deletes it.
 
+Every reference is resolved against Pocket-ID on each reconcile. If a referenced group
+does not exist, the client's `Ready` condition reports reason `UserGroupNotFound` and
+reconciliation retries until it appears. This applies equally to a group that is later
+deleted in Pocket-ID. Pocket-ID accepts unknown group IDs without complaint, so without
+this check a stale `groupID` would leave the client group-restricted with nothing
+attached — locking every user out — while the resource still reported `Ready`.
+
 Groups can also be attached from the other direction, using `spec.allowedOIDCClients`
 on a `PocketIDUserGroup`; the final set is the union of both. That direction always
 requires the oidcclient to reference a `PocketIDOIDCClient` in the same cluster.

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -146,6 +146,28 @@ spec:
     - "https://app.example.com/logout"
 ```
 
+## Allowed User Groups
+
+`spec.allowedUserGroups` restricts the client to members of the listed groups. Each
+entry names a group one of three ways:
+
+```yaml
+spec:
+  allowedUserGroups:
+    - name: platform-admins       # a PocketIDUserGroup CR
+      namespace: pocket-id        # optional, defaults to the client's namespace
+    - groupName: developers       # an existing Pocket-ID group, by name
+    - groupID: 4f8c1b2e-...       # an existing Pocket-ID group, by ID
+```
+
+`groupName` and `groupID` reference a group that already exists in Pocket-ID and is
+**not** managed by a `PocketIDUserGroup` in this cluster. The operator resolves the
+group only to grant this client access; it never creates, modifies, or deletes it.
+
+Groups can also be attached from the other direction, using `spec.allowedOIDCClients`
+on a `PocketIDUserGroup`; the final set is the union of both. That direction always
+requires the oidcclient to reference a `PocketIDOIDCClient` in the same cluster.
+
 ## Minimal Public Client
 
 ```yaml
@@ -410,4 +432,4 @@ spec:
 
 When `spec.scim` is removed the operator deletes the SCIM service provider from Pocket ID.
 
-*Note:* For all options and an up-to-date spec `kubectl explain PocketIDOIDCClient` 
+*Note:* For all options and an up-to-date spec `kubectl explain PocketIDOIDCClient`

--- a/docs/pocketidusergroup.md
+++ b/docs/pocketidusergroup.md
@@ -72,6 +72,12 @@ spec:
 - `spec.allowedOIDCClients[].namespace`: namespace of the CR (defaults to the user group's namespace).
 - `status.allowedOIDCClientIDs`: resolved Pocket ID client IDs after reconciliation.
 
+Both directions require the `PocketIDOIDCClient` and `PocketIDUserGroup` to exist in
+the cluster. To attach a client to a group that has no `PocketIDUserGroup` here — a
+group owned by another cluster or created in the UI — use `groupName` or `groupID` in
+the client's `spec.allowedUserGroups` instead. See
+[pocketidoidcclient.md](pocketidoidcclient.md#allowed-user-groups).
+
 ## Status Highlights
 
 - `status.groupID`: Pocket-ID group ID.

--- a/internal/controller/helpers/references.go
+++ b/internal/controller/helpers/references.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -9,7 +10,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pocketidv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
 )
+
+// ErrUserGroupNotFound marks a reference to a Pocket-ID user group that does not
+// exist. It is a spec error rather than a transient failure, so callers can surface
+// it distinctly instead of as a generic reconcile error.
+var ErrUserGroupNotFound = stderrors.New("user group not found in Pocket-ID")
+
+// UserGroupLookup resolves user groups that are not managed by a PocketIDUserGroup
+// in this cluster.
+type UserGroupLookup interface {
+	ListUserGroups(ctx context.Context, search string) ([]*pocketid.UserGroup, error)
+}
 
 // IsResourceReady checks if a resource has the Ready condition set to True
 func IsResourceReady(conditions []metav1.Condition) bool {
@@ -93,40 +106,88 @@ func ResolveOIDCClientReferences(
 	return clientIDs, nil
 }
 
-// ResolveUserGroupReferences resolves PocketIDUserGroup references to group IDs
+// ResolveUserGroupReferences resolves user group references to Pocket-ID group IDs.
+// A ref naming a PocketIDUserGroup CR is read from the cluster; a groupName/groupID
+// ref names a group directly in Pocket-ID and is resolved through lookup.
 func ResolveUserGroupReferences(
 	ctx context.Context,
 	c client.Client,
+	lookup UserGroupLookup,
 	refs []pocketidv1alpha1.NamespacedUserGroupReference,
 	defaultNamespace string,
 ) ([]string, error) {
 	groupIDs := make([]string, 0, len(refs))
 
 	for _, ref := range refs {
-		if ref.Name == "" {
-			return nil, fmt.Errorf("user group reference contains an empty name")
+		var id string
+		var err error
+
+		switch {
+		case ref.GroupID != "":
+			// Used as-is
+			id = ref.GroupID
+		case ref.GroupName != "":
+			id, err = lookupUserGroupByName(ctx, lookup, ref.GroupName)
+		case ref.Name != "":
+			id, err = userGroupCRGroupID(ctx, c, ref, defaultNamespace)
+		default:
+			err = fmt.Errorf("user group reference must set one of name, groupName, or groupID")
+		}
+		if err != nil {
+			return nil, err
 		}
 
-		namespace := ref.Namespace
-		if namespace == "" {
-			namespace = defaultNamespace
-		}
-
-		group := &pocketidv1alpha1.PocketIDUserGroup{}
-		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, group); err != nil {
-			return nil, fmt.Errorf("get user group %s: %w", ref.Name, err)
-		}
-
-		if !IsResourceReady(group.Status.Conditions) {
-			return nil, fmt.Errorf("user group %s is not ready (Ready condition not True)", ref.Name)
-		}
-
-		if group.Status.GroupID == "" {
-			return nil, fmt.Errorf("user group %s has no GroupID in status", ref.Name)
-		}
-
-		groupIDs = append(groupIDs, group.Status.GroupID)
+		groupIDs = append(groupIDs, id)
 	}
 
 	return groupIDs, nil
+}
+
+// userGroupCRGroupID returns the Pocket-ID group ID a PocketIDUserGroup CR resolved to.
+func userGroupCRGroupID(
+	ctx context.Context,
+	c client.Client,
+	ref pocketidv1alpha1.NamespacedUserGroupReference,
+	defaultNamespace string,
+) (string, error) {
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	group := &pocketidv1alpha1.PocketIDUserGroup{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, group); err != nil {
+		return "", fmt.Errorf("get user group %s: %w", ref.Name, err)
+	}
+
+	if !IsResourceReady(group.Status.Conditions) {
+		return "", fmt.Errorf("user group %s is not ready (Ready condition not True)", ref.Name)
+	}
+
+	if group.Status.GroupID == "" {
+		return "", fmt.Errorf("user group %s has no GroupID in status", ref.Name)
+	}
+
+	return group.Status.GroupID, nil
+}
+
+// lookupUserGroupByName resolves a Pocket-ID group name to its ID. The search is
+// server-side and paginated, so only an exact name match is accepted.
+func lookupUserGroupByName(ctx context.Context, lookup UserGroupLookup, name string) (string, error) {
+	if lookup == nil {
+		return "", fmt.Errorf("cannot resolve user group %q by name without a Pocket-ID client", name)
+	}
+
+	groups, err := lookup.ListUserGroups(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("list user groups matching %q: %w", name, err)
+	}
+
+	for _, group := range groups {
+		if group.Name == name {
+			return group.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: no group named %q", ErrUserGroupNotFound, name)
 }

--- a/internal/controller/helpers/references.go
+++ b/internal/controller/helpers/references.go
@@ -22,6 +22,7 @@ var ErrUserGroupNotFound = stderrors.New("user group not found in Pocket-ID")
 // in this cluster.
 type UserGroupLookup interface {
 	ListUserGroups(ctx context.Context, search string) ([]*pocketid.UserGroup, error)
+	GetUserGroup(ctx context.Context, id string) (*pocketid.UserGroup, error)
 }
 
 // IsResourceReady checks if a resource has the Ready condition set to True
@@ -124,8 +125,7 @@ func ResolveUserGroupReferences(
 
 		switch {
 		case ref.GroupID != "":
-			// Used as-is
-			id = ref.GroupID
+			id, err = lookupUserGroupByID(ctx, lookup, ref.GroupID)
 		case ref.GroupName != "":
 			id, err = lookupUserGroupByName(ctx, lookup, ref.GroupName)
 		case ref.Name != "":
@@ -190,4 +190,23 @@ func lookupUserGroupByName(ctx context.Context, lookup UserGroupLookup, name str
 	}
 
 	return "", fmt.Errorf("%w: no group named %q", ErrUserGroupNotFound, name)
+}
+
+// lookupUserGroupByID confirms the group exists. Pocket-ID accepts unknown IDs on the
+// allowed-groups write without error, so an unchecked ID would leave the client
+// group-restricted with nothing attached while still reporting Ready.
+func lookupUserGroupByID(ctx context.Context, lookup UserGroupLookup, id string) (string, error) {
+	if lookup == nil {
+		return "", fmt.Errorf("cannot resolve user group %q by ID without a Pocket-ID client", id)
+	}
+
+	group, err := lookup.GetUserGroup(ctx, id)
+	if err != nil {
+		if pocketid.IsNotFoundError(err) {
+			return "", fmt.Errorf("%w: no group with ID %q", ErrUserGroupNotFound, id)
+		}
+		return "", fmt.Errorf("get user group %s: %w", id, err)
+	}
+
+	return group.ID, nil
 }

--- a/internal/controller/helpers/references_test.go
+++ b/internal/controller/helpers/references_test.go
@@ -343,3 +343,110 @@ func TestResolveUserGroupReferences_EmptyRef(t *testing.T) {
 		t.Fatal("expected error for a reference with no name, groupName, or groupID")
 	}
 }
+
+func TestResolveUserGroupReferences_ByGroupNamePicksExactMatchAmongResults(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	// Search for "devs" also matches "platform-devs" and "devs-readonly", and the
+	// exact match is not first in the result set.
+	lookup := &fakeUserGroupLookup{groups: []*pocketid.UserGroup{
+		{ID: "gid-platform", Name: "platform-devs"},
+		{ID: "gid-devs", Name: "devs"},
+		{ID: "gid-readonly", Name: "devs-readonly"},
+	}}
+
+	ids, err := ResolveUserGroupReferences(ctx, fc, lookup,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupName: "devs"}}, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "gid-devs" {
+		t.Errorf("expected [gid-devs], got %v", ids)
+	}
+}
+
+func TestResolveUserGroupReferences_ByGroupNameNoResults(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	_, err := ResolveUserGroupReferences(ctx, fc, &fakeUserGroupLookup{},
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupName: "developers"}}, "default")
+	if !stderrors.Is(err, ErrUserGroupNotFound) {
+		t.Fatalf("expected ErrUserGroupNotFound, got %v", err)
+	}
+}
+
+func TestResolveUserGroupReferences_ByGroupNameWithoutLookup(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	// A nil lookup is a programming error, not a missing group: it must not be
+	// reported as ErrUserGroupNotFound, which callers treat as a spec problem.
+	_, err := ResolveUserGroupReferences(ctx, fc, nil,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupName: "developers"}}, "default")
+	if err == nil {
+		t.Fatal("expected error when resolving by name with no lookup")
+	}
+	if stderrors.Is(err, ErrUserGroupNotFound) {
+		t.Error("expected a non-ErrUserGroupNotFound error for a nil lookup")
+	}
+}
+
+func TestResolveUserGroupReferences_CRRefUsesExplicitNamespace(t *testing.T) {
+	ctx := context.Background()
+	// Two groups with the same name in different namespaces: the ref's namespace
+	// must win over defaultNamespace.
+	local := &pocketidv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "admins", Namespace: "default"},
+		Status: pocketidv1alpha1.PocketIDUserGroupStatus{
+			GroupID: "gid-default", Conditions: readyConditions(),
+		},
+	}
+	other := &pocketidv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "admins", Namespace: "other"},
+		Status: pocketidv1alpha1.PocketIDUserGroupStatus{
+			GroupID: "gid-other", Conditions: readyConditions(),
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(local, other).Build()
+
+	ids, err := ResolveUserGroupReferences(ctx, fc, nil,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{Name: "admins", Namespace: "other"}}, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "gid-other" {
+		t.Errorf("expected [gid-other], got %v", ids)
+	}
+}
+
+func TestResolveUserGroupReferences_KeepsDuplicates(t *testing.T) {
+	ctx := context.Background()
+	group := &pocketidv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "devs", Namespace: "default"},
+		Status: pocketidv1alpha1.PocketIDUserGroupStatus{
+			GroupID: "gid-dev", Conditions: readyConditions(),
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(group).Build()
+	lookup := &fakeUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
+
+	// The same group named three ways. The resolver is deliberately not responsible
+	// for deduplication; aggregateAllowedUserGroupIDs collapses the set.
+	ids, err := ResolveUserGroupReferences(ctx, fc, lookup, []pocketidv1alpha1.NamespacedUserGroupReference{
+		{Name: "devs"},
+		{GroupName: "developers"},
+		{GroupID: "gid-dev"},
+	}, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 entries before dedup, got %v", ids)
+	}
+	for _, id := range ids {
+		if id != "gid-dev" {
+			t.Errorf("expected every entry to be gid-dev, got %v", ids)
+		}
+	}
+}

--- a/internal/controller/helpers/references_test.go
+++ b/internal/controller/helpers/references_test.go
@@ -2,6 +2,8 @@ package helpers
 
 import (
 	"context"
+	stderrors "errors"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,7 +11,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	pocketidv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
 )
+
+// fakeUserGroupLookup serves user groups from a fixed set, mimicking Pocket-ID's
+// substring search.
+type fakeUserGroupLookup struct {
+	groups   []*pocketid.UserGroup
+	listErr  error
+	listCall int
+}
+
+func (f *fakeUserGroupLookup) ListUserGroups(_ context.Context, search string) ([]*pocketid.UserGroup, error) {
+	f.listCall++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var matches []*pocketid.UserGroup
+	for _, group := range f.groups {
+		if strings.Contains(group.Name, search) {
+			matches = append(matches, group)
+		}
+	}
+	return matches, nil
+}
 
 func readyConditions() []metav1.Condition {
 	return []metav1.Condition{{
@@ -151,7 +176,7 @@ func TestResolveUserGroupReferences_Ready(t *testing.T) {
 	}
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(group).Build()
 
-	ids, err := ResolveUserGroupReferences(ctx, fc,
+	ids, err := ResolveUserGroupReferences(ctx, fc, nil,
 		[]pocketidv1alpha1.NamespacedUserGroupReference{{Name: "group-a"}}, "default")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -174,7 +199,7 @@ func TestResolveUserGroupReferences_NotReady(t *testing.T) {
 	}
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(group).Build()
 
-	_, err := ResolveUserGroupReferences(ctx, fc,
+	_, err := ResolveUserGroupReferences(ctx, fc, nil,
 		[]pocketidv1alpha1.NamespacedUserGroupReference{{Name: "group-b"}}, "default")
 	if err == nil {
 		t.Fatal("expected error for not-ready user group")
@@ -186,7 +211,7 @@ func TestResolveUserGroupReferences_NotFound(t *testing.T) {
 	scheme := newScheme(t)
 	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	_, err := ResolveUserGroupReferences(ctx, fc,
+	_, err := ResolveUserGroupReferences(ctx, fc, nil,
 		[]pocketidv1alpha1.NamespacedUserGroupReference{{Name: "does-not-exist"}}, "default")
 	if err == nil {
 		t.Fatal("expected error for missing user group")
@@ -206,9 +231,115 @@ func TestResolveUserGroupReferences_MissingGroupID(t *testing.T) {
 	}
 	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(group).Build()
 
-	_, err := ResolveUserGroupReferences(ctx, fc,
+	_, err := ResolveUserGroupReferences(ctx, fc, nil,
 		[]pocketidv1alpha1.NamespacedUserGroupReference{{Name: "group-c"}}, "default")
 	if err == nil {
 		t.Fatal("expected error for empty GroupID")
+	}
+}
+
+// --- ResolveUserGroupReferences: groups with no CR in this cluster ---
+
+func TestResolveUserGroupReferences_ByGroupName(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	lookup := &fakeUserGroupLookup{groups: []*pocketid.UserGroup{
+		{ID: "gid-dev", Name: "developers"},
+		{ID: "gid-ops", Name: "operators"},
+	}}
+
+	ids, err := ResolveUserGroupReferences(ctx, fc, lookup,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupName: "developers"}}, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "gid-dev" {
+		t.Errorf("expected [gid-dev], got %v", ids)
+	}
+}
+
+func TestResolveUserGroupReferences_ByGroupNameRequiresExactMatch(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	// Pocket-ID search is a substring match, so "dev" returns "developers".
+	// Only an exact name may resolve, otherwise a prefix would grant the wrong group.
+	lookup := &fakeUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
+
+	_, err := ResolveUserGroupReferences(ctx, fc, lookup,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupName: "dev"}}, "default")
+	if !stderrors.Is(err, ErrUserGroupNotFound) {
+		t.Fatalf("expected ErrUserGroupNotFound, got %v", err)
+	}
+}
+
+func TestResolveUserGroupReferences_ByGroupNameListError(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	lookup := &fakeUserGroupLookup{listErr: stderrors.New("boom")}
+
+	// A failed lookup is transient and must not be reported as a missing group.
+	_, err := ResolveUserGroupReferences(ctx, fc, lookup,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupName: "developers"}}, "default")
+	if err == nil {
+		t.Fatal("expected error when the lookup fails")
+	}
+	if stderrors.Is(err, ErrUserGroupNotFound) {
+		t.Error("expected a transient error, not ErrUserGroupNotFound")
+	}
+}
+
+func TestResolveUserGroupReferences_ByGroupIDIsPassedThrough(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	lookup := &fakeUserGroupLookup{}
+
+	// An ID needs no resolution: it is handed to Pocket-ID as-is, which rejects it
+	// on the allowed-groups write if it does not exist.
+	ids, err := ResolveUserGroupReferences(ctx, fc, lookup,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupID: "gid-dev"}}, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "gid-dev" {
+		t.Errorf("expected [gid-dev], got %v", ids)
+	}
+	if lookup.listCall != 0 {
+		t.Errorf("expected no API calls when resolving by ID, got %d", lookup.listCall)
+	}
+}
+
+func TestResolveUserGroupReferences_MixedCRAndExternalRefs(t *testing.T) {
+	ctx := context.Background()
+	group := &pocketidv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "local-admins", Namespace: "default"},
+		Status: pocketidv1alpha1.PocketIDUserGroupStatus{
+			GroupID:    "gid-admins",
+			Conditions: readyConditions(),
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(group).Build()
+	lookup := &fakeUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
+
+	ids, err := ResolveUserGroupReferences(ctx, fc, lookup, []pocketidv1alpha1.NamespacedUserGroupReference{
+		{Name: "local-admins"},
+		{GroupName: "developers"},
+	}, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "gid-admins" || ids[1] != "gid-dev" {
+		t.Errorf("expected [gid-admins gid-dev], got %v", ids)
+	}
+}
+
+func TestResolveUserGroupReferences_EmptyRef(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	// CEL rejects this at admission; the resolver must not silently skip it.
+	_, err := ResolveUserGroupReferences(ctx, fc, nil,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{}}, "default")
+	if err == nil {
+		t.Fatal("expected error for a reference with no name, groupName, or groupID")
 	}
 }

--- a/internal/controller/helpers/references_test.go
+++ b/internal/controller/helpers/references_test.go
@@ -3,9 +3,11 @@ package helpers
 import (
 	"context"
 	stderrors "errors"
+	"net/http"
 	"strings"
 	"testing"
 
+	openapiruntime "github.com/go-openapi/runtime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -34,6 +36,15 @@ func (f *fakeUserGroupLookup) ListUserGroups(_ context.Context, search string) (
 		}
 	}
 	return matches, nil
+}
+
+func (f *fakeUserGroupLookup) GetUserGroup(_ context.Context, id string) (*pocketid.UserGroup, error) {
+	for _, group := range f.groups {
+		if group.ID == id {
+			return group, nil
+		}
+	}
+	return nil, openapiruntime.NewAPIError("getUserGroup", nil, http.StatusNotFound)
 }
 
 func readyConditions() []metav1.Condition {
@@ -288,13 +299,11 @@ func TestResolveUserGroupReferences_ByGroupNameListError(t *testing.T) {
 	}
 }
 
-func TestResolveUserGroupReferences_ByGroupIDIsPassedThrough(t *testing.T) {
+func TestResolveUserGroupReferences_ByGroupID(t *testing.T) {
 	ctx := context.Background()
 	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
-	lookup := &fakeUserGroupLookup{}
+	lookup := &fakeUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
 
-	// An ID needs no resolution: it is handed to Pocket-ID as-is, which rejects it
-	// on the allowed-groups write if it does not exist.
 	ids, err := ResolveUserGroupReferences(ctx, fc, lookup,
 		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupID: "gid-dev"}}, "default")
 	if err != nil {
@@ -304,7 +313,34 @@ func TestResolveUserGroupReferences_ByGroupIDIsPassedThrough(t *testing.T) {
 		t.Errorf("expected [gid-dev], got %v", ids)
 	}
 	if lookup.listCall != 0 {
-		t.Errorf("expected no API calls when resolving by ID, got %d", lookup.listCall)
+		t.Errorf("expected an ID to be fetched directly, not searched, got %d searches", lookup.listCall)
+	}
+}
+
+func TestResolveUserGroupReferences_ByGroupIDNotFound(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	// Pocket-ID accepts unknown IDs on the allowed-groups write, so this check is the
+	// only thing standing between a typo and a client restricted to no groups at all.
+	_, err := ResolveUserGroupReferences(ctx, fc, &fakeUserGroupLookup{},
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupID: "gid-missing"}}, "default")
+	if !stderrors.Is(err, ErrUserGroupNotFound) {
+		t.Fatalf("expected ErrUserGroupNotFound, got %v", err)
+	}
+}
+
+func TestResolveUserGroupReferences_ByGroupIDWithoutLookup(t *testing.T) {
+	ctx := context.Background()
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+
+	_, err := ResolveUserGroupReferences(ctx, fc, nil,
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{GroupID: "gid-dev"}}, "default")
+	if err == nil {
+		t.Fatal("expected error when resolving by ID with no lookup")
+	}
+	if stderrors.Is(err, ErrUserGroupNotFound) {
+		t.Error("expected a non-ErrUserGroupNotFound error for a nil lookup")
 	}
 }
 

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -19,6 +19,7 @@ package oidcclient
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -154,7 +155,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		requeue, err := r.createOrAdoptOIDCClient(ctx, oidcClient, apiClient)
 		if err != nil {
 			log.Error(err, "Failed to create or adopt OIDC client")
-			_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "ReconcileError", err.Error())
+			_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, reconcileErrorReason(err), err.Error())
 			return ctrl.Result{RequeueAfter: common.Requeue}, nil
 		}
 		if requeue {
@@ -194,7 +195,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	updated, err := r.pushOIDCClientState(ctx, oidcClient, apiClient, current)
 	if err != nil {
 		log.Error(err, "Failed to push OIDC client state")
-		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "ReconcileError", err.Error())
+		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, reconcileErrorReason(err), err.Error())
 		return ctrl.Result{RequeueAfter: common.Requeue}, nil
 	}
 
@@ -303,7 +304,7 @@ func (r *Reconciler) createOrAdoptOIDCClient(ctx context.Context, oidcClient *po
 	input := r.OidcClientInput(oidcClient, nil, logoURL, darkLogoURL)
 
 	// Aggregate all allowed groups
-	groupIDs, err := r.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	groupIDs, err := r.aggregateAllowedUserGroupIDs(ctx, oidcClient, apiClient)
 	if err != nil {
 		return false, fmt.Errorf("aggregate allowed user groups: %w", err)
 	}
@@ -379,7 +380,7 @@ func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocket
 	log := logf.FromContext(ctx)
 
 	// Aggregate allowed groups before building input so IsGroupRestricted is correct
-	groupIDs, err := r.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	groupIDs, err := r.aggregateAllowedUserGroupIDs(ctx, oidcClient, apiClient)
 	if err != nil {
 		return false, fmt.Errorf("aggregate allowed user groups: %w", err)
 	}
@@ -444,7 +445,10 @@ func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocket
 // 1. Direct refs from spec.allowedUserGroups
 // 2. UserGroups whose spec.allowedOIDCClients references this client
 // Returns nil if neither source contributes.
-func (r *Reconciler) aggregateAllowedUserGroupIDs(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) ([]string, error) {
+//
+// The reverse direction can only come from a PocketIDUserGroup in this cluster, so
+// only the direct refs need lookup to resolve groups that have no CR here.
+func (r *Reconciler) aggregateAllowedUserGroupIDs(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, lookup helpers.UserGroupLookup) ([]string, error) {
 	// Find UserGroups whose spec.allowedOIDCClients references this client
 	clientKey := fmt.Sprintf("%s/%s", oidcClient.Namespace, oidcClient.Name)
 	userGroups := &pocketidinternalv1alpha1.PocketIDUserGroupList{}
@@ -464,7 +468,7 @@ func (r *Reconciler) aggregateAllowedUserGroupIDs(ctx context.Context, oidcClien
 	groupIDSet := make(map[string]struct{})
 
 	if hasDirectRefs {
-		directIDs, err := helpers.ResolveUserGroupReferences(ctx, r.Client, oidcClient.Spec.AllowedUserGroups, oidcClient.Namespace)
+		directIDs, err := helpers.ResolveUserGroupReferences(ctx, r.Client, lookup, oidcClient.Spec.AllowedUserGroups, oidcClient.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("resolve allowed user groups: %w", err)
 		}
@@ -486,6 +490,16 @@ func (r *Reconciler) aggregateAllowedUserGroupIDs(ctx context.Context, oidcClien
 	}
 	sort.Strings(groupIDs)
 	return groupIDs, nil
+}
+
+// reconcileErrorReason classifies a reconcile failure for the Ready condition, so a
+// reference to a user group that does not exist reads as a spec error rather than a
+// transient one.
+func reconcileErrorReason(err error) string {
+	if stderrors.Is(err, helpers.ErrUserGroupNotFound) {
+		return "UserGroupNotFound"
+	}
+	return "ReconcileError"
 }
 
 // setClientID persists only the client ID to status.

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	openapiruntime "github.com/go-openapi/runtime"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2248,6 +2249,15 @@ func (s staticUserGroupLookup) ListUserGroups(_ context.Context, search string) 
 		}
 	}
 	return nil, nil
+}
+
+func (s staticUserGroupLookup) GetUserGroup(_ context.Context, id string) (*pocketid.UserGroup, error) {
+	for _, group := range s.groups {
+		if group.ID == id {
+			return group, nil
+		}
+	}
+	return nil, openapiruntime.NewAPIError("getUserGroup", nil, http.StatusNotFound)
 }
 
 func TestAggregateAllowedUserGroupIDs_ExternalGroupNeedsNoCR(t *testing.T) {

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -2319,6 +2319,136 @@ func TestReconcileErrorReason_DistinguishesMissingUserGroup(t *testing.T) {
 	}
 }
 
+func TestAggregateAllowedUserGroupIDs_MissingGroupKeepsSentinelThroughWrapping(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-missing-ext", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{GroupName: "nope"},
+			},
+		},
+	}
+
+	fc := newAggregationFakeClient(scheme, oidcClient)
+	reconciler := &Reconciler{Client: fc, Scheme: scheme}
+
+	_, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, staticUserGroupLookup{})
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable group name")
+	}
+	// aggregate wraps once and the caller wraps again; the condition reason depends
+	// on the sentinel surviving both.
+	if reason := reconcileErrorReason(fmt.Errorf("aggregate allowed user groups: %w", err)); reason != "UserGroupNotFound" {
+		t.Errorf("expected UserGroupNotFound through the real call chain, got %q", reason)
+	}
+}
+
+func TestAggregateAllowedUserGroupIDs_DedupesSameGroupNamedThreeWays(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "devs", Namespace: testNamespace},
+		Status:     pocketidinternalv1alpha1.PocketIDUserGroupStatus{GroupID: "gid-dev", Conditions: readyCondition()},
+	}
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-dupe", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{Name: "devs"},
+				{GroupName: "developers"},
+				{GroupID: "gid-dev"},
+			},
+		},
+	}
+
+	fc := newAggregationFakeClient(scheme, group, oidcClient)
+	reconciler := &Reconciler{Client: fc, Scheme: scheme}
+	lookup := staticUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
+
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, lookup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "gid-dev" {
+		t.Errorf("expected a single [gid-dev], got %v", ids)
+	}
+}
+
+func TestAggregateAllowedUserGroupIDs_UnionsExternalAndReverseRefs(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	// Reverse direction: a UserGroup CR naming this client in spec.allowedOIDCClients.
+	reverse := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-rev", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDUserGroupSpec{
+			AllowedOIDCClients: []pocketidinternalv1alpha1.NamespacedOIDCClientReference{{Name: "client-ext-rev"}},
+		},
+		Status: pocketidinternalv1alpha1.PocketIDUserGroupStatus{GroupID: "gid-rev", Conditions: readyCondition()},
+	}
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-ext-rev", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{GroupName: "developers"},
+			},
+		},
+	}
+
+	fc := newAggregationFakeClient(scheme, reverse, oidcClient)
+	reconciler := &Reconciler{Client: fc, Scheme: scheme}
+	lookup := staticUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
+
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, lookup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "gid-dev" || ids[1] != "gid-rev" {
+		t.Errorf("expected sorted [gid-dev gid-rev], got %v", ids)
+	}
+}
+
+func TestOidcClientInput_IsGroupRestrictedForExternalOnlyRefs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	// spec.allowedUserGroups holds only external refs, so a count of the list is
+	// still the right signal for group restriction.
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-restricted", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{GroupName: "developers"},
+				{GroupID: "gid-ops"},
+			},
+		},
+	}
+
+	reconciler := &Reconciler{Scheme: scheme}
+	if !reconciler.OidcClientInput(oidcClient, nil, "", "").IsGroupRestricted {
+		t.Error("expected IsGroupRestricted to be true for external-only refs")
+	}
+}
+
+func TestUserGroupAllowsOIDCClient_IgnoresRefsWithoutName(t *testing.T) {
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-a", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDUserGroupSpec{
+			AllowedOIDCClients: []pocketidinternalv1alpha1.NamespacedOIDCClientReference{{Name: ""}},
+		},
+	}
+	if userGroupAllowsOIDCClient(group, testNamespace, "client-a") {
+		t.Error("expected an empty client ref to match nothing")
+	}
+}
+
 func TestReconcileDelete_RemoveFinalizerWhenNoInstance(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
 	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
+	"github.com/aclerici38/pocket-id-operator/internal/controller/helpers"
 	"github.com/aclerici38/pocket-id-operator/internal/metrics"
 	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
 )
@@ -2107,7 +2108,7 @@ func TestAggregateAllowedUserGroupIDs_DirectOnly(t *testing.T) {
 	fc := newAggregationFakeClient(scheme, group, oidcClient)
 	reconciler := &Reconciler{Client: fc, Scheme: scheme}
 
-	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2135,7 +2136,7 @@ func TestAggregateAllowedUserGroupIDs_ReverseOnly(t *testing.T) {
 	fc := newAggregationFakeClient(scheme, group, oidcClient)
 	reconciler := &Reconciler{Client: fc, Scheme: scheme}
 
-	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2170,7 +2171,7 @@ func TestAggregateAllowedUserGroupIDs_Union(t *testing.T) {
 	fc := newAggregationFakeClient(scheme, groupA, groupB, oidcClient)
 	reconciler := &Reconciler{Client: fc, Scheme: scheme}
 
-	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2205,7 +2206,7 @@ func TestAggregateAllowedUserGroupIDs_SkipsNotReady(t *testing.T) {
 	fc := newAggregationFakeClient(scheme, group, oidcClient)
 	reconciler := &Reconciler{Client: fc, Scheme: scheme}
 
-	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2226,12 +2227,95 @@ func TestAggregateAllowedUserGroupIDs_NilWhenNoRefs(t *testing.T) {
 	fc := newAggregationFakeClient(scheme, oidcClient)
 	reconciler := &Reconciler{Client: fc, Scheme: scheme}
 
-	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if ids != nil {
 		t.Errorf("expected nil when no refs from either side, got %v", ids)
+	}
+}
+
+// staticUserGroupLookup resolves groups that have no PocketIDUserGroup in this cluster.
+type staticUserGroupLookup struct {
+	groups []*pocketid.UserGroup
+}
+
+func (s staticUserGroupLookup) ListUserGroups(_ context.Context, search string) ([]*pocketid.UserGroup, error) {
+	for _, group := range s.groups {
+		if group.Name == search {
+			return []*pocketid.UserGroup{group}, nil
+		}
+	}
+	return nil, nil
+}
+
+func TestAggregateAllowedUserGroupIDs_ExternalGroupNeedsNoCR(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-ext", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{GroupName: "developers"},
+			},
+		},
+	}
+
+	fc := newAggregationFakeClient(scheme, oidcClient)
+	reconciler := &Reconciler{Client: fc, Scheme: scheme}
+	lookup := staticUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
+
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, lookup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "gid-dev" {
+		t.Errorf("expected [gid-dev], got %v", ids)
+	}
+}
+
+func TestAggregateAllowedUserGroupIDs_UnionsCRAndExternalRefs(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-a", Namespace: testNamespace},
+		Status:     pocketidinternalv1alpha1.PocketIDUserGroupStatus{GroupID: "gid-a", Conditions: readyCondition()},
+	}
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-mixed", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{Name: "group-a"},
+				{GroupName: "developers"},
+			},
+		},
+	}
+
+	fc := newAggregationFakeClient(scheme, group, oidcClient)
+	reconciler := &Reconciler{Client: fc, Scheme: scheme}
+	lookup := staticUserGroupLookup{groups: []*pocketid.UserGroup{{ID: "gid-dev", Name: "developers"}}}
+
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, lookup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "gid-a" || ids[1] != "gid-dev" {
+		t.Errorf("expected sorted [gid-a gid-dev], got %v", ids)
+	}
+}
+
+func TestReconcileErrorReason_DistinguishesMissingUserGroup(t *testing.T) {
+	missing := fmt.Errorf("aggregate allowed user groups: %w", helpers.ErrUserGroupNotFound)
+	if got := reconcileErrorReason(missing); got != "UserGroupNotFound" {
+		t.Errorf("expected UserGroupNotFound, got %q", got)
+	}
+	if got := reconcileErrorReason(fmt.Errorf("connection refused")); got != "ReconcileError" {
+		t.Errorf("expected ReconcileError, got %q", got)
 	}
 }
 

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -574,7 +574,7 @@ func TestAggregateAllowedUserGroupIDs_OutputIsSorted(t *testing.T) {
 	fc := newAggregationFakeClient(scheme, groupC, groupA, groupB, oidcClient)
 	reconciler := &Reconciler{Client: fc, Scheme: scheme}
 
-	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient)
+	ids, err := reconciler.aggregateAllowedUserGroupIDs(ctx, oidcClient, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/controller/pocketidoidcclient_controller_test.go
+++ b/internal/controller/pocketidoidcclient_controller_test.go
@@ -154,7 +154,7 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 				}); err != nil {
 					return nil, err
 				}
-				return helpers.ResolveUserGroupReferences(ctx, k8sClient, oidcClient.Spec.AllowedUserGroups, oidcClient.Namespace)
+				return helpers.ResolveUserGroupReferences(ctx, k8sClient, nil, oidcClient.Spec.AllowedUserGroups, oidcClient.Namespace)
 			}, timeout, interval).Should(Equal([]string{"group-id-1"}))
 		})
 
@@ -171,7 +171,7 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 				},
 			}
 
-			_, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, client.Spec.AllowedUserGroups, client.Namespace)
+			_, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, nil, client.Spec.AllowedUserGroups, client.Namespace)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -188,7 +188,7 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 				},
 			}
 
-			_, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, client.Spec.AllowedUserGroups, client.Namespace)
+			_, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, nil, client.Spec.AllowedUserGroups, client.Namespace)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -220,7 +220,7 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 				},
 			}
 
-			_, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, client.Spec.AllowedUserGroups, client.Namespace)
+			_, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, nil, client.Spec.AllowedUserGroups, client.Namespace)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -276,7 +276,7 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 				},
 			}
 
-			ids, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, client.Spec.AllowedUserGroups, client.Namespace)
+			ids, err := helpers.ResolveUserGroupReferences(ctx, k8sClient, nil, client.Spec.AllowedUserGroups, client.Namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ids).To(Equal([]string{"cross-ns-group-id"}))
 		})
@@ -456,6 +456,64 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+		})
+	})
+
+	Context("AllowedUserGroups reference validation", func() {
+		newClient := func(name string, refs ...pocketidinternalv1alpha1.NamespacedUserGroupReference) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+			return &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec:       pocketidinternalv1alpha1.PocketIDOIDCClientSpec{AllowedUserGroups: refs},
+			}
+		}
+		expectAccepted := func(resource *pocketidinternalv1alpha1.PocketIDOIDCClient) {
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, resource) })
+		}
+		expectRejected := func(resource *pocketidinternalv1alpha1.PocketIDOIDCClient) {
+			err := k8sClient.Create(ctx, resource)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+		}
+
+		It("accepts a CR reference with a namespace", func() {
+			expectAccepted(newClient("ug-cel-cr",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{Name: "group-a", Namespace: namespace}))
+		})
+
+		It("accepts a groupName reference", func() {
+			expectAccepted(newClient("ug-cel-name",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupName: "developers"}))
+		})
+
+		It("accepts a groupID reference", func() {
+			expectAccepted(newClient("ug-cel-id",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupID: "gid-dev"}))
+		})
+
+		It("accepts CR and external references in the same list", func() {
+			expectAccepted(newClient("ug-cel-mixed",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{Name: "group-a"},
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupName: "developers"}))
+		})
+
+		It("rejects an empty reference", func() {
+			expectRejected(newClient("ug-cel-empty", pocketidinternalv1alpha1.NamespacedUserGroupReference{}))
+		})
+
+		It("rejects a reference setting both name and groupName", func() {
+			expectRejected(newClient("ug-cel-both",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{Name: "group-a", GroupName: "developers"}))
+		})
+
+		It("rejects a reference setting both groupName and groupID", func() {
+			expectRejected(newClient("ug-cel-both-external",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupName: "developers", GroupID: "gid-dev"}))
+		})
+
+		It("rejects a namespace without a CR name", func() {
+			expectRejected(newClient("ug-cel-ns-only",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupName: "developers", Namespace: namespace}))
 		})
 	})
 

--- a/internal/controller/pocketidoidcclient_controller_test.go
+++ b/internal/controller/pocketidoidcclient_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -514,6 +515,43 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 		It("rejects a namespace without a CR name", func() {
 			expectRejected(newClient("ug-cel-ns-only",
 				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupName: "developers", Namespace: namespace}))
+		})
+
+		It("rejects a namespace alongside groupID", func() {
+			expectRejected(newClient("ug-cel-ns-id",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupID: "gid-dev", Namespace: namespace}))
+		})
+
+		It("rejects a reference setting both name and groupID", func() {
+			expectRejected(newClient("ug-cel-name-id",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{Name: "group-a", GroupID: "gid-dev"}))
+		})
+
+		It("rejects a reference setting all three", func() {
+			expectRejected(newClient("ug-cel-all-three",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{Name: "group-a", GroupName: "developers", GroupID: "gid-dev"}))
+		})
+
+		// The length bounds are not cosmetic: without them the exactly-one-of rule
+		// exceeds the API server's CEL cost budget and the CRD is rejected outright.
+		It("rejects a groupName shorter than the minimum", func() {
+			expectRejected(newClient("ug-cel-short-name",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupName: "d"}))
+		})
+
+		It("rejects a groupName longer than the maximum", func() {
+			expectRejected(newClient("ug-cel-long-name",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupName: strings.Repeat("d", 256)}))
+		})
+
+		It("rejects a groupID longer than the maximum", func() {
+			expectRejected(newClient("ug-cel-long-id",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupID: strings.Repeat("g", 65)}))
+		})
+
+		It("accepts a groupID at the maximum length", func() {
+			expectAccepted(newClient("ug-cel-max-id",
+				pocketidinternalv1alpha1.NamespacedUserGroupReference{GroupID: strings.Repeat("g", 64)}))
 		})
 	})
 

--- a/internal/controller/usergroup/controller_test.go
+++ b/internal/controller/usergroup/controller_test.go
@@ -276,3 +276,98 @@ func TestReconcileDelete_KeepFinalizerWhenAPIClientNotReady(t *testing.T) {
 		t.Error("expected UserGroupFinalizer to be kept")
 	}
 }
+
+func TestReconcileUserGroupFinalizers_ExternalRefsDoNotCouple(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	// The CR is named "developers" and the client references a Pocket-ID group that
+	// is also named "developers". They must stay decoupled: an external ref names a
+	// group in Pocket-ID, never a CR, so it must not add the blocking finalizer.
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "developers", Namespace: testNamespace},
+	}
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "external-only-client", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{GroupName: "developers"},
+				{GroupID: "gid-developers"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(group, oidcClient).
+		Build()
+
+	reconciler := &Reconciler{Client: fakeClient, Scheme: scheme}
+	if _, err := reconciler.ReconcileUserGroupFinalizers(ctx, group); err != nil {
+		t.Fatalf("ReconcileUserGroupFinalizers returned error: %v", err)
+	}
+
+	updatedGroup := &pocketidinternalv1alpha1.PocketIDUserGroup{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: group.Name, Namespace: group.Namespace}, updatedGroup); err != nil {
+		t.Fatalf("failed to get updated group: %v", err)
+	}
+	for _, f := range updatedGroup.Finalizers {
+		if f == OIDCClientUserGroupFinalizer {
+			t.Error("expected no OIDCClientUserGroupFinalizer for an external-only reference")
+		}
+	}
+}
+
+func TestOIDCClientAllowsGroup_ExternalRefsNeverMatch(t *testing.T) {
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-a", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{GroupName: "developers"},
+				{GroupID: "gid-dev"},
+			},
+		},
+	}
+	if oidcClientAllowsGroup(oidcClient, testNamespace, "developers") {
+		t.Error("expected groupName not to match a CR of the same name")
+	}
+	if oidcClientAllowsGroup(oidcClient, testNamespace, "gid-dev") {
+		t.Error("expected groupID not to match a CR of the same name")
+	}
+}
+
+func TestOIDCClientAllowsGroup_MixedRefsMatchOnlyTheCRRef(t *testing.T) {
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-a", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{GroupName: "developers"},
+				{Name: "local-admins"},
+			},
+		},
+	}
+	if !oidcClientAllowsGroup(oidcClient, testNamespace, "local-admins") {
+		t.Error("expected the CR ref to match")
+	}
+	if oidcClientAllowsGroup(oidcClient, testNamespace, "developers") {
+		t.Error("expected the external ref not to match")
+	}
+}
+
+func TestOIDCClientAllowsGroup_CRRefRespectsNamespace(t *testing.T) {
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client-a", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{Name: "admins", Namespace: "other"},
+			},
+		},
+	}
+	if !oidcClientAllowsGroup(oidcClient, "other", "admins") {
+		t.Error("expected a match in the referenced namespace")
+	}
+	if oidcClientAllowsGroup(oidcClient, testNamespace, "admins") {
+		t.Error("expected no match in the client's own namespace")
+	}
+}

--- a/internal/pocketid/client.go
+++ b/internal/pocketid/client.go
@@ -1037,23 +1037,6 @@ func (c *Client) UpdateUserGroupUsers(ctx context.Context, id string, userIDs []
 	return nil
 }
 
-func (c *Client) UpdateUserGroupAllowedOIDCClients(ctx context.Context, id string, clientIDs []string) error {
-	params := oidc.NewPutAPIUserGroupsIDAllowedOidcClientsParams().
-		WithID(id).
-		WithGroups(&models.GithubComPocketIDPocketIDBackendInternalDtoUserGroupUpdateAllowedOidcClientsDto{
-			OidcClientIds: clientIDs,
-		})
-
-	start := time.Now()
-	_, err := c.raw.OIDc.PutAPIUserGroupsIDAllowedOidcClientsContext(ctx, params)
-	recordCall("update_user_group_allowed_oidc_clients", err, time.Since(start))
-	if err != nil {
-		return fmt.Errorf("update user group allowed OIDC clients failed: %w", err)
-	}
-
-	return nil
-}
-
 func (c *Client) UpdateUserGroupCustomClaims(ctx context.Context, id string, claims []CustomClaim) ([]CustomClaim, error) {
 	payload := make([]*models.GithubComPocketIDPocketIDBackendInternalDtoCustomClaimCreateDto, 0, len(claims))
 	for _, claim := range claims {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -314,7 +314,9 @@ type OIDCClientOptions struct {
 	LogoutCallbackURLs []string
 	IsPublic           bool
 	SkipConsent        bool
-	AllowedUserGroups  []string
+	AllowedUserGroups  []string // spec.allowedUserGroups[].name: PocketIDUserGroup CRs
+	AllowedGroupNames  []string // spec.allowedUserGroups[].groupName: Pocket-ID groups with no CR
+	AllowedGroupIDs    []string // spec.allowedUserGroups[].groupID: Pocket-ID groups with no CR
 	APIAccess          []APIAccessGrant
 	Logo               *OIDCLogoConfig
 	Secret             *OIDCSecretConfig
@@ -413,10 +415,16 @@ func buildOIDCClientYAML(opts OIDCClientOptions) string {
 		}
 	}
 
-	if len(opts.AllowedUserGroups) > 0 {
+	if len(opts.AllowedUserGroups) > 0 || len(opts.AllowedGroupNames) > 0 || len(opts.AllowedGroupIDs) > 0 {
 		spec.WriteString("  allowedUserGroups:\n")
 		for _, group := range opts.AllowedUserGroups {
 			spec.WriteString(fmt.Sprintf("  - name: %s\n", group))
+		}
+		for _, group := range opts.AllowedGroupNames {
+			spec.WriteString(fmt.Sprintf("  - groupName: %s\n", group))
+		}
+		for _, group := range opts.AllowedGroupIDs {
+			spec.WriteString(fmt.Sprintf("  - groupID: %s\n", group))
 		}
 	}
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -972,6 +972,29 @@ echo "$BODY" | grep -o '"id":"[^"]*"' | head -1 | sed 's/"id":"//;s/"//'`,
 	return getPodLogs(podName, namespace)
 }
 
+// deleteUserGroupInPocketID deletes a user group directly via the Pocket-ID API,
+// simulating a group removed out-of-band (another cluster, or the UI).
+func deleteUserGroupInPocketID(podName, namespace, groupID string) {
+	staticSecretName := instanceName + "-static-api-key"
+
+	apiKeyBase64 := kubectlGet("secret", staticSecretName, "-n", instanceNS,
+		"-o", "jsonpath={.data.token}")
+	Expect(apiKeyBase64).NotTo(BeEmpty(), "static API key secret should exist")
+
+	script := fmt.Sprintf(`API_KEY=$(echo '%s' | base64 -d)
+HTTP_CODE=$(curl -s -o /dev/null -w '%%{http_code}' -X DELETE \
+  -H "X-API-KEY: $API_KEY" %s/api/user-groups/%s)
+if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "204" ]; then
+  echo "Failed to delete user group: HTTP $HTTP_CODE" >&2
+  exit 1
+fi
+echo "User group deleted"`,
+		apiKeyBase64, formatInstanceURL(), groupID)
+
+	applyYAML(createCurlPodYAML(podName, namespace, script))
+	waitForPodSucceeded(podName, namespace)
+}
+
 // getGroupMembersFromPocketID returns the space-separated user IDs of a group
 // by querying the Pocket-ID API directly.
 func getGroupMembersFromPocketID(podName, namespace, groupID string) string {

--- a/test/e2e/usergroup_oidcclient_test.go
+++ b/test/e2e/usergroup_oidcclient_test.go
@@ -1082,8 +1082,141 @@ var _ = Describe("OIDCClient attaching groups that have no PocketIDUserGroup CR"
 		waitForReady("pocketidoidcclient", missingRefClient, userNS)
 	})
 
+	It("should leave the external group itself untouched", func() {
+		// The core promise: the operator resolves the group but never manages it.
+		// friendlyName is the field a PocketIDUserGroup would overwrite on every
+		// resync, so its survival is the strongest available signal.
+		body := getFromPocketID("verify-external-group-unmodified", userNS, "/api/user-groups/"+externalGroupID)
+		Expect(body).To(ContainSubstring("External Only Group"))
+		Expect(body).To(ContainSubstring(externalGroup))
+	})
+
 	It("should not block deletion of the client on the external group", func() {
 		Expect(kubectlDeleteWait("pocketidoidcclient", byNameClient, userNS, 2*time.Minute)).To(Succeed())
 		waitForResourceDeleted("pocketidoidcclient", byNameClient, userNS)
+	})
+
+	It("should survive deleting a client that shared the external group", func() {
+		// byNameClient was just deleted; byIDClient referenced the same group and
+		// must be unaffected, and the group must still exist in Pocket-ID.
+		waitForReady("pocketidoidcclient", byIDClient, userNS)
+		waitForStatusField("pocketidoidcclient", byIDClient, userNS,
+			".status.allowedUserGroupIDs[0]", externalGroupID)
+
+		body := getFromPocketID("verify-external-group-survives", userNS, "/api/user-groups/"+externalGroupID)
+		Expect(body).To(ContainSubstring(externalGroupID))
+	})
+})
+
+var _ = Describe("OIDCClient mixing CR, name, and ID group references", Ordered, func() {
+	const (
+		comboClient   = "attach-combo-groups"
+		comboCRGroup  = "combo-cr-group"
+		comboExtA     = "combo-external-a"
+		comboExtB     = "combo-external-b"
+		comboExtByID  = "combo-external-by-id"
+		comboCRPocket = "combo-cr-pocket-group"
+	)
+
+	var (
+		crGroupID  string
+		extAID     string
+		extBID     string
+		extByIDGid string
+	)
+
+	BeforeAll(func() {
+		By("creating one group through a PocketIDUserGroup CR")
+		createUserGroupAndWaitReady(UserGroupOptions{
+			Name:         comboCRGroup,
+			GroupName:    comboCRPocket,
+			FriendlyName: "Combo CR Group",
+		})
+		crGroupID = kubectlGet("pocketidusergroup", comboCRGroup, "-n", userNS,
+			"-o", "jsonpath={.status.groupID}")
+		Expect(crGroupID).NotTo(BeEmpty())
+
+		By("creating three groups directly in Pocket-ID with no CR")
+		extAID = createUserGroupInPocketID("create-combo-a", userNS, comboExtA, "Combo External A")
+		extBID = createUserGroupInPocketID("create-combo-b", userNS, comboExtB, "Combo External B")
+		extByIDGid = createUserGroupInPocketID("create-combo-id", userNS, comboExtByID, "Combo External By ID")
+		Expect(extAID).NotTo(BeEmpty())
+		Expect(extBID).NotTo(BeEmpty())
+		Expect(extByIDGid).NotTo(BeEmpty())
+	})
+
+	It("should resolve every reference form on one client", func() {
+		createOIDCClient(OIDCClientOptions{
+			Name:              comboClient,
+			CallbackURLs:      []string{"https://combo.example.com/callback"},
+			AllowedUserGroups: []string{comboCRGroup},
+			AllowedGroupNames: []string{comboExtA, comboExtB},
+			AllowedGroupIDs:   []string{extByIDGid},
+		})
+
+		waitForReady("pocketidoidcclient", comboClient, userNS)
+		Eventually(func(g Gomega) {
+			output := kubectlGet("pocketidoidcclient", comboClient, "-n", userNS,
+				"-o", "jsonpath={.status.allowedUserGroupIDs[*]}")
+			for _, id := range []string{crGroupID, extAID, extBID, extByIDGid} {
+				g.Expect(output).To(ContainSubstring(id))
+			}
+			g.Expect(strings.Fields(output)).To(HaveLen(4))
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	It("should push all four groups through to Pocket-ID", func() {
+		clientID := kubectlGet("pocketidoidcclient", comboClient, "-n", userNS,
+			"-o", "jsonpath={.status.clientID}")
+
+		Eventually(func(g Gomega) {
+			body := getFromPocketID("verify-combo-groups", userNS, "/api/oidc/clients/"+clientID)
+			for _, id := range []string{crGroupID, extAID, extBID, extByIDGid} {
+				g.Expect(body).To(ContainSubstring(id))
+			}
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("should collapse duplicate references to the same group", func() {
+		// The CR group named three ways: by CR, by its Pocket-ID name, and by ID.
+		createOIDCClient(OIDCClientOptions{
+			Name:              comboClient,
+			CallbackURLs:      []string{"https://combo.example.com/callback"},
+			AllowedUserGroups: []string{comboCRGroup},
+			AllowedGroupNames: []string{comboCRPocket},
+			AllowedGroupIDs:   []string{crGroupID},
+		})
+
+		waitForReady("pocketidoidcclient", comboClient, userNS)
+		Eventually(func(g Gomega) {
+			output := kubectlGet("pocketidoidcclient", comboClient, "-n", userNS,
+				"-o", "jsonpath={.status.allowedUserGroupIDs[*]}")
+			g.Expect(strings.Fields(output)).To(Equal([]string{crGroupID}))
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	It("should detach external groups when their references are removed", func() {
+		createOIDCClient(OIDCClientOptions{
+			Name:              comboClient,
+			CallbackURLs:      []string{"https://combo.example.com/callback"},
+			AllowedGroupNames: []string{comboExtA},
+		})
+
+		waitForReady("pocketidoidcclient", comboClient, userNS)
+		Eventually(func(g Gomega) {
+			output := kubectlGet("pocketidoidcclient", comboClient, "-n", userNS,
+				"-o", "jsonpath={.status.allowedUserGroupIDs[*]}")
+			g.Expect(strings.Fields(output)).To(Equal([]string{extAID}))
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	It("should not add a finalizer to the CR group for external references", func() {
+		// The CR group is no longer referenced by the client at all, so the
+		// cross-resource finalizer must be gone and deletion must not block.
+		Eventually(func(g Gomega) {
+			finalizers := kubectlGet("pocketidusergroup", comboCRGroup, "-n", userNS,
+				"-o", "jsonpath={.metadata.finalizers}")
+			g.Expect(finalizers).NotTo(ContainSubstring("pocketid.internal/oidc-client-finalizer"))
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 	})
 })

--- a/test/e2e/usergroup_oidcclient_test.go
+++ b/test/e2e/usergroup_oidcclient_test.go
@@ -985,3 +985,105 @@ var _ = Describe("Multiple OIDC Clients Sharing a User Group", Ordered, func() {
 		}
 	})
 })
+
+var _ = Describe("OIDCClient attaching groups that have no PocketIDUserGroup CR", Ordered, func() {
+	const (
+		externalGroup    = "external-only-group"
+		byNameClient     = "attach-by-group-name"
+		byIDClient       = "attach-by-group-id"
+		missingRefClient = "attach-missing-group"
+		badIDClient      = "attach-bad-group-id"
+		nonexistentGroup = "no-such-group-anywhere"
+		// A well-formed UUID that no group in Pocket-ID owns.
+		nonexistentGroupID = "00000000-0000-4000-8000-000000000000"
+		createGroupPod     = "create-external-group"
+		verifyAttachedPod  = "verify-external-group-attached"
+	)
+
+	var externalGroupID string
+
+	BeforeAll(func() {
+		By("creating a user group directly in Pocket-ID, with no CR in this cluster")
+		externalGroupID = createUserGroupInPocketID(createGroupPod, userNS, externalGroup, "External Only Group")
+		Expect(externalGroupID).NotTo(BeEmpty(), "expected a group ID from Pocket-ID")
+	})
+
+	It("should resolve a group by groupName without a PocketIDUserGroup", func() {
+		createOIDCClient(OIDCClientOptions{
+			Name:              byNameClient,
+			CallbackURLs:      []string{"https://external-group.example.com/callback"},
+			AllowedGroupNames: []string{externalGroup},
+		})
+
+		waitForReady("pocketidoidcclient", byNameClient, userNS)
+		waitForStatusField("pocketidoidcclient", byNameClient, userNS,
+			".status.allowedUserGroupIDs[0]", externalGroupID)
+	})
+
+	It("should push the assignment through to Pocket-ID", func() {
+		clientID := kubectlGet("pocketidoidcclient", byNameClient, "-n", userNS,
+			"-o", "jsonpath={.status.clientID}")
+
+		Eventually(func(g Gomega) {
+			body := getFromPocketID(verifyAttachedPod, userNS, "/api/oidc/clients/"+clientID)
+			g.Expect(body).To(ContainSubstring(externalGroupID))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("should leave no PocketIDUserGroup behind for the external group", func() {
+		output := kubectlGet("pocketidusergroup", "-n", userNS, "-o", "name")
+		Expect(output).NotTo(ContainSubstring(externalGroup))
+	})
+
+	It("should resolve a group by groupID", func() {
+		createOIDCClient(OIDCClientOptions{
+			Name:            byIDClient,
+			CallbackURLs:    []string{"https://external-group-id.example.com/callback"},
+			AllowedGroupIDs: []string{externalGroupID},
+		})
+
+		waitForReady("pocketidoidcclient", byIDClient, userNS)
+		waitForStatusField("pocketidoidcclient", byIDClient, userNS,
+			".status.allowedUserGroupIDs[0]", externalGroupID)
+	})
+
+	It("should not become Ready when groupID does not exist", func() {
+		createOIDCClient(OIDCClientOptions{
+			Name:            badIDClient,
+			CallbackURLs:    []string{"https://bad-group-id.example.com/callback"},
+			AllowedGroupIDs: []string{nonexistentGroupID},
+		})
+
+		// A groupID is handed to Pocket-ID unverified, so unlike groupName the failure
+		// comes from the allowed-groups write and carries reason ReconcileError.
+		waitForCondition("pocketidoidcclient", badIDClient, userNS, "Ready", "False")
+		waitForConditionReason("pocketidoidcclient", badIDClient, userNS, "Ready", "ReconcileError")
+
+		By("verifying it stays not Ready across resyncs")
+		Consistently(func(g Gomega) {
+			output := kubectlGet("pocketidoidcclient", badIDClient, "-n", userNS,
+				"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+			g.Expect(output).To(Equal("False"))
+		}, 30*time.Second, 5*time.Second).Should(Succeed())
+	})
+
+	It("should report UserGroupNotFound for a group that does not exist", func() {
+		createOIDCClient(OIDCClientOptions{
+			Name:              missingRefClient,
+			CallbackURLs:      []string{"https://missing-group.example.com/callback"},
+			AllowedGroupNames: []string{nonexistentGroup},
+		})
+
+		waitForConditionReason("pocketidoidcclient", missingRefClient, userNS, "Ready", "UserGroupNotFound")
+	})
+
+	It("should recover once the referenced group exists in Pocket-ID", func() {
+		createUserGroupInPocketID("create-late-group", userNS, nonexistentGroup, "Late Group")
+		waitForReady("pocketidoidcclient", missingRefClient, userNS)
+	})
+
+	It("should not block deletion of the client on the external group", func() {
+		Expect(kubectlDeleteWait("pocketidoidcclient", byNameClient, userNS, 2*time.Minute)).To(Succeed())
+		waitForResourceDeleted("pocketidoidcclient", byNameClient, userNS)
+	})
+})

--- a/test/e2e/usergroup_oidcclient_test.go
+++ b/test/e2e/usergroup_oidcclient_test.go
@@ -1054,10 +1054,10 @@ var _ = Describe("OIDCClient attaching groups that have no PocketIDUserGroup CR"
 			AllowedGroupIDs: []string{nonexistentGroupID},
 		})
 
-		// A groupID is handed to Pocket-ID unverified, so unlike groupName the failure
-		// comes from the allowed-groups write and carries reason ReconcileError.
+		// Pocket-ID accepts unknown group IDs silently, so the operator detects this by
+		// re-reading the client after the push rather than from the write failing.
 		waitForCondition("pocketidoidcclient", badIDClient, userNS, "Ready", "False")
-		waitForConditionReason("pocketidoidcclient", badIDClient, userNS, "Ready", "ReconcileError")
+		waitForConditionReason("pocketidoidcclient", badIDClient, userNS, "Ready", "UserGroupNotFound")
 
 		By("verifying it stays not Ready across resyncs")
 		Consistently(func(g Gomega) {
@@ -1218,5 +1218,69 @@ var _ = Describe("OIDCClient mixing CR, name, and ID group references", Ordered,
 				"-o", "jsonpath={.metadata.finalizers}")
 			g.Expect(finalizers).NotTo(ContainSubstring("pocketid.internal/oidc-client-finalizer"))
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+})
+
+var _ = Describe("OIDCClient referencing a group deleted upstream", Ordered, func() {
+	const (
+		doomedGroup = "doomed-external-group"
+		byIDClient  = "doomed-by-group-id"
+		byNameClnt  = "doomed-by-group-name"
+	)
+
+	var doomedGroupID string
+
+	BeforeAll(func() {
+		By("creating a group directly in Pocket-ID, with no CR in this cluster")
+		doomedGroupID = createUserGroupInPocketID("create-doomed-group", userNS, doomedGroup, "Doomed Group")
+		Expect(doomedGroupID).NotTo(BeEmpty())
+
+		By("attaching two clients, one by groupID and one by groupName")
+		createOIDCClient(OIDCClientOptions{
+			Name:            byIDClient,
+			CallbackURLs:    []string{"https://doomed-id.example.com/callback"},
+			AllowedGroupIDs: []string{doomedGroupID},
+		})
+		createOIDCClient(OIDCClientOptions{
+			Name:              byNameClnt,
+			CallbackURLs:      []string{"https://doomed-name.example.com/callback"},
+			AllowedGroupNames: []string{doomedGroup},
+		})
+	})
+
+	It("should start Ready with the group attached", func() {
+		for _, name := range []string{byIDClient, byNameClnt} {
+			waitForReady("pocketidoidcclient", name, userNS)
+			waitForStatusField("pocketidoidcclient", name, userNS,
+				".status.allowedUserGroupIDs[0]", doomedGroupID)
+		}
+	})
+
+	It("should go not Ready after the group is deleted in Pocket-ID", func() {
+		By("deleting the group out-of-band")
+		deleteUserGroupInPocketID("delete-doomed-group", userNS, doomedGroupID)
+
+		// Nothing in the cluster changed, so this is only caught because references
+		// are re-resolved against Pocket-ID on every reconcile.
+		By("verifying both clients report UserGroupNotFound without any spec edit")
+		for _, name := range []string{byIDClient, byNameClnt} {
+			waitForCondition("pocketidoidcclient", name, userNS, "Ready", "False")
+			waitForConditionReason("pocketidoidcclient", name, userNS, "Ready", "UserGroupNotFound")
+		}
+	})
+
+	It("should recover a groupName reference when the group is recreated", func() {
+		// A name can be re-resolved to whatever group now holds it; a groupID cannot,
+		// since a recreated group gets a new ID.
+		newID := createUserGroupInPocketID("recreate-doomed-group", userNS, doomedGroup, "Doomed Group")
+		Expect(newID).NotTo(BeEmpty())
+		Expect(newID).NotTo(Equal(doomedGroupID))
+
+		waitForReady("pocketidoidcclient", byNameClnt, userNS)
+		waitForStatusField("pocketidoidcclient", byNameClnt, userNS,
+			".status.allowedUserGroupIDs[0]", newID)
+
+		By("verifying the stale groupID reference stays not Ready")
+		waitForConditionReason("pocketidoidcclient", byIDClient, userNS, "Ready", "UserGroupNotFound")
 	})
 })


### PR DESCRIPTION
Closes https://github.com/aclerici38/pocket-id-operator/issues/489

user groups can now be referenced from an oidcclient via their ID or name, same as usergroups reference users. The spec is unfortunately structured differently, however

```yaml
spec:
  allowedUserGroups:
    - name: platform-admins       # a PocketIDUserGroup CR
      namespace: pocket-id        # optional, defaults to the client's namespace
    - groupName: developers       # an existing Pocket-ID group, by name
    - groupID: 4f8c1b2e-...       # an existing Pocket-ID group, by ID
```
I would have much rather used a struct similar to what the userGroup CRD uses but that would require another deprecation and separate field or a breaking change.