### PR TITLE
fix: don't hardcode cluster domain

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -170,7 +170,7 @@ jobs:
             --create-namespace \
             --namespace pocket-id-instance-test \
             --values .github/helm-test-values-instance.yaml \
-            --set "instance.spec.appUrl=http://pocket-id-instance.pocket-id-instance-test.svc.cluster.local:1411" \
+            --set "instance.spec.appUrl=http://pocket-id-instance.pocket-id-instance-test.svc:1411" \
             --wait \
             --timeout 2m
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -135,8 +135,11 @@ else
   kind create cluster --name "${KIND_CLUSTER}" --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  dnsDomain: ${domain}
+kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    networking:
+      dnsDomain: ${domain}
 EOF
 fi
 '''

--- a/.mise.toml
+++ b/.mise.toml
@@ -40,7 +40,7 @@ lefthook = "2.1.10"
 # Changelog generation
 "aqua:orhun/git-cliff" = "2.13.1"
 
-# Register lefthook's git hooks after `mise install`. 
+# Register lefthook's git hooks after `mise install`.
 # No-op in CI jobs
 [hooks]
 postinstall = "command -v lefthook >/dev/null 2>&1 && lefthook install || true"
@@ -124,13 +124,20 @@ run = [
 ]
 
 [tasks.setup-test-e2e]
-description = "Create the e2e Kind cluster if it does not exist"
+description = "Create the e2e Kind cluster if it does not exist, with a randomized DNS domain (pin with KIND_DNS_DOMAIN)"
 run = '''
 if kind get clusters 2>/dev/null | grep -q "^${KIND_CLUSTER}$"; then
   echo "Kind cluster '${KIND_CLUSTER}' already exists. Skipping creation."
 else
-  echo "Creating Kind cluster '${KIND_CLUSTER}'..."
-  kind create cluster --name "${KIND_CLUSTER}"
+  # `.internal` rather than `.local` keeps the name off macOS mDNS.
+  domain="${KIND_DNS_DOMAIN:-e2e-$(od -An -N3 -tx1 /dev/urandom | tr -d ' \n').internal}"
+  echo "Creating Kind cluster '${KIND_CLUSTER}' with dnsDomain '${domain}'..."
+  kind create cluster --name "${KIND_CLUSTER}" --config - <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  dnsDomain: ${domain}
+EOF
 fi
 '''
 

--- a/internal/controller/common/api_client.go
+++ b/internal/controller/common/api_client.go
@@ -91,5 +91,5 @@ func StaticAPIKeySecretName(instanceName string) string {
 
 // InternalServiceURL returns the internal Kubernetes service URL for the instance.
 func InternalServiceURL(instanceName, namespace string) string {
-	return fmt.Sprintf("http://%s.%s.svc.cluster.local:1411", instanceName, namespace)
+	return fmt.Sprintf("http://%s.%s.svc:1411", instanceName, namespace)
 }

--- a/internal/controller/common/api_client_test.go
+++ b/internal/controller/common/api_client_test.go
@@ -191,7 +191,7 @@ func TestResolveAPIClientCredentials_Deployed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if want := InternalServiceURL("deployed", "pocket-id"); url != want {
+	if want := "http://deployed.pocket-id.svc:1411"; url != want {
 		t.Errorf("url: got %q, want %q", url, want)
 	}
 	if key != "static-key" {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -92,7 +92,7 @@ metadata:
       secretKeyRef:
         name: pocket-id-encryption
         key: key
-  appUrl: "http://%s.%s.svc.cluster.local:1411"
+  appUrl: "http://%s.%s.svc:1411"
 %s`, opts.Name, opts.Namespace, labels, opts.Image, opts.Name, opts.Namespace, persistence)
 }
 
@@ -884,7 +884,7 @@ func getPodLogs(name, namespace string) string {
 
 // formatInstanceURL returns the internal service URL for the e2e instance
 func formatInstanceURL() string {
-	return fmt.Sprintf("http://%s.%s.svc.cluster.local:1411", instanceName, instanceNS)
+	return fmt.Sprintf("http://%s.%s.svc:1411", instanceName, instanceNS)
 }
 
 // addUserToGroupInPocketID adds a user to a group directly via the Pocket-ID API,


### PR DESCRIPTION
fixes https://github.com/aclerici38/pocket-id-operator/issues/521

Instead of hardcoding `%s.%s.svc.cluster.local` uses `%s.%s.svc` and lets ndots do its thing with whatever the configured cluster domain is. 
In the linked issue envoy-gateway exposes a env for cluster domain but envoy uses that for more than just connectivity (certs, serviceAccount, other envoy things I don't understand) where dns isn't managed by the cluster. This url is only used by the operator -> instance communication and should be safe.

Also configures KIND with a random cluster domain for the e2e tests just to verify