### PR TITLE
feat: add replay protection to the CRD

### DIFF
--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -119,6 +119,11 @@ type OIDCClientFederatedIdentity struct {
 	// JWKS is the URL or JSON for the identity's JWKS
 	// +optional
 	JWKS string `json:"jwks,omitempty"`
+
+	// ReplayProtection requires client assertions to carry a jti and rejects replays
+	// +kubebuilder:default=false
+	// +optional
+	ReplayProtection bool `json:"replayProtection,omitempty"`
 }
 
 // OIDCClientSecretSpec defines how credentials should be stored in a Secret.

--- a/charts/pocket-id-instance/values.schema.json
+++ b/charts/pocket-id-instance/values.schema.json
@@ -4818,6 +4818,14 @@
                         "null"
                       ]
                     },
+                    "replayProtection": {
+                      "default": false,
+                      "description": "ReplayProtection requires client assertions to carry a jti and rejects replays",
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
                     "subject": {
                       "description": "Subject is the subject for the identity",
                       "type": [

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -248,6 +248,11 @@ spec:
                     jwks:
                       description: JWKS is the URL or JSON for the identity's JWKS
                       type: string
+                    replayProtection:
+                      default: false
+                      description: ReplayProtection requires client assertions to
+                        carry a jti and rejects replays
+                      type: boolean
                     subject:
                       description: Subject is the subject for the identity
                       type: string

--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -4824,6 +4824,14 @@
                             "null"
                           ]
                         },
+                        "replayProtection": {
+                          "default": false,
+                          "description": "ReplayProtection requires client assertions to carry a jti and rejects replays",
+                          "type": [
+                            "boolean",
+                            "null"
+                          ]
+                        },
                         "subject": {
                           "description": "Subject is the subject for the identity",
                           "type": [

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -248,6 +248,11 @@ spec:
                     jwks:
                       description: JWKS is the URL or JSON for the identity's JWKS
                       type: string
+                    replayProtection:
+                      default: false
+                      description: ReplayProtection requires client assertions to
+                        carry a jti and rejects replays
+                      type: boolean
                     subject:
                       description: Subject is the subject for the identity
                       type: string

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-  - manager.yaml
+- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: ghcr.io/aclerici38/pocket-id-operator
-    newName: ghcr.io/aclerici38/pocket-id-operator
-    newTag: v0.12.1@sha256:44be40a88bf039c16875760713399c0bdbe9ac6f304586492932bf4f7982778c
+- name: ghcr.io/aclerici38/pocket-id-operator
+  newName: pocket-id-operator
+  newTag: e2e

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -3435,6 +3435,11 @@ spec:
                     jwks:
                       description: JWKS is the URL or JSON for the identity's JWKS
                       type: string
+                    replayProtection:
+                      default: false
+                      description: ReplayProtection requires client assertions to
+                        carry a jti and rejects replays
+                      type: boolean
                     subject:
                       description: Subject is the subject for the identity
                       type: string

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -4887,7 +4887,7 @@ spec:
         - --zap-log-level=info
         command:
         - /manager
-        image: ghcr.io/aclerici38/pocket-id-operator:v0.12.1@sha256:44be40a88bf039c16875760713399c0bdbe9ac6f304586492932bf4f7982778c
+        image: pocket-id-operator:e2e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3444,6 +3444,11 @@ spec:
                     jwks:
                       description: JWKS is the URL or JSON for the identity's JWKS
                       type: string
+                    replayProtection:
+                      default: false
+                      description: ReplayProtection requires client assertions to
+                        carry a jti and rejects replays
+                      type: boolean
                     subject:
                       description: Subject is the subject for the identity
                       type: string

--- a/dist/schemas/helmrelease_v2_pocket-id-instance.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-instance.json
@@ -5739,6 +5739,14 @@
                                 "null"
                               ]
                             },
+                            "replayProtection": {
+                              "default": false,
+                              "description": "ReplayProtection requires client assertions to carry a jti and rejects replays",
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            },
                             "subject": {
                               "description": "Subject is the subject for the identity",
                               "type": [

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -5745,6 +5745,14 @@
                                     "null"
                                   ]
                                 },
+                                "replayProtection": {
+                                  "default": false,
+                                  "description": "ReplayProtection requires client assertions to carry a jti and rejects replays",
+                                  "type": [
+                                    "boolean",
+                                    "null"
+                                  ]
+                                },
                                 "subject": {
                                   "description": "Subject is the subject for the identity",
                                   "type": [

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -306,6 +306,14 @@
                   "null"
                 ]
               },
+              "replayProtection": {
+                "default": false,
+                "description": "ReplayProtection requires client assertions to carry a jti and rejects replays",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
               "subject": {
                 "description": "Subject is the subject for the identity",
                 "type": [

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -555,10 +555,11 @@ func (r *Reconciler) OidcClientInput(oidcClient *pocketidinternalv1alpha1.Pocket
 		identities := make([]pocketid.OIDCClientFederatedIdentity, 0, len(oidcClient.Spec.FederatedIdentities))
 		for _, identity := range oidcClient.Spec.FederatedIdentities {
 			identities = append(identities, pocketid.OIDCClientFederatedIdentity{
-				Issuer:   identity.Issuer,
-				Subject:  identity.Subject,
-				Audience: identity.Audience,
-				JWKS:     identity.JWKS,
+				Issuer:           identity.Issuer,
+				Subject:          identity.Subject,
+				Audience:         identity.Audience,
+				JWKS:             identity.JWKS,
+				ReplayProtection: identity.ReplayProtection,
 			})
 		}
 		credentials = &pocketid.OIDCClientCredentials{FederatedIdentities: identities}

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -50,10 +50,11 @@ func TestOidcClientInput(t *testing.T) {
 			SkipConsent:                         true,
 			FederatedIdentities: []pocketidinternalv1alpha1.OIDCClientFederatedIdentity{
 				{
-					Issuer:   "https://issuer.example.com",
-					Subject:  "subject",
-					Audience: "audience",
-					JWKS:     "https://issuer.example.com/jwks",
+					Issuer:           "https://issuer.example.com",
+					Subject:          "subject",
+					Audience:         "audience",
+					JWKS:             "https://issuer.example.com/jwks",
+					ReplayProtection: true,
 				},
 			},
 			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
@@ -91,10 +92,11 @@ func TestOidcClientInput(t *testing.T) {
 		t.Fatalf("expected 1 federated identity, got %d", len(input.Credentials.FederatedIdentities))
 	}
 	expected := pocketid.OIDCClientFederatedIdentity{
-		Issuer:   "https://issuer.example.com",
-		Subject:  "subject",
-		Audience: "audience",
-		JWKS:     "https://issuer.example.com/jwks",
+		Issuer:           "https://issuer.example.com",
+		Subject:          "subject",
+		Audience:         "audience",
+		JWKS:             "https://issuer.example.com/jwks",
+		ReplayProtection: true,
 	}
 	if input.Credentials.FederatedIdentities[0] != expected {
 		t.Errorf("expected federated identity %+v, got %+v", expected, input.Credentials.FederatedIdentities[0])

--- a/internal/pocketid/client.go
+++ b/internal/pocketid/client.go
@@ -107,10 +107,11 @@ func (c *OIDCClient) ToInput() OIDCClientInput {
 
 // OIDCClientFederatedIdentity represents a federated identity for OIDC clients.
 type OIDCClientFederatedIdentity struct {
-	Issuer   string
-	Subject  string
-	Audience string
-	JWKS     string
+	Issuer           string
+	Subject          string
+	Audience         string
+	JWKS             string
+	ReplayProtection bool
 }
 
 // OIDCClientCredentials holds optional federated identity configuration.
@@ -1179,10 +1180,11 @@ func oidcCredentialsToDTO(credentials *OIDCClientCredentials) *models.GithubComP
 	identities := make([]*models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientFederatedIdentityDto, 0, len(credentials.FederatedIdentities))
 	for _, identity := range credentials.FederatedIdentities {
 		identities = append(identities, &models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientFederatedIdentityDto{
-			Issuer:   identity.Issuer,
-			Subject:  identity.Subject,
-			Audience: identity.Audience,
-			Jwks:     identity.JWKS,
+			Issuer:           identity.Issuer,
+			Subject:          identity.Subject,
+			Audience:         identity.Audience,
+			Jwks:             identity.JWKS,
+			ReplayProtection: identity.ReplayProtection,
 		})
 	}
 	return &models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientCredentialsDto{

--- a/internal/pocketid/client_test.go
+++ b/internal/pocketid/client_test.go
@@ -106,6 +106,44 @@ func TestUpdateOIDCClient_SendsRequiresPushedAuthorizationRequests(t *testing.T)
 	}
 }
 
+func TestUpdateOIDCClient_SendsFederatedIdentityReplayProtection(t *testing.T) {
+	var body map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/oidc/clients/test-id" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oidcClientResponse{ID: "test-id", Name: "test-client", AllowedUserGroups: []any{}})
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.UpdateOIDCClient(context.Background(), "test-id", OIDCClientInput{
+		Name: "test-client",
+		Credentials: &OIDCClientCredentials{
+			FederatedIdentities: []OIDCClientFederatedIdentity{{
+				Issuer:           "https://issuer.example.com",
+				ReplayProtection: true,
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateOIDCClient: %v", err)
+	}
+
+	identity := firstFederatedIdentity(t, body)
+	if got, _ := identity["replayProtection"].(bool); !got {
+		t.Errorf("expected replayProtection true in payload, got %v", identity["replayProtection"])
+	}
+}
+
 func TestUpdateOIDCClientAllowedGroups_RetriesOn500(t *testing.T) {
 	attempts := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -640,6 +678,26 @@ func TestCustomClaimsEqual_ExtraKeyNotEqual(t *testing.T) {
 }
 
 // jsonStringSlice extracts a []string from a JSON-decoded map.
+// firstFederatedIdentity returns credentials.federatedIdentities[0] from a
+// decoded OIDC client write payload.
+func firstFederatedIdentity(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+
+	credentials, ok := body["credentials"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credentials object in payload, got %v", body["credentials"])
+	}
+	identities, ok := credentials["federatedIdentities"].([]any)
+	if !ok || len(identities) == 0 {
+		t.Fatalf("expected a federated identity in payload, got %v", credentials["federatedIdentities"])
+	}
+	identity, ok := identities[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected federated identity object, got %v", identities[0])
+	}
+	return identity
+}
+
 func jsonStringSlice(m map[string]any, key string) []string {
 	raw, ok := m[key]
 	if !ok || raw == nil {

--- a/internal/pocketid/oidc_write_dto_test.go
+++ b/internal/pocketid/oidc_write_dto_test.go
@@ -1,0 +1,155 @@
+package pocketid
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aclerici38/pocket-id-go-client/v2/models"
+)
+
+// Every field on the OIDC client write DTOs is operator-managed, so a field the
+// mapping in client.go forgets to populate leaves its key out of the request
+// body entirely. These tests send an input with every field set and assert the
+// serialized payload covers the generated DTOs, so a field added by a client
+// regen fails here instead of silently never being pushed.
+
+func TestCreateOIDCClient_PayloadCoversWriteDTO(t *testing.T) {
+	body := captureOIDCClientWrite(t, http.MethodPost, "/api/oidc/clients", func(c *Client, input OIDCClientInput) error {
+		_, err := c.CreateOIDCClient(context.Background(), input)
+		return err
+	})
+
+	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientCreateDto{}, body, "")
+	assertFederatedIdentityFieldsSet(t, body)
+}
+
+func TestUpdateOIDCClient_PayloadCoversWriteDTO(t *testing.T) {
+	body := captureOIDCClientWrite(t, http.MethodPut, "/api/oidc/clients/test-id", func(c *Client, input OIDCClientInput) error {
+		_, err := c.UpdateOIDCClient(context.Background(), "test-id", input)
+		return err
+	})
+
+	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientUpdateDto{}, body, "")
+	assertFederatedIdentityFieldsSet(t, body)
+}
+
+// captureOIDCClientWrite calls write against a stub server and returns the
+// decoded request body it sent.
+func captureOIDCClientWrite(t *testing.T, method, path string, write func(*Client, OIDCClientInput) error) map[string]any {
+	t.Helper()
+
+	var body map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != method || r.URL.Path != path {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		if method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+		}
+		_ = json.NewEncoder(w).Encode(oidcClientResponse{ID: "test-id", Name: "test-client", AllowedUserGroups: []any{}})
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	id := "test-id"
+	input := OIDCClientInput{
+		ID:                                  &id,
+		Name:                                "test-client",
+		Description:                         "a test client",
+		CallbackURLs:                        []string{"https://example.com/callback"},
+		LogoutCallbackURLs:                  []string{"https://example.com/logout"},
+		LaunchURL:                           "https://example.com",
+		LogoURL:                             "https://example.com/logo.png",
+		DarkLogoURL:                         "https://example.com/logo-dark.png",
+		HasLogo:                             true,
+		HasDarkLogo:                         true,
+		IsPublic:                            true,
+		IsGroupRestricted:                   true,
+		PKCEEnabled:                         true,
+		RequiresReauthentication:            true,
+		RequiresPushedAuthorizationRequests: true,
+		SkipConsent:                         true,
+		Credentials: &OIDCClientCredentials{
+			FederatedIdentities: []OIDCClientFederatedIdentity{{
+				Issuer:           "https://issuer.example.com",
+				Subject:          "subject",
+				Audience:         "audience",
+				JWKS:             "https://issuer.example.com/jwks",
+				ReplayProtection: true,
+			}},
+		},
+	}
+
+	if err := write(client, input); err != nil {
+		t.Fatalf("write OIDC client: %v", err)
+	}
+	if body == nil {
+		t.Fatal("expected the stub server to receive a request body")
+	}
+	return body
+}
+
+func assertFederatedIdentityFieldsSet(t *testing.T, body map[string]any) {
+	t.Helper()
+
+	credentials, ok := body["credentials"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credentials object in payload, got %v", body["credentials"])
+	}
+	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientCredentialsDto{}, credentials, "credentials.")
+	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientFederatedIdentityDto{},
+		firstFederatedIdentity(t, body), "credentials.federatedIdentities[0].")
+}
+
+// assertDTOFieldsSet reports every JSON key of dto's type that the payload
+// leaves out or sends as a zero value.
+func assertDTOFieldsSet(t *testing.T, dto any, payload map[string]any, prefix string) {
+	t.Helper()
+
+	typ := reflect.TypeOf(dto)
+	for i := range typ.NumField() {
+		key, _, _ := strings.Cut(typ.Field(i).Tag.Get("json"), ",")
+		if key == "" || key == "-" {
+			continue
+		}
+		value, present := payload[key]
+		if !present {
+			t.Errorf("%s%s: missing from payload — map it in client.go", prefix, key)
+			continue
+		}
+		if isZeroJSON(value) {
+			t.Errorf("%s%s: sent as zero value %v — map it in client.go", prefix, key, value)
+		}
+	}
+}
+
+func isZeroJSON(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return true
+	case bool:
+		return !v
+	case string:
+		return v == ""
+	case float64:
+		return v == 0
+	case []any:
+		return len(v) == 0
+	case map[string]any:
+		return len(v) == 0
+	default:
+		return false
+	}
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -318,13 +318,25 @@ type OIDCClientOptions struct {
 	LogoutCallbackURLs []string
 	IsPublic           bool
 	SkipConsent        bool
-	AllowedUserGroups  []string // spec.allowedUserGroups[].name: PocketIDUserGroup CRs
-	AllowedGroupNames  []string // spec.allowedUserGroups[].groupName: Pocket-ID groups with no CR
-	AllowedGroupIDs    []string // spec.allowedUserGroups[].groupID: Pocket-ID groups with no CR
-	APIAccess          []APIAccessGrant
-	Logo               *OIDCLogoConfig
-	Secret             *OIDCSecretConfig
-	SCIM               *SCIMConfig
+	RequiresPAR        bool // spec.requiresPushedAuthorizationRequests
+
+	FederatedIdentities []FederatedIdentity
+	AllowedUserGroups   []string // spec.allowedUserGroups[].name: PocketIDUserGroup CRs
+	AllowedGroupNames   []string // spec.allowedUserGroups[].groupName: Pocket-ID groups with no CR
+	AllowedGroupIDs     []string // spec.allowedUserGroups[].groupID: Pocket-ID groups with no CR
+	APIAccess           []APIAccessGrant
+	Logo                *OIDCLogoConfig
+	Secret              *OIDCSecretConfig
+	SCIM                *SCIMConfig
+}
+
+// FederatedIdentity configures a spec.federatedIdentities entry.
+type FederatedIdentity struct {
+	Issuer           string
+	Subject          string
+	Audience         string
+	JWKS             string
+	ReplayProtection bool
 }
 
 // APIAccessGrant configures a spec.apiAccess entry granting permissions on a PocketIDAPI.
@@ -405,6 +417,29 @@ func buildOIDCClientYAML(opts OIDCClientOptions) string {
 
 	if opts.SkipConsent {
 		spec.WriteString("  skipConsent: true\n")
+	}
+
+	if opts.RequiresPAR {
+		spec.WriteString("  requiresPushedAuthorizationRequests: true\n")
+	}
+
+	if len(opts.FederatedIdentities) > 0 {
+		spec.WriteString("  federatedIdentities:\n")
+		for _, identity := range opts.FederatedIdentities {
+			spec.WriteString(fmt.Sprintf("  - issuer: %s\n", identity.Issuer))
+			if identity.Subject != "" {
+				spec.WriteString(fmt.Sprintf("    subject: %s\n", identity.Subject))
+			}
+			if identity.Audience != "" {
+				spec.WriteString(fmt.Sprintf("    audience: %s\n", identity.Audience))
+			}
+			if identity.JWKS != "" {
+				spec.WriteString(fmt.Sprintf("    jwks: %s\n", identity.JWKS))
+			}
+			if identity.ReplayProtection {
+				spec.WriteString("    replayProtection: true\n")
+			}
+		}
 	}
 
 	spec.WriteString("  callbackUrls:\n")

--- a/test/e2e/oidcclient_federated_identity_test.go
+++ b/test/e2e/oidcclient_federated_identity_test.go
@@ -1,0 +1,49 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OIDC Client Federated Identity", Ordered, func() {
+	// Verifies that spec.federatedIdentities[].replayProtection is actually
+	// persisted by Pocket-ID, not just mapped into the operator's input. The value
+	// is read back from the Pocket-ID API to confirm the full round-trip
+	// (serialize -> store -> return).
+
+	const clientName = "test-federated-identity"
+
+	It("should propagate replayProtection to Pocket-ID", func() {
+		By("creating a PocketIDOIDCClient with a federated identity using replayProtection: true")
+		createOIDCClient(OIDCClientOptions{
+			Name:         clientName,
+			CallbackURLs: []string{"https://federated-identity.example.com/callback"},
+			FederatedIdentities: []FederatedIdentity{{
+				Issuer:           "https://issuer.example.com",
+				Subject:          "test-subject",
+				Audience:         "test-audience",
+				JWKS:             "https://issuer.example.com/.well-known/jwks.json",
+				ReplayProtection: true,
+			}},
+		})
+
+		By("waiting for the client to be ready")
+		waitForReady("pocketidoidcclient", clientName, userNS)
+
+		By("capturing the client ID from status")
+		clientID := waitForStatusFieldNotEmpty("pocketidoidcclient", clientName, userNS, ".status.clientID")
+
+		By("verifying Pocket-ID reports replayProtection: true for the federated identity")
+		body := getOIDCClientFromPocketID("federated-identity-verify", userNS, clientID)
+		Expect(body).To(ContainSubstring(`"replayProtection":true`),
+			"Pocket-ID should persist and return replayProtection: true")
+	})
+
+	AfterAll(func() {
+		kubectlDelete("pocketidoidcclient", clientName, userNS)
+		waitForResourceDeleted("pocketidoidcclient", clientName, userNS)
+	})
+})

--- a/test/e2e/oidcclient_par_test.go
+++ b/test/e2e/oidcclient_par_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OIDC Client Pushed Authorization Requests", Ordered, func() {
+	// Verifies that spec.requiresPushedAuthorizationRequests is actually persisted
+	// by Pocket-ID, not just mapped into the operator's input. The value is read
+	// back from the Pocket-ID API to confirm the full round-trip
+	// (serialize -> store -> return).
+
+	const clientName = "test-par"
+
+	It("should propagate spec.requiresPushedAuthorizationRequests to Pocket-ID", func() {
+		By("creating a PocketIDOIDCClient with requiresPushedAuthorizationRequests: true")
+		createOIDCClient(OIDCClientOptions{
+			Name:         clientName,
+			RequiresPAR:  true,
+			CallbackURLs: []string{"https://par.example.com/callback"},
+		})
+
+		By("waiting for the client to be ready")
+		waitForReady("pocketidoidcclient", clientName, userNS)
+
+		By("capturing the client ID from status")
+		clientID := waitForStatusFieldNotEmpty("pocketidoidcclient", clientName, userNS, ".status.clientID")
+
+		By("verifying Pocket-ID reports requiresPushedAuthorizationRequests: true for the client")
+		body := getOIDCClientFromPocketID("par-verify", userNS, clientID)
+		Expect(body).To(ContainSubstring(`"requiresPushedAuthorizationRequests":true`),
+			"Pocket-ID should persist and return requiresPushedAuthorizationRequests: true")
+	})
+
+	AfterAll(func() {
+		kubectlDelete("pocketidoidcclient", clientName, userNS)
+		waitForResourceDeleted("pocketidoidcclient", clientName, userNS)
+	})
+})


### PR DESCRIPTION
Same as #527, this was omitted from api calls and would get reset to default if configured through the ui.

Also added uncommitted e2e for #527