### PR TITLE
fix: Always use 16-char login code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,4 +87,4 @@ On creation a PocketIDOIDCClient is matched to existing user groups by `spec.cli
 On creation a PocketIDAPI is matched to an existing API in pocket-id by `spec.resource`, its permanent audience identifier. See [PocketIDAPI](pocketidapi.md) for more details.
 
 # Starting Fresh
-If installing Pocket-ID for the first time with this operator the procedure should be straightforward. The only difference in features are with the `PocketIDUser` custom resources, when initialized through the operator a one-time passcode will be generated and stored in the status of the custom resource for 15 minutes.
+If installing Pocket-ID for the first time with this operator the procedure should be straightforward. The only difference in features are with the `PocketIDUser` custom resources, when initialized through the operator a one-time passcode will be generated and stored in the status of the custom resource for 60 minutes.

--- a/docs/pocketiduser.md
+++ b/docs/pocketiduser.md
@@ -115,7 +115,7 @@ spec:
 When a user is first created in pocket-id via a custom resource a one-time code is automatically
 generated for them to use on first login. The code will be displayed in the resource's status under `oneTimeLoginToken`.
 If `spec.appUrl` is set on the targeted `PocketIDInstance`, `oneTimeLoginURL` will contain a fqdn that will auto-login the user with the code.
-This code expires after 15 minutes and is subsequently removed from the resource's status.
+This code expires after 60 minutes and is subsequently removed from the resource's status.
 
 ## Status Highlights
 

--- a/internal/controller/user/controller.go
+++ b/internal/controller/user/controller.go
@@ -45,9 +45,10 @@ import (
 )
 
 const (
-	UserFinalizer              = "pocketid.internal/user-finalizer"
-	UserGroupUserFinalizer     = "pocketid.internal/user-group-finalizer"
-	DefaultLoginTokenExpiryMin = 15
+	UserFinalizer          = "pocketid.internal/user-finalizer"
+	UserGroupUserFinalizer = "pocketid.internal/user-group-finalizer"
+	// DefaultLoginTokenExpiryMin must stay above 15 for a full-length token
+	DefaultLoginTokenExpiryMin = 60
 
 	// DeleteFromPocketIDAnnotation when set to "true" will delete the user from Pocket-ID
 	// when the PocketIDUser resource is deleted from Kubernetes. By default, users are

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -956,6 +956,22 @@ curl -sf -H "X-API-KEY: $API_KEY" %s%s`,
 	return getPodLogs(podName, namespace)
 }
 
+// getAppConfigFieldFromPocketID returns a single field from Pocket-ID's public
+// application configuration. This endpoint needs no auth: it is the same payload the
+// login page reads in the browser before the user has a session. The response is a flat
+// array of {"key","type","value"} objects rather than an object keyed by field name, so
+// this pulls the entry whose "key" matches and reads its "value". Values are always
+// strings, so booleans come back as "true"/"false".
+func getAppConfigFieldFromPocketID(podName, namespace, field string) string {
+	script := fmt.Sprintf(`curl -sf %s/api/application-configuration \
+  | grep -o '{[^{}]*"key":"%s"[^{}]*}' \
+  | grep -o '"value":"[^"]*"' | head -1 | sed 's/.*":"//;s/"$//'`,
+		formatInstanceURL(), field)
+
+	applyYAML(createCurlPodYAML(podName, namespace, script))
+	return getPodLogs(podName, namespace)
+}
+
 // createAPIInPocketID creates an API directly via the Pocket-ID API (bypassing the
 // operator, simulating creation through the UI) and returns the new API's ID. Used to
 // test adoption of a pre-existing API by resource.

--- a/test/e2e/user_test.go
+++ b/test/e2e/user_test.go
@@ -319,6 +319,32 @@ curl -sf -H "X-API-KEY: $TOKEN" %s/api/users/me | grep -q '"username":"%s"'`,
 			}, time.Minute, 2*time.Second).Should(Succeed())
 		})
 
+		// Pocket-ID derives the login code's length from the TTL requested when minting
+		// it: a TTL of 15m or less yields a 6-character code built for the email login
+		// flow, anything longer yields the 16-character link code. The page behind
+		// status.oneTimeLoginURL only submits a 6-character code when
+		// emailOneTimeAccessAsUnauthenticatedEnabled is on, so a short code leaves the
+		// link unusable in a browser even though the exchange endpoint still accepts it.
+		// That is why the session-exchange test below cannot catch this on its own.
+		It("should issue a 16-character login code", func() {
+			const userName = "test-login-code-length"
+			const podName = "login-code-config-check"
+
+			createUserAndWaitReady(UserOptions{Name: userName})
+
+			token := waitForStatusFieldNotEmpty("pocketiduser", userName, userNS,
+				".status.oneTimeLoginToken")
+
+			By("confirming email one-time access is off, so the page requires the long code")
+			Expect(getAppConfigFieldFromPocketID(podName, userNS,
+				"emailOneTimeAccessAsUnauthenticatedEnabled")).To(Equal("false"))
+
+			Expect(token).To(HaveLen(16),
+				"expected the 16-character link code; a 6-character code means either "+
+					"DefaultLoginTokenExpiryMin dropped to Pocket-ID's short-code threshold "+
+					"or Pocket-ID raised that threshold past the TTL we request")
+		})
+
 		It("should exchange the one-time access token for a session", func() {
 			const userName = "test-login-token-exchange"
 			const podName = "login-token-exchange-test"


### PR DESCRIPTION
fixes https://github.com/aclerici38/pocket-id-operator/issues/519

https://github.com/pocket-id/pocket-id/pull/1512/changes forces a full-length login code in the ui by default. The api still accepts shorter codes unconditionally so all tests still passed here. The token length is chosen based on the ttl https://github.com/pocket-id/pocket-id/blob/281bea54d351128e29bb2e54455a7cb2e619554a/backend/internal/onetimeaccess/service.go#L266-L269

This changes it to 1 hour, which will force the 16-digit code. Their CLI defaults to 1 hour https://github.com/pocket-id/pocket-id/blob/281bea54d351128e29bb2e54455a7cb2e619554a/backend/internal/cmds/one_time_access_token.go#L68-L69