### PR TITLE
feat: support CIMD oidcclients

### DIFF
--- a/api/v1alpha1/pocketidinstance_types.go
+++ b/api/v1alpha1/pocketidinstance_types.go
@@ -650,6 +650,13 @@ type PocketIDInstanceSpec struct {
 	// +optional
 	Timezone string `json:"timezone,omitempty"`
 
+	// CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata
+	// Documents. Entries are callback-URL patterns (wildcards allowed). A non-empty list
+	// enables CIMD; leaving it empty keeps the feature off.
+	// The operator automatically sets UI_CONFIG_DISABLED=true when this field is set.
+	// +optional
+	CIMDURLAllowlist []string `json:"cimdUrlAllowlist,omitempty"`
+
 	// OIDCClientRotation configures instance-wide throttling of OIDC client secret rotations.
 	// +optional
 	OIDCClientRotation *OIDCClientRotationConfig `json:"OIDCClientRotation,omitempty"`

--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -281,6 +281,10 @@ type SCIMSpec struct {
 // +kubebuilder:validation:XValidation:rule="!self.isPublic || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions) || size(a.clientPermissions) == 0)",message="clientPermissions require a confidential client (isPublic must be false)"
 // +kubebuilder:validation:XValidation:rule="!has(self.clientSecretRef) || !self.isPublic",message="clientSecretRef requires a confidential client (isPublic must be false)"
 // +kubebuilder:validation:XValidation:rule="!has(self.clientSecretRef) || !has(self.clientSecretRotation) || !self.clientSecretRotation.enabled",message="clientSecretRotation cannot be enabled when clientSecretRef is set"
+// +kubebuilder:validation:XValidation:rule="!has(self.clientID) || self.clientID.startsWith('https://') || self.clientID.size() <= 128",message="clientID must be at most 128 characters unless it is a client ID metadata document URL"
+// +kubebuilder:validation:XValidation:rule="!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls) && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)",message="name, callbackUrls, logoutCallbackUrls, federatedIdentities, isPublic, and pkceEnabled are owned by the client ID metadata document and must not be set on a CIMD client"
+// +kubebuilder:validation:XValidation:rule="!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled))",message="a CIMD client is always public and has no client secret, so clientSecretRef and clientSecretRotation are not supported"
+// +kubebuilder:validation:XValidation:rule="!(has(self.clientID) && self.clientID.startsWith('https://')) || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions) || size(a.clientPermissions) == 0)",message="clientPermissions require a confidential client, and a CIMD client is always public"
 type PocketIDOIDCClientSpec struct {
 	// Name of the oidc client to create in Pocket ID.
 	// If omitted, defaults to metadata.name of the oidcclient resource.
@@ -296,10 +300,12 @@ type PocketIDOIDCClientSpec struct {
 	// +optional
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector,omitempty"`
 
-	// ClientID is the optional OIDC client ID to use instead of a generated one
-	// The Client ID is immutable and cannot be changed once the oidc client is created
+	// ClientID is the optional OIDC client ID to use instead of a generated one.
+	// The Client ID is immutable and cannot be changed once the oidc client is created.
+	// An https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)
+	// client, which the operator adopts but never creates and only partially manages.
 	// +kubebuilder:validation:MinLength=2
-	// +kubebuilder:validation:MaxLength=128
+	// +kubebuilder:validation:MaxLength=512
 	// +optional
 	ClientID string `json:"clientID,omitempty"`
 
@@ -463,6 +469,12 @@ type PocketIDOIDCClientStatus struct {
 	// Name is the resolved name from Pocket-ID
 	// +optional
 	Name string `json:"name,omitempty"`
+
+	// ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
+	// The operator refuses to manage "cimd" clients, whose configuration is owned by
+	// their OAuth Client ID Metadata Document.
+	// +optional
+	ClientType string `json:"clientType,omitempty"`
 
 	// CreatedAt is the creation timestamp from Pocket-ID
 	// +optional

--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -471,8 +471,8 @@ type PocketIDOIDCClientStatus struct {
 	Name string `json:"name,omitempty"`
 
 	// ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
-	// The operator refuses to manage "cimd" clients, whose configuration is owned by
-	// their OAuth Client ID Metadata Document.
+	// For a "cimd" client the operator manages only the fields Pocket-ID persists on an
+	// admin update; the rest are owned by its OAuth Client ID Metadata Document.
 	// +optional
 	ClientType string `json:"clientType,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -835,6 +835,11 @@ func (in *PocketIDInstanceSpec) DeepCopyInto(out *PocketIDInstanceSpec) {
 		*out = new(TrustedProxiesConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CIMDURLAllowlist != nil {
+		in, out := &in.CIMDURLAllowlist, &out.CIMDURLAllowlist
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.OIDCClientRotation != nil {
 		in, out := &in.OIDCClientRotation, &out.OIDCClientRotation
 		*out = new(OIDCClientRotationConfig)

--- a/charts/pocket-id-instance/values.schema.json
+++ b/charts/pocket-id-instance/values.schema.json
@@ -136,6 +136,16 @@
                   "null"
                 ]
               },
+              "cimdUrlAllowlist": {
+                "description": "CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata\nDocuments. Entries are callback-URL patterns (wildcards allowed). A non-empty list\nenables CIMD; leaving it empty keeps the feature off.\nThe operator automatically sets UI_CONFIG_DISABLED=true when this field is set.",
+                "items": {
+                  "type": "string"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
               "containerSecurityContext": {
                 "additionalProperties": false,
                 "description": "Container security context",
@@ -4685,8 +4695,8 @@
                 ]
               },
               "clientID": {
-                "description": "ClientID is the optional OIDC client ID to use instead of a generated one\nThe Client ID is immutable and cannot be changed once the oidc client is created",
-                "maxLength": 128,
+                "description": "ClientID is the optional OIDC client ID to use instead of a generated one.\nThe Client ID is immutable and cannot be changed once the oidc client is created.\nAn https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)\nclient, which the operator adopts but never creates and only partially manages.",
+                "maxLength": 512,
                 "minLength": 2,
                 "type": [
                   "string",
@@ -5265,6 +5275,22 @@
               {
                 "message": "clientSecretRotation cannot be enabled when clientSecretRef is set",
                 "rule": "!has(self.clientSecretRef) || !has(self.clientSecretRotation) || !self.clientSecretRotation.enabled"
+              },
+              {
+                "message": "clientID must be at most 128 characters unless it is a client ID metadata document URL",
+                "rule": "!has(self.clientID) || self.clientID.startsWith('https://') || self.clientID.size() <= 128"
+              },
+              {
+                "message": "name, callbackUrls, logoutCallbackUrls, federatedIdentities, isPublic, and pkceEnabled are owned by the client ID metadata document and must not be set on a CIMD client",
+                "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls) && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)"
+              },
+              {
+                "message": "a CIMD client is always public and has no client secret, so clientSecretRef and clientSecretRotation are not supported",
+                "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled))"
+              },
+              {
+                "message": "clientPermissions require a confidential client, and a CIMD client is always public",
+                "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions) || size(a.clientPermissions) == 0)"
               }
             ]
           }

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
@@ -74,6 +74,15 @@ spec:
                 description: Audit log retention in days
                 format: int32
                 type: integer
+              cimdUrlAllowlist:
+                description: |-
+                  CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata
+                  Documents. Entries are callback-URL patterns (wildcards allowed). A non-empty list
+                  enables CIMD; leaving it empty keeps the feature off.
+                  The operator automatically sets UI_CONFIG_DISABLED=true when this field is set.
+                items:
+                  type: string
+                type: array
               containerSecurityContext:
                 description: Container security context
                 properties:

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -148,9 +148,11 @@ spec:
                 type: array
               clientID:
                 description: |-
-                  ClientID is the optional OIDC client ID to use instead of a generated one
-                  The Client ID is immutable and cannot be changed once the oidc client is created
-                maxLength: 128
+                  ClientID is the optional OIDC client ID to use instead of a generated one.
+                  The Client ID is immutable and cannot be changed once the oidc client is created.
+                  An https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)
+                  client, which the operator adopts but never creates and only partially manages.
+                maxLength: 512
                 minLength: 2
                 type: string
               clientSecretRef:
@@ -560,6 +562,26 @@ spec:
                 is set
               rule: '!has(self.clientSecretRef) || !has(self.clientSecretRotation)
                 || !self.clientSecretRotation.enabled'
+            - message: clientID must be at most 128 characters unless it is a client
+                ID metadata document URL
+              rule: '!has(self.clientID) || self.clientID.startsWith(''https://'')
+                || self.clientID.size() <= 128'
+            - message: name, callbackUrls, logoutCallbackUrls, federatedIdentities,
+                isPublic, and pkceEnabled are owned by the client ID metadata document
+                and must not be set on a CIMD client
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls)
+                && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)'
+            - message: a CIMD client is always public and has no client secret, so
+                clientSecretRef and clientSecretRotation are not supported
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation)
+                || !self.clientSecretRotation.enabled))'
+            - message: clientPermissions require a confidential client, and a CIMD
+                client is always public
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions)
+                || size(a.clientPermissions) == 0)'
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:
@@ -582,6 +604,12 @@ spec:
                   ClientSecretSourceVersion identifies the spec.clientSecretRef source last pushed to
                   Pocket-ID. Pocket-ID stores the secret hashed and never returns it, so this is how the
                   operator detects that the referenced Secret changed and needs pushing again.
+                type: string
+              clientType:
+                description: |-
+                  ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
+                  The operator refuses to manage "cimd" clients, whose configuration is owned by
+                  their OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -608,8 +608,8 @@ spec:
               clientType:
                 description: |-
                   ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
-                  The operator refuses to manage "cimd" clients, whose configuration is owned by
-                  their OAuth Client ID Metadata Document.
+                  For a "cimd" client the operator manages only the fields Pocket-ID persists on an
+                  admin update; the rest are owned by its OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -142,6 +142,16 @@
                       "null"
                     ]
                   },
+                  "cimdUrlAllowlist": {
+                    "description": "CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata\nDocuments. Entries are callback-URL patterns (wildcards allowed). A non-empty list\nenables CIMD; leaving it empty keeps the feature off.\nThe operator automatically sets UI_CONFIG_DISABLED=true when this field is set.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
                   "containerSecurityContext": {
                     "additionalProperties": false,
                     "description": "Container security context",
@@ -4691,8 +4701,8 @@
                     ]
                   },
                   "clientID": {
-                    "description": "ClientID is the optional OIDC client ID to use instead of a generated one\nThe Client ID is immutable and cannot be changed once the oidc client is created",
-                    "maxLength": 128,
+                    "description": "ClientID is the optional OIDC client ID to use instead of a generated one.\nThe Client ID is immutable and cannot be changed once the oidc client is created.\nAn https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)\nclient, which the operator adopts but never creates and only partially manages.",
+                    "maxLength": 512,
                     "minLength": 2,
                     "type": [
                       "string",
@@ -5271,6 +5281,22 @@
                   {
                     "message": "clientSecretRotation cannot be enabled when clientSecretRef is set",
                     "rule": "!has(self.clientSecretRef) || !has(self.clientSecretRotation) || !self.clientSecretRotation.enabled"
+                  },
+                  {
+                    "message": "clientID must be at most 128 characters unless it is a client ID metadata document URL",
+                    "rule": "!has(self.clientID) || self.clientID.startsWith('https://') || self.clientID.size() <= 128"
+                  },
+                  {
+                    "message": "name, callbackUrls, logoutCallbackUrls, federatedIdentities, isPublic, and pkceEnabled are owned by the client ID metadata document and must not be set on a CIMD client",
+                    "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls) && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)"
+                  },
+                  {
+                    "message": "a CIMD client is always public and has no client secret, so clientSecretRef and clientSecretRotation are not supported",
+                    "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled))"
+                  },
+                  {
+                    "message": "clientPermissions require a confidential client, and a CIMD client is always public",
+                    "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions) || size(a.clientPermissions) == 0)"
                   }
                 ]
               }
@@ -5579,6 +5605,16 @@
                 "format": "int32",
                 "type": [
                   "integer",
+                  "null"
+                ]
+              },
+              "cimdUrlAllowlist": {
+                "description": "CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata\nDocuments. Entries are callback-URL patterns (wildcards allowed). A non-empty list\nenables CIMD; leaving it empty keeps the feature off.\nThe operator automatically sets UI_CONFIG_DISABLED=true when this field is set.",
+                "items": {
+                  "type": "string"
+                },
+                "type": [
+                  "array",
                   "null"
                 ]
               },

--- a/config/crd/bases/pocketid.internal_pocketidinstances.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidinstances.yaml
@@ -74,6 +74,15 @@ spec:
                 description: Audit log retention in days
                 format: int32
                 type: integer
+              cimdUrlAllowlist:
+                description: |-
+                  CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata
+                  Documents. Entries are callback-URL patterns (wildcards allowed). A non-empty list
+                  enables CIMD; leaving it empty keeps the feature off.
+                  The operator automatically sets UI_CONFIG_DISABLED=true when this field is set.
+                items:
+                  type: string
+                type: array
               containerSecurityContext:
                 description: Container security context
                 properties:

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -148,9 +148,11 @@ spec:
                 type: array
               clientID:
                 description: |-
-                  ClientID is the optional OIDC client ID to use instead of a generated one
-                  The Client ID is immutable and cannot be changed once the oidc client is created
-                maxLength: 128
+                  ClientID is the optional OIDC client ID to use instead of a generated one.
+                  The Client ID is immutable and cannot be changed once the oidc client is created.
+                  An https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)
+                  client, which the operator adopts but never creates and only partially manages.
+                maxLength: 512
                 minLength: 2
                 type: string
               clientSecretRef:
@@ -560,6 +562,26 @@ spec:
                 is set
               rule: '!has(self.clientSecretRef) || !has(self.clientSecretRotation)
                 || !self.clientSecretRotation.enabled'
+            - message: clientID must be at most 128 characters unless it is a client
+                ID metadata document URL
+              rule: '!has(self.clientID) || self.clientID.startsWith(''https://'')
+                || self.clientID.size() <= 128'
+            - message: name, callbackUrls, logoutCallbackUrls, federatedIdentities,
+                isPublic, and pkceEnabled are owned by the client ID metadata document
+                and must not be set on a CIMD client
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls)
+                && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)'
+            - message: a CIMD client is always public and has no client secret, so
+                clientSecretRef and clientSecretRotation are not supported
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation)
+                || !self.clientSecretRotation.enabled))'
+            - message: clientPermissions require a confidential client, and a CIMD
+                client is always public
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions)
+                || size(a.clientPermissions) == 0)'
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:
@@ -582,6 +604,12 @@ spec:
                   ClientSecretSourceVersion identifies the spec.clientSecretRef source last pushed to
                   Pocket-ID. Pocket-ID stores the secret hashed and never returns it, so this is how the
                   operator detects that the referenced Secret changed and needs pushing again.
+                type: string
+              clientType:
+                description: |-
+                  ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
+                  The operator refuses to manage "cimd" clients, whose configuration is owned by
+                  their OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -608,8 +608,8 @@ spec:
               clientType:
                 description: |-
                   ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
-                  The operator refuses to manage "cimd" clients, whose configuration is owned by
-                  their OAuth Client ID Metadata Document.
+                  For a "cimd" client the operator manages only the fields Pocket-ID persists on an
+                  admin update; the rest are owned by its OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -3810,8 +3810,8 @@ spec:
               clientType:
                 description: |-
                   ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
-                  The operator refuses to manage "cimd" clients, whose configuration is owned by
-                  their OAuth Client ID Metadata Document.
+                  For a "cimd" client the operator manages only the fields Pocket-ID persists on an
+                  admin update; the rest are owned by its OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -333,6 +333,15 @@ spec:
                 description: Audit log retention in days
                 format: int32
                 type: integer
+              cimdUrlAllowlist:
+                description: |-
+                  CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata
+                  Documents. Entries are callback-URL patterns (wildcards allowed). A non-empty list
+                  enables CIMD; leaving it empty keeps the feature off.
+                  The operator automatically sets UI_CONFIG_DISABLED=true when this field is set.
+                items:
+                  type: string
+                type: array
               containerSecurityContext:
                 description: Container security context
                 properties:
@@ -3341,9 +3350,11 @@ spec:
                 type: array
               clientID:
                 description: |-
-                  ClientID is the optional OIDC client ID to use instead of a generated one
-                  The Client ID is immutable and cannot be changed once the oidc client is created
-                maxLength: 128
+                  ClientID is the optional OIDC client ID to use instead of a generated one.
+                  The Client ID is immutable and cannot be changed once the oidc client is created.
+                  An https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)
+                  client, which the operator adopts but never creates and only partially manages.
+                maxLength: 512
                 minLength: 2
                 type: string
               clientSecretRef:
@@ -3753,6 +3764,26 @@ spec:
                 is set
               rule: '!has(self.clientSecretRef) || !has(self.clientSecretRotation)
                 || !self.clientSecretRotation.enabled'
+            - message: clientID must be at most 128 characters unless it is a client
+                ID metadata document URL
+              rule: '!has(self.clientID) || self.clientID.startsWith(''https://'')
+                || self.clientID.size() <= 128'
+            - message: name, callbackUrls, logoutCallbackUrls, federatedIdentities,
+                isPublic, and pkceEnabled are owned by the client ID metadata document
+                and must not be set on a CIMD client
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls)
+                && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)'
+            - message: a CIMD client is always public and has no client secret, so
+                clientSecretRef and clientSecretRotation are not supported
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation)
+                || !self.clientSecretRotation.enabled))'
+            - message: clientPermissions require a confidential client, and a CIMD
+                client is always public
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions)
+                || size(a.clientPermissions) == 0)'
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:
@@ -3775,6 +3806,12 @@ spec:
                   ClientSecretSourceVersion identifies the spec.clientSecretRef source last pushed to
                   Pocket-ID. Pocket-ID stores the secret hashed and never returns it, so this is how the
                   operator detects that the referenced Secret changed and needs pushing again.
+                type: string
+              clientType:
+                description: |-
+                  ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
+                  The operator refuses to manage "cimd" clients, whose configuration is owned by
+                  their OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3819,8 +3819,8 @@ spec:
               clientType:
                 description: |-
                   ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
-                  The operator refuses to manage "cimd" clients, whose configuration is owned by
-                  their OAuth Client ID Metadata Document.
+                  For a "cimd" client the operator manages only the fields Pocket-ID persists on an
+                  admin update; the rest are owned by its OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -342,6 +342,15 @@ spec:
                 description: Audit log retention in days
                 format: int32
                 type: integer
+              cimdUrlAllowlist:
+                description: |-
+                  CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata
+                  Documents. Entries are callback-URL patterns (wildcards allowed). A non-empty list
+                  enables CIMD; leaving it empty keeps the feature off.
+                  The operator automatically sets UI_CONFIG_DISABLED=true when this field is set.
+                items:
+                  type: string
+                type: array
               containerSecurityContext:
                 description: Container security context
                 properties:
@@ -3350,9 +3359,11 @@ spec:
                 type: array
               clientID:
                 description: |-
-                  ClientID is the optional OIDC client ID to use instead of a generated one
-                  The Client ID is immutable and cannot be changed once the oidc client is created
-                maxLength: 128
+                  ClientID is the optional OIDC client ID to use instead of a generated one.
+                  The Client ID is immutable and cannot be changed once the oidc client is created.
+                  An https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)
+                  client, which the operator adopts but never creates and only partially manages.
+                maxLength: 512
                 minLength: 2
                 type: string
               clientSecretRef:
@@ -3762,6 +3773,26 @@ spec:
                 is set
               rule: '!has(self.clientSecretRef) || !has(self.clientSecretRotation)
                 || !self.clientSecretRotation.enabled'
+            - message: clientID must be at most 128 characters unless it is a client
+                ID metadata document URL
+              rule: '!has(self.clientID) || self.clientID.startsWith(''https://'')
+                || self.clientID.size() <= 128'
+            - message: name, callbackUrls, logoutCallbackUrls, federatedIdentities,
+                isPublic, and pkceEnabled are owned by the client ID metadata document
+                and must not be set on a CIMD client
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls)
+                && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)'
+            - message: a CIMD client is always public and has no client secret, so
+                clientSecretRef and clientSecretRotation are not supported
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation)
+                || !self.clientSecretRotation.enabled))'
+            - message: clientPermissions require a confidential client, and a CIMD
+                client is always public
+              rule: '!(has(self.clientID) && self.clientID.startsWith(''https://''))
+                || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions)
+                || size(a.clientPermissions) == 0)'
           status:
             description: status defines the observed state of PocketIDOIDCClient
             properties:
@@ -3784,6 +3815,12 @@ spec:
                   ClientSecretSourceVersion identifies the spec.clientSecretRef source last pushed to
                   Pocket-ID. Pocket-ID stores the secret hashed and never returns it, so this is how the
                   operator detects that the referenced Secret changed and needs pushing again.
+                type: string
+              clientType:
+                description: |-
+                  ClientType is how the client was registered in Pocket-ID: "standard" or "cimd".
+                  The operator refuses to manage "cimd" clients, whose configuration is owned by
+                  their OAuth Client ID Metadata Document.
                 type: string
               conditions:
                 description: Conditions represent the current state of the PocketIDOIDCClient

--- a/dist/schemas/helmrelease_v2_pocket-id-instance.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-instance.json
@@ -1057,6 +1057,16 @@
                           "null"
                         ]
                       },
+                      "cimdUrlAllowlist": {
+                        "description": "CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata\nDocuments. Entries are callback-URL patterns (wildcards allowed). A non-empty list\nenables CIMD; leaving it empty keeps the feature off.\nThe operator automatically sets UI_CONFIG_DISABLED=true when this field is set.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
                       "containerSecurityContext": {
                         "additionalProperties": false,
                         "description": "Container security context",
@@ -5606,8 +5616,8 @@
                         ]
                       },
                       "clientID": {
-                        "description": "ClientID is the optional OIDC client ID to use instead of a generated one\nThe Client ID is immutable and cannot be changed once the oidc client is created",
-                        "maxLength": 128,
+                        "description": "ClientID is the optional OIDC client ID to use instead of a generated one.\nThe Client ID is immutable and cannot be changed once the oidc client is created.\nAn https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)\nclient, which the operator adopts but never creates and only partially manages.",
+                        "maxLength": 512,
                         "minLength": 2,
                         "type": [
                           "string",
@@ -6186,6 +6196,22 @@
                       {
                         "message": "clientSecretRotation cannot be enabled when clientSecretRef is set",
                         "rule": "!has(self.clientSecretRef) || !has(self.clientSecretRotation) || !self.clientSecretRotation.enabled"
+                      },
+                      {
+                        "message": "clientID must be at most 128 characters unless it is a client ID metadata document URL",
+                        "rule": "!has(self.clientID) || self.clientID.startsWith('https://') || self.clientID.size() <= 128"
+                      },
+                      {
+                        "message": "name, callbackUrls, logoutCallbackUrls, federatedIdentities, isPublic, and pkceEnabled are owned by the client ID metadata document and must not be set on a CIMD client",
+                        "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls) && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)"
+                      },
+                      {
+                        "message": "a CIMD client is always public and has no client secret, so clientSecretRef and clientSecretRotation are not supported",
+                        "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled))"
+                      },
+                      {
+                        "message": "clientPermissions require a confidential client, and a CIMD client is always public",
+                        "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions) || size(a.clientPermissions) == 0)"
                       }
                     ]
                   }

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -1063,6 +1063,16 @@
                               "null"
                             ]
                           },
+                          "cimdUrlAllowlist": {
+                            "description": "CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata\nDocuments. Entries are callback-URL patterns (wildcards allowed). A non-empty list\nenables CIMD; leaving it empty keeps the feature off.\nThe operator automatically sets UI_CONFIG_DISABLED=true when this field is set.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": [
+                              "array",
+                              "null"
+                            ]
+                          },
                           "containerSecurityContext": {
                             "additionalProperties": false,
                             "description": "Container security context",
@@ -5612,8 +5622,8 @@
                             ]
                           },
                           "clientID": {
-                            "description": "ClientID is the optional OIDC client ID to use instead of a generated one\nThe Client ID is immutable and cannot be changed once the oidc client is created",
-                            "maxLength": 128,
+                            "description": "ClientID is the optional OIDC client ID to use instead of a generated one.\nThe Client ID is immutable and cannot be changed once the oidc client is created.\nAn https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)\nclient, which the operator adopts but never creates and only partially manages.",
+                            "maxLength": 512,
                             "minLength": 2,
                             "type": [
                               "string",
@@ -6192,6 +6202,22 @@
                           {
                             "message": "clientSecretRotation cannot be enabled when clientSecretRef is set",
                             "rule": "!has(self.clientSecretRef) || !has(self.clientSecretRotation) || !self.clientSecretRotation.enabled"
+                          },
+                          {
+                            "message": "clientID must be at most 128 characters unless it is a client ID metadata document URL",
+                            "rule": "!has(self.clientID) || self.clientID.startsWith('https://') || self.clientID.size() <= 128"
+                          },
+                          {
+                            "message": "name, callbackUrls, logoutCallbackUrls, federatedIdentities, isPublic, and pkceEnabled are owned by the client ID metadata document and must not be set on a CIMD client",
+                            "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.name) && !has(self.callbackUrls) && !has(self.logoutCallbackUrls) && !has(self.federatedIdentities) && !self.isPublic && !self.pkceEnabled)"
+                          },
+                          {
+                            "message": "a CIMD client is always public and has no client secret, so clientSecretRef and clientSecretRotation are not supported",
+                            "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || (!has(self.clientSecretRef) && (!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled))"
+                          },
+                          {
+                            "message": "clientPermissions require a confidential client, and a CIMD client is always public",
+                            "rule": "!(has(self.clientID) && self.clientID.startsWith('https://')) || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions) || size(a.clientPermissions) == 0)"
                           }
                         ]
                       }
@@ -6500,6 +6526,16 @@
                         "format": "int32",
                         "type": [
                           "integer",
+                          "null"
+                        ]
+                      },
+                      "cimdUrlAllowlist": {
+                        "description": "CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata\nDocuments. Entries are callback-URL patterns (wildcards allowed). A non-empty list\nenables CIMD; leaving it empty keeps the feature off.\nThe operator automatically sets UI_CONFIG_DISABLED=true when this field is set.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": [
+                          "array",
                           "null"
                         ]
                       },

--- a/dist/schemas/pocketidinstance_v1alpha1.json
+++ b/dist/schemas/pocketidinstance_v1alpha1.json
@@ -81,6 +81,16 @@
             "null"
           ]
         },
+        "cimdUrlAllowlist": {
+          "description": "CIMDURLAllowlist restricts which https URLs may be used as OAuth Client ID Metadata\nDocuments. Entries are callback-URL patterns (wildcards allowed). A non-empty list\nenables CIMD; leaving it empty keeps the feature off.\nThe operator automatically sets UI_CONFIG_DISABLED=true when this field is set.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "containerSecurityContext": {
           "additionalProperties": false,
           "description": "Container security context",

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -165,8 +165,8 @@
           ]
         },
         "clientID": {
-          "description": "ClientID is the optional OIDC client ID to use instead of a generated one\nThe Client ID is immutable and cannot be changed once the oidc client is created",
-          "maxLength": 128,
+          "description": "ClientID is the optional OIDC client ID to use instead of a generated one.\nThe Client ID is immutable and cannot be changed once the oidc client is created.\nAn https:// URL marks the client as an OAuth Client ID Metadata Document (CIMD)\nclient, which the operator adopts but never creates and only partially manages.",
+          "maxLength": 512,
           "minLength": 2,
           "type": [
             "string",
@@ -745,6 +745,22 @@
         {
           "message": "clientSecretRotation cannot be enabled when clientSecretRef is set",
           "rule": "!has(self.clientSecretRef) || !has(self.clientSecretRotation) || !self.clientSecretRotation.enabled"
+        },
+        {
+          "message": "clientID must be at most 128 characters unless it is a client ID metadata document URL",
+          "rule": "!has(self.clientID) || self.clientID.startsWith('https://') || self.clientID.size() \u003c= 128"
+        },
+        {
+          "message": "name, callbackUrls, logoutCallbackUrls, federatedIdentities, isPublic, and pkceEnabled are owned by the client ID metadata document and must not be set on a CIMD client",
+          "rule": "!(has(self.clientID) \u0026\u0026 self.clientID.startsWith('https://')) || (!has(self.name) \u0026\u0026 !has(self.callbackUrls) \u0026\u0026 !has(self.logoutCallbackUrls) \u0026\u0026 !has(self.federatedIdentities) \u0026\u0026 !self.isPublic \u0026\u0026 !self.pkceEnabled)"
+        },
+        {
+          "message": "a CIMD client is always public and has no client secret, so clientSecretRef and clientSecretRotation are not supported",
+          "rule": "!(has(self.clientID) \u0026\u0026 self.clientID.startsWith('https://')) || (!has(self.clientSecretRef) \u0026\u0026 (!has(self.clientSecretRotation) || !self.clientSecretRotation.enabled))"
+        },
+        {
+          "message": "clientPermissions require a confidential client, and a CIMD client is always public",
+          "rule": "!(has(self.clientID) \u0026\u0026 self.clientID.startsWith('https://')) || !has(self.apiAccess) || self.apiAccess.all(a, !has(a.clientPermissions) || size(a.clientPermissions) == 0)"
         }
       ]
     },
@@ -781,6 +797,13 @@
         },
         "clientSecretSourceVersion": {
           "description": "ClientSecretSourceVersion identifies the spec.clientSecretRef source last pushed to\nPocket-ID. Pocket-ID stores the secret hashed and never returns it, so this is how the\noperator detects that the referenced Secret changed and needs pushing again.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "clientType": {
+          "description": "ClientType is how the client was registered in Pocket-ID: \"standard\" or \"cimd\".\nThe operator refuses to manage \"cimd\" clients, whose configuration is owned by\ntheir OAuth Client ID Metadata Document.",
           "type": [
             "string",
             "null"

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -803,7 +803,7 @@
           ]
         },
         "clientType": {
-          "description": "ClientType is how the client was registered in Pocket-ID: \"standard\" or \"cimd\".\nThe operator refuses to manage \"cimd\" clients, whose configuration is owned by\ntheir OAuth Client ID Metadata Document.",
+          "description": "ClientType is how the client was registered in Pocket-ID: \"standard\" or \"cimd\".\nFor a \"cimd\" client the operator manages only the fields Pocket-ID persists on an\nadmin update; the rest are owned by its OAuth Client ID Metadata Document.",
           "type": [
             "string",
             "null"

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -14,6 +14,11 @@ The operator recognizes the following annotations.
   regenerates the client secret and then removes the annotation. It is ignored (but still
   removed, and the reason logged) when `spec.clientSecretRef` is set or
   `spec.secret.storeClientSecret` is `false`.
+- `pocketid.internal/refresh-client-metadata`: when set to `"true"`, the operator forces
+  the adopted client to re-fetch its OAuth Client ID Metadata Document, bypassing the
+  cache TTL. The annotation is removed before the call, so a rejected refresh (a
+  `standard` client, or CIMD not enabled on the instance) fires once and surfaces on the
+  `Ready` condition rather than retrying forever.
 
 ## Labels
 

--- a/docs/pocketidinstance.md
+++ b/docs/pocketidinstance.md
@@ -176,7 +176,7 @@ spec:
 
 ## UI Configuration
 
-The operator automatically sets `UI_CONFIG_DISABLED=true` when any of the `ui`, `userManagement`, `smtp`, `emailNotifications`, or `ldap` sections are configured.
+The operator automatically sets `UI_CONFIG_DISABLED=true` when any of the `ui`, `userManagement`, `smtp`, `emailNotifications`, or `ldap` sections, or `cimdUrlAllowlist`, are configured.
 
 ```yaml
 spec:
@@ -187,6 +187,24 @@ spec:
     disableAnimations: false
     accentColor: "#3b82f6"                   # any valid CSS color
 ```
+
+## Client ID Metadata Documents
+
+`cimdUrlAllowlist` restricts which `https` URLs may be used as OAuth Client ID Metadata
+Documents, letting clients self-register by publishing metadata instead of being
+provisioned ahead of time. Entries are callback-URL patterns, so wildcards are allowed. The
+operator JSON-encodes the list into `CIMD_URL_ALLOWLIST`; leaving it empty keeps CIMD off
+and `client_id_metadata_document_supported` false in the discovery document.
+
+```yaml
+spec:
+  cimdUrlAllowlist:
+    - "https://apps.example.com/*/client-metadata.json"
+```
+
+Removing a URL from this list is how you revoke a self-registered app's access. To manage
+an individual CIMD client's policy from the cluster, see
+[pocketidoidcclient.md](pocketidoidcclient.md#client-id-metadata-documents).
 
 ## User Management
 
@@ -591,7 +609,7 @@ spec:
   - `ENCRYPTION_KEY` (from `spec.encryptionKey`)
   - `STATIC_API_KEY` (secret reference)
 - Conditionally set from spec fields:
-  - `UI_CONFIG_DISABLED=true` (when `spec.ui`, `spec.userManagement`, `spec.smtp`, `spec.emailNotifications`, or `spec.ldap` is configured)
+  - `UI_CONFIG_DISABLED=true` (when `spec.ui`, `spec.userManagement`, `spec.smtp`, `spec.emailNotifications`, `spec.ldap`, or `spec.cimdUrlAllowlist` is configured)
   - `DB_CONNECTION_STRING` (from `spec.databaseUrl`)
   - `APP_URL` (from `spec.appUrl`)
   - `INTERNAL_APP_URL` (from `spec.internalAppUrl`)
@@ -605,6 +623,7 @@ spec:
   - `OTEL_METRICS_EXPORTER=prometheus` + `OTEL_*` (from `spec.metrics`)
   - `APP_NAME`, `SESSION_DURATION`, `HOME_PAGE_URL`, `DISABLE_ANIMATIONS`, `ACCENT_COLOR` (from `spec.ui`)
   - `EMAILS_VERIFIED`, `ALLOW_OWN_ACCOUNT_EDIT`, `ALLOW_USER_SIGNUPS`, `SIGNUP_DEFAULT_*` (from `spec.userManagement`)
+  - `CIMD_URL_ALLOWLIST` (JSON-encoded from `spec.cimdUrlAllowlist`)
   - `MAXMIND_LICENSE_KEY`, `GEOLITE_DB_PATH`, `GEOLITE_DB_URL` (from `spec.geoip`)
   - `TZ` (from `spec.timezone`)
   - `LOCAL_IPV6_RANGES` (from `spec.localIPv6Ranges`)

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -195,6 +195,53 @@ spec:
     - "https://app.example.com/logout"
 ```
 
+## Client ID Metadata Documents
+
+A `cimd` client is synthesized by Pocket-ID from an OAuth Client ID Metadata Document that
+the app publishes at an https URL, rather than being provisioned ahead of time. Enable the
+feature with [`spec.cimdUrlAllowlist`](pocketidinstance.md#client-id-metadata-documents) on
+the instance. `status.clientType` reports `standard` or `cimd`.
+
+Set `spec.clientID` to the metadata document URL to manage one via the operator.
+
+```yaml
+spec:
+  clientID: "https://apps.example.com/myapp/client-metadata.json"
+
+  description: "Self-registered via metadata document"
+  launchUrl: "https://apps.example.com/myapp"
+  skipConsent: false
+  requiresReauthentication: true
+  accessTokenDurationMinutes: 15
+  refreshTokenDurationMinutes: 1440
+  allowedUserGroups:
+    - name: platform-engineers
+```
+
+### What the operator manages
+
+Only the fields Pocket-ID persists for a `cimd` client: `description`, `launchUrl`,
+`skipConsent`, `requiresReauthentication`, `requiresPushedAuthorizationRequests`,
+`accessTokenDurationMinutes`, `refreshTokenDurationMinutes`, `allowedUserGroups`, and
+logos.
+
+Everything else is owned by the metadata document and rejected at admission. They
+still appear in `status` as observed values.
+
+### Lifecycle
+
+The operator adopts a `cimd` client but never creates one — Pocket-ID materializes the
+record when the app first authorizes. Until that happens the resource stays `Ready=False`
+with reason `AwaitingFirstAuthorization`. Adoption requires an explicit `spec.clientID`.
+
+> **Deleting the resource does not revoke access.** The app's url is still allowlisted on the
+> instance, so it re-materializes on its next authorization.
+> To revoke access, remove its URL from `spec.cimdUrlAllowlist` on the instance.
+
+To force a re-fetch of the metadata document ahead of the cache TTL, set the
+`pocketid.internal/refresh-client-metadata` annotation (see
+[annotations.md](annotations.md)).
+
 ## Token Lifetimes
 
 `spec.accessTokenDurationMinutes` and `spec.refreshTokenDurationMinutes` set how long

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -220,13 +220,24 @@ spec:
 
 ### What the operator manages
 
-Only the fields Pocket-ID persists for a `cimd` client: `description`, `launchUrl`,
-`skipConsent`, `requiresReauthentication`, `requiresPushedAuthorizationRequests`,
-`accessTokenDurationMinutes`, `refreshTokenDurationMinutes`, `allowedUserGroups`, and
-logos.
+The fields Pocket-ID persists on an admin update of a `cimd` client: `description`,
+`launchUrl`, `skipConsent`, `requiresReauthentication`,
+`requiresPushedAuthorizationRequests`, `accessTokenDurationMinutes`, and
+`refreshTokenDurationMinutes`.
 
-Everything else is owned by the metadata document and rejected at admission. They
-still appear in `status` as observed values.
+The parts of the client that live outside that update are managed as usual, because
+Pocket-ID applies them to any client type: `allowedUserGroups`, `logo`, `scim`, the
+`apiAccess` delegated permissions, and the generated Kubernetes `secret`.
+
+Note that an auto-generated logo is resolved from `metadata.name`, not from the document's
+`client_name`. Set `logo.nameOverride` or disable `logo.autoGenerate` if that is wrong for
+the app.
+
+`name`, `callbackUrls`, `logoutCallbackUrls`, `isPublic`, `pkceEnabled`,
+`federatedIdentities`, `clientSecretRef`, `clientSecretRotation`, and the `apiAccess`
+client permissions are owned by the metadata document or unsupported for a public client,
+and are rejected at admission. The document-owned ones still appear in `status` as observed
+values.
 
 ### Lifecycle
 
@@ -234,9 +245,14 @@ The operator adopts a `cimd` client but never creates one — Pocket-ID material
 record when the app first authorizes. Until that happens the resource stays `Ready=False`
 with reason `AwaitingFirstAuthorization`. Adoption requires an explicit `spec.clientID`.
 
-> **Deleting the resource does not revoke access.** The app's url is still allowlisted on the
-> instance, so it re-materializes on its next authorization.
-> To revoke access, remove its URL from `spec.cimdUrlAllowlist` on the instance.
+Deleting the resource deletes the client from Pocket-ID, exactly as it does for a standard
+client.
+
+> **Deleting the resource does not revoke access.** The app's URL is still allowlisted on
+> the instance, so it re-materializes from its metadata document on the next authorization.
+> What the delete does remove is local state: every user's existing consent for the app,
+> along with the settings below. To revoke access, remove its URL from
+> `spec.cimdUrlAllowlist` on the instance.
 
 To force a re-fetch of the metadata document ahead of the cache TTL, set the
 `pocketid.internal/refresh-client-metadata` annotation (see

--- a/internal/controller/instance/env.go
+++ b/internal/controller/instance/env.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -58,6 +59,7 @@ func buildEnvVars(instance *pocketidinternalv1alpha1.PocketIDInstance) []corev1.
 	env = append(env, buildTracingEnv(instance)...)
 	env = append(env, buildUIEnv(instance)...)
 	env = append(env, buildUserManagementEnv(instance)...)
+	env = append(env, buildOIDCEnv(instance)...)
 	env = append(env, buildGeoIPEnv(instance)...)
 	env = append(env, buildStandaloneEnv(instance)...)
 
@@ -115,7 +117,8 @@ func needsUIConfigDisabled(instance *pocketidinternalv1alpha1.PocketIDInstance) 
 		instance.Spec.UserManagement != nil ||
 		instance.Spec.SMTP != nil ||
 		instance.Spec.EmailNotifications != nil ||
-		instance.Spec.LDAP != nil
+		instance.Spec.LDAP != nil ||
+		len(instance.Spec.CIMDURLAllowlist) > 0
 }
 
 func buildMetricsEnv(instance *pocketidinternalv1alpha1.PocketIDInstance) []corev1.EnvVar {
@@ -361,6 +364,17 @@ func buildUserManagementEnv(instance *pocketidinternalv1alpha1.PocketIDInstance)
 		env = append(env, corev1.EnvVar{Name: "SIGNUP_DEFAULT_USER_GROUP_IDS", Value: strings.Join(um.SignupDefaultUserGroupIDs, ",")})
 	}
 	return env
+}
+
+// buildOIDCEnv emits the OAuth Client ID Metadata Document allowlist. Pocket-ID reads
+// CIMD_URL_ALLOWLIST as a JSON-encoded array of strings.
+func buildOIDCEnv(instance *pocketidinternalv1alpha1.PocketIDInstance) []corev1.EnvVar {
+	if len(instance.Spec.CIMDURLAllowlist) == 0 {
+		return nil
+	}
+	// Marshalling a []string cannot fail.
+	allowlist, _ := json.Marshal(instance.Spec.CIMDURLAllowlist)
+	return []corev1.EnvVar{{Name: "CIMD_URL_ALLOWLIST", Value: string(allowlist)}}
 }
 
 func buildGeoIPEnv(instance *pocketidinternalv1alpha1.PocketIDInstance) []corev1.EnvVar {

--- a/internal/controller/instance/env_test.go
+++ b/internal/controller/instance/env_test.go
@@ -206,6 +206,32 @@ func TestBuildEnvVars_UIConfigDisabledWhenLDAPSet(t *testing.T) {
 	requireEnv(t, buildEnvVars(inst), "UI_CONFIG_DISABLED", "true")
 }
 
+func TestBuildEnvVars_UIConfigDisabledWhenCIMDAllowlistSet(t *testing.T) {
+	inst := minimalInstance()
+	inst.Spec.CIMDURLAllowlist = []string{"https://apps.example.com/*/client-metadata.json"}
+	requireEnv(t, buildEnvVars(inst), "UI_CONFIG_DISABLED", "true")
+}
+
+func TestBuildEnvVars_CIMDURLAllowlist(t *testing.T) {
+	inst := minimalInstance()
+	inst.Spec.CIMDURLAllowlist = []string{
+		"https://apps.example.com/*/client-metadata.json",
+		`https://quo"ted.example.com/meta.json`,
+	}
+
+	requireEnv(t, buildEnvVars(inst), "CIMD_URL_ALLOWLIST",
+		`["https://apps.example.com/*/client-metadata.json","https://quo\"ted.example.com/meta.json"]`)
+}
+
+func TestBuildEnvVars_CIMDURLAllowlistAbsentWhenEmpty(t *testing.T) {
+	inst := minimalInstance()
+	inst.Spec.CIMDURLAllowlist = []string{}
+
+	env := buildEnvVars(inst)
+	requireEnvAbsent(t, env, "CIMD_URL_ALLOWLIST")
+	requireEnvAbsent(t, env, "UI_CONFIG_DISABLED")
+}
+
 func TestBuildEnvVars_DatabaseUrl(t *testing.T) {
 	inst := minimalInstance()
 	inst.Spec.DatabaseUrl = &pocketidinternalv1alpha1.SensitiveValue{Value: "postgres://localhost/pocket-id"}

--- a/internal/controller/oidcclient/cimd_test.go
+++ b/internal/controller/oidcclient/cimd_test.go
@@ -1,0 +1,306 @@
+package oidcclient
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
+)
+
+// fakeRefreshAPI records RefreshOIDCClientMetadata calls. The embedded interface leaves every
+// other method nil, so an unexpected call panics rather than silently passing.
+type fakeRefreshAPI struct {
+	PocketIDOIDCClientAPI
+	calls []string
+	err   error
+}
+
+func (f *fakeRefreshAPI) RefreshOIDCClientMetadata(_ context.Context, id string) (*pocketid.OIDCClient, error) {
+	f.calls = append(f.calls, id)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &pocketid.OIDCClient{ID: id, ClientType: pocketid.ClientTypeCIMD}, nil
+}
+
+func cimdClient(annotations map[string]string) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+	return &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-client",
+			Namespace:   testNamespace,
+			Annotations: annotations,
+		},
+	}
+}
+
+// annotationOf re-reads the object so the assertion covers the persisted state, not just the
+// in-memory copy the helper mutated.
+func annotationOf(t *testing.T, r *Reconciler, obj client.Object, key string) (string, bool) {
+	t.Helper()
+	fresh := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(obj), fresh); err != nil {
+		t.Fatalf("get client: %v", err)
+	}
+	v, ok := fresh.Annotations[key]
+	return v, ok
+}
+
+func TestRefreshClientMetadata_NoAnnotationIsNoOp(t *testing.T) {
+	oidcClient := cimdClient(nil)
+	oidcClient.Status.ClientID = "https://apps.example.com/meta.json"
+	r := declaredSecretReconciler(t, oidcClient)
+	api := &fakeRefreshAPI{}
+
+	if err := r.refreshClientMetadata(context.Background(), oidcClient, api); err != nil {
+		t.Fatalf("refreshClientMetadata returned error: %v", err)
+	}
+	if len(api.calls) != 0 {
+		t.Fatalf("expected no refresh call, got %v", api.calls)
+	}
+}
+
+func TestRefreshClientMetadata_NonTrueAnnotationIsNoOp(t *testing.T) {
+	oidcClient := cimdClient(map[string]string{refreshClientMetadataAnnotation: "false"})
+	oidcClient.Status.ClientID = "https://apps.example.com/meta.json"
+	r := declaredSecretReconciler(t, oidcClient)
+	api := &fakeRefreshAPI{}
+
+	if err := r.refreshClientMetadata(context.Background(), oidcClient, api); err != nil {
+		t.Fatalf("refreshClientMetadata returned error: %v", err)
+	}
+	if len(api.calls) != 0 {
+		t.Fatalf("expected no refresh call, got %v", api.calls)
+	}
+	if _, ok := annotationOf(t, r, oidcClient, refreshClientMetadataAnnotation); !ok {
+		t.Error("expected a non-\"true\" annotation to be left in place")
+	}
+}
+
+func TestRefreshClientMetadata_UsesStatusClientID(t *testing.T) {
+	oidcClient := cimdClient(map[string]string{refreshClientMetadataAnnotation: "true"})
+	oidcClient.Status.ClientID = "https://apps.example.com/adopted.json"
+	oidcClient.Spec.ClientID = "https://apps.example.com/spec.json"
+	r := declaredSecretReconciler(t, oidcClient)
+	api := &fakeRefreshAPI{}
+
+	if err := r.refreshClientMetadata(context.Background(), oidcClient, api); err != nil {
+		t.Fatalf("refreshClientMetadata returned error: %v", err)
+	}
+	if len(api.calls) != 1 || api.calls[0] != "https://apps.example.com/adopted.json" {
+		t.Fatalf("expected one refresh of the status client ID, got %v", api.calls)
+	}
+	if _, ok := annotationOf(t, r, oidcClient, refreshClientMetadataAnnotation); ok {
+		t.Error("expected the annotation to be removed")
+	}
+}
+
+// spec.clientID is deliberately not a fallback: refreshing a client the operator has not
+// adopted would act on something outside its management.
+func TestRefreshClientMetadata_NotAdoptedErrors(t *testing.T) {
+	oidcClient := cimdClient(map[string]string{refreshClientMetadataAnnotation: "true"})
+	r := declaredSecretReconciler(t, oidcClient)
+	api := &fakeRefreshAPI{}
+
+	oidcClient.Spec.ClientID = "https://apps.example.com/spec.json"
+
+	if err := r.refreshClientMetadata(context.Background(), oidcClient, api); err == nil {
+		t.Fatal("expected an error when the client has not been adopted")
+	}
+	if len(api.calls) != 0 {
+		t.Fatalf("expected no refresh call, got %v", api.calls)
+	}
+}
+
+// The annotation must be cleared even when the refresh is rejected, so a standard client or a
+// CIMD-disabled instance does not re-trigger the call on every resync.
+func TestRefreshClientMetadata_FailureStillClearsAnnotation(t *testing.T) {
+	oidcClient := cimdClient(map[string]string{refreshClientMetadataAnnotation: "true"})
+	oidcClient.Status.ClientID = "grafana-id"
+	r := declaredSecretReconciler(t, oidcClient)
+	api := &fakeRefreshAPI{err: errors.New("client ID metadata documents are not enabled")}
+
+	if err := r.refreshClientMetadata(context.Background(), oidcClient, api); err == nil {
+		t.Fatal("expected the refresh error to be returned")
+	}
+	if _, ok := annotationOf(t, r, oidcClient, refreshClientMetadataAnnotation); ok {
+		t.Error("expected the annotation to be removed despite the failure")
+	}
+}
+
+// The whole point of managing CIMD clients: a spec that disagrees with the metadata
+// document on metadata-owned fields must produce no diff, or the operator would push,
+// read back the discarded values, and push again on every reconcile.
+func TestPreserveMetadataOwnedFields_NoDiffAgainstMetadataOwnedValues(t *testing.T) {
+	current := &pocketid.OIDCClient{
+		ID:                 "https://apps.example.com/meta.json",
+		Name:               "My App",
+		CallbackURLs:       []string{"https://apps.example.com/cb"},
+		LogoutCallbackURLs: []string{"https://apps.example.com/logout"},
+		IsPublic:           true,
+		PKCEEnabled:        true,
+		ClientType:         pocketid.ClientTypeCIMD,
+	}
+
+	// What the operator would build from a CR that leaves every metadata-owned field at
+	// its CRD default: a name from metadata.name, no callbacks, isPublic/pkceEnabled false.
+	desired := pocketid.OIDCClientInput{
+		Name:        "metadata-app",
+		Credentials: &pocketid.OIDCClientCredentials{},
+	}
+
+	if desired.Equal(current.ToInput()) {
+		t.Fatal("test is vacuous: the inputs already matched before preserving")
+	}
+
+	preserveMetadataOwnedFields(&desired, current)
+
+	if !desired.Equal(current.ToInput()) {
+		t.Errorf("expected no diff after preserving metadata-owned fields\n desired=%+v\n current=%+v", desired, current.ToInput())
+	}
+	if desired.Credentials != nil {
+		t.Error("expected federated credentials to be dropped for a CIMD client")
+	}
+}
+
+// The writable columns must still drive an update, otherwise adoption would be pointless.
+func TestPreserveMetadataOwnedFields_KeepsWritableFields(t *testing.T) {
+	current := &pocketid.OIDCClient{
+		ID:                         "https://apps.example.com/meta.json",
+		Name:                       "My App",
+		ClientType:                 pocketid.ClientTypeCIMD,
+		SkipConsent:                false,
+		AccessTokenDurationMinutes: 60,
+		IsGroupRestricted:          false,
+	}
+	desired := pocketid.OIDCClientInput{
+		Name:                       "metadata-app",
+		SkipConsent:                true,
+		AccessTokenDurationMinutes: 15,
+		IsGroupRestricted:          true,
+	}
+
+	preserveMetadataOwnedFields(&desired, current)
+
+	if desired.Equal(current.ToInput()) {
+		t.Fatal("expected the writable fields to still register as a change")
+	}
+	if !desired.SkipConsent || desired.AccessTokenDurationMinutes != 15 || !desired.IsGroupRestricted {
+		t.Errorf("writable fields were overwritten: %+v", desired)
+	}
+}
+
+// A CIMD client's metadata document must declare token_endpoint_auth_method "none", so it
+// is always public and the operator must never try to mint or rotate a secret for it.
+func TestIsPublicClient_TreatsCIMDAsPublic(t *testing.T) {
+	oidcClient := cimdClient(nil)
+	if isPublicClient(oidcClient) {
+		t.Error("a standard confidential client should not be treated as public")
+	}
+
+	oidcClient.Status.ClientType = pocketid.ClientTypeCIMD
+	if !isPublicClient(oidcClient) {
+		t.Error("a CIMD client must be treated as public regardless of spec.isPublic")
+	}
+}
+
+func TestReconcileErrorReason_ClassifiesAwaitingCIMD(t *testing.T) {
+	if got := reconcileErrorReason(fmt.Errorf("adopt: %w", errAwaitingCIMD)); got != "AwaitingFirstAuthorization" {
+		t.Errorf("reason: got %q, want %q", got, "AwaitingFirstAuthorization")
+	}
+	if got := reconcileErrorReason(errors.New("boom")); got != "ReconcileError" {
+		t.Errorf("reason: got %q, want %q", got, "ReconcileError")
+	}
+}
+
+// The CIMD row only exists after the app's first authorization, so a missing client is a
+// waiting state. Falling through to CreateOrAdopt would register a standard client under
+// the document URL instead. This also exercises the "~<base64url>" path encoding, since
+// the stub only answers the encoded route.
+func TestCreateOrAdoptOIDCClient_CIMD(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	const metadataURL = "https://apps.example.com/myapp/client-metadata.json"
+	encodedPath := "/api/oidc/clients/~" + base64.RawURLEncoding.EncodeToString([]byte(metadataURL))
+
+	for _, tc := range []struct {
+		name           string
+		materialized   bool
+		wantAwaiting   bool
+		wantStatusETag string
+	}{
+		{name: "not yet materialized", materialized: false, wantAwaiting: true},
+		{name: "materialized", materialized: true, wantStatusETag: metadataURL},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var createAttempted bool
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method == http.MethodPost && req.URL.Path == "/api/oidc/clients" {
+					createAttempted = true
+					http.Error(w, "must not create", http.StatusBadRequest)
+					return
+				}
+				if req.Method == http.MethodGet && req.URL.Path == encodedPath {
+					if !tc.materialized {
+						http.NotFound(w, req)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"id":"` + metadataURL + `","name":"My App","clientType":"cimd","allowedUserGroups":[]}`))
+					return
+				}
+				http.NotFound(w, req)
+			}))
+			defer ts.Close()
+
+			oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "metadata-app", Namespace: testNamespace},
+				Spec:       pocketidinternalv1alpha1.PocketIDOIDCClientSpec{ClientID: metadataURL},
+			}
+			r := newPushStateOIDCReconciler(scheme, oidcClient)
+			apiClient, _ := pocketid.NewClient(ts.URL, "")
+
+			_, err := r.createOrAdoptOIDCClient(ctx, oidcClient, apiClient)
+
+			if createAttempted {
+				t.Error("the operator must never create a CIMD client")
+			}
+			if tc.wantAwaiting {
+				if !errors.Is(err, errAwaitingCIMD) {
+					t.Fatalf("expected errAwaitingCIMD, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("createOrAdoptOIDCClient returned error: %v", err)
+			}
+			if oidcClient.Status.ClientID != tc.wantStatusETag {
+				t.Errorf("status.clientID: got %q, want %q", oidcClient.Status.ClientID, tc.wantStatusETag)
+			}
+		})
+	}
+}
+
+func TestUpdateOIDCClientStatus_RecordsClientType(t *testing.T) {
+	oidcClient := cimdClient(nil)
+	r := declaredSecretReconciler(t, oidcClient)
+
+	current := &pocketid.OIDCClient{ID: "grafana-id", Name: "grafana", ClientType: "standard"}
+	if err := r.UpdateOIDCClientStatus(context.Background(), oidcClient, current); err != nil {
+		t.Fatalf("UpdateOIDCClientStatus returned error: %v", err)
+	}
+	if oidcClient.Status.ClientType != "standard" {
+		t.Errorf("status.clientType: got %q, want %q", oidcClient.Status.ClientType, "standard")
+	}
+}

--- a/internal/controller/oidcclient/cimd_test.go
+++ b/internal/controller/oidcclient/cimd_test.go
@@ -28,12 +28,9 @@ type fakeRefreshAPI struct {
 	err   error
 }
 
-func (f *fakeRefreshAPI) RefreshOIDCClientMetadata(_ context.Context, id string) (*pocketid.OIDCClient, error) {
+func (f *fakeRefreshAPI) RefreshOIDCClientMetadata(_ context.Context, id string) error {
 	f.calls = append(f.calls, id)
-	if f.err != nil {
-		return nil, f.err
-	}
-	return &pocketid.OIDCClient{ID: id, ClientType: pocketid.ClientTypeCIMD}, nil
+	return f.err
 }
 
 func cimdClient(annotations map[string]string) *pocketidinternalv1alpha1.PocketIDOIDCClient {
@@ -218,9 +215,9 @@ func cimdCurrent() *pocketid.OIDCClient {
 	}
 }
 
-func cimdClientCR(name string, mutate func(*pocketidinternalv1alpha1.PocketIDOIDCClient)) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+func cimdClientCR(mutate func(*pocketidinternalv1alpha1.PocketIDOIDCClient)) *pocketidinternalv1alpha1.PocketIDOIDCClient {
 	cr := &pocketidinternalv1alpha1.PocketIDOIDCClient{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "metadata-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			ClientID:                    "https://apps.example.com/meta.json",
 			AccessTokenDurationMinutes:  60,
@@ -246,7 +243,7 @@ func TestPushOIDCClientState_CIMDDoesNotDrift(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
 
-	cr := cimdClientCR("metadata-app", nil)
+	cr := cimdClientCR(nil)
 	r := newPushStateOIDCReconciler(scheme, cr)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -273,7 +270,7 @@ func TestPushOIDCClientState_CIMDPushesWritableFields(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
 
-	cr := cimdClientCR("metadata-app", func(c *pocketidinternalv1alpha1.PocketIDOIDCClient) {
+	cr := cimdClientCR(func(c *pocketidinternalv1alpha1.PocketIDOIDCClient) {
 		c.Spec.SkipConsent = true
 		c.Spec.AccessTokenDurationMinutes = 15
 		c.Status.Conditions = readyCondition()
@@ -334,7 +331,7 @@ func TestIsPublicClient_TreatsCIMDAsPublic(t *testing.T) {
 // would take the mint path and try to regenerate a secret on adoption. A nil apiClient
 // makes any such call fail loudly instead of passing silently.
 func TestReconcileSecret_CIMDClientSkipsSecretMinting(t *testing.T) {
-	oidcClient := cimdClientCR("metadata-app", nil)
+	oidcClient := cimdClientCR(nil)
 	instance := &pocketidinternalv1alpha1.PocketIDInstance{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-instance", Namespace: testNamespace},
 	}
@@ -446,5 +443,71 @@ func TestUpdateOIDCClientStatus_RecordsClientType(t *testing.T) {
 	}
 	if oidcClient.Status.ClientType != "standard" {
 		t.Errorf("status.clientType: got %q, want %q", oidcClient.Status.ClientType, "standard")
+	}
+}
+
+// A CIMD client is deleted like any other. Pocket-ID has no garbage collection for them —
+// removing a URL from the allowlist only stops it resolving, and the row keeps appearing in
+// the admin client list — so skipping the delete would strand a record nothing owns. The
+// encoded path also has to survive the delete, since the ID is the document URL.
+func TestReconcileDelete_DeletesCIMDClient(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	wantPath := "/api/oidc/clients/~" + base64.RawURLEncoding.EncodeToString(
+		[]byte("https://apps.example.com/meta.json"))
+	var deleted bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodDelete || req.URL.EscapedPath() != wantPath {
+			t.Errorf("unexpected %s %s, want DELETE %s", req.Method, req.URL.EscapedPath(), wantPath)
+			http.NotFound(w, req)
+			return
+		}
+		deleted = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	instance := &pocketidinternalv1alpha1.PocketIDInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "external-instance", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+			External: &pocketidinternalv1alpha1.ExternalInstanceConfig{
+				URL: ts.URL,
+				APIKeySecretRef: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "external-api-key"},
+					Key:                  "token",
+				},
+			},
+		},
+	}
+	apiKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "external-api-key", Namespace: testNamespace},
+		Data:       map[string][]byte{"token": []byte("a-token")},
+	}
+	resource := cimdClientCR(func(c *pocketidinternalv1alpha1.PocketIDOIDCClient) {
+		c.Finalizers = []string{oidcClientFinalizer}
+	})
+
+	r := newPushStateOIDCReconciler(scheme, instance, apiKeySecret, resource)
+	r.BaseReconciler.APIReader = r.Client
+
+	if _, err := r.ReconcileDelete(ctx, resource); err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+
+	if !deleted {
+		t.Error("expected the CIMD client to be deleted from Pocket-ID")
+	}
+
+	updated := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(resource), updated); err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	for _, f := range updated.Finalizers {
+		if f == oidcClientFinalizer {
+			t.Error("expected the finalizer to be removed after deleting the client")
+		}
 	}
 }

--- a/internal/controller/oidcclient/cimd_test.go
+++ b/internal/controller/oidcclient/cimd_test.go
@@ -3,14 +3,17 @@ package oidcclient
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
@@ -199,6 +202,119 @@ func TestPreserveMetadataOwnedFields_KeepsWritableFields(t *testing.T) {
 	}
 }
 
+// cimdCurrent is a CIMD client as Pocket-ID reports it: the metadata document owns the
+// name, callbacks, and public/PKCE flags, all of which disagree with what a CR produces.
+func cimdCurrent() *pocketid.OIDCClient {
+	return &pocketid.OIDCClient{
+		ID:                          "https://apps.example.com/meta.json",
+		Name:                        "My App",
+		CallbackURLs:                []string{"https://apps.example.com/cb"},
+		LogoutCallbackURLs:          []string{"https://apps.example.com/logout"},
+		IsPublic:                    true,
+		PKCEEnabled:                 true,
+		ClientType:                  pocketid.ClientTypeCIMD,
+		AccessTokenDurationMinutes:  60,
+		RefreshTokenDurationMinutes: 43200,
+	}
+}
+
+func cimdClientCR(name string, mutate func(*pocketidinternalv1alpha1.PocketIDOIDCClient)) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+	cr := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			ClientID:                    "https://apps.example.com/meta.json",
+			AccessTokenDurationMinutes:  60,
+			RefreshTokenDurationMinutes: 43200,
+		},
+		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
+			ClientID:   "https://apps.example.com/meta.json",
+			ClientType: pocketid.ClientTypeCIMD,
+		},
+	}
+	if mutate != nil {
+		mutate(cr)
+	}
+	return cr
+}
+
+// The drift loop this design exists to prevent, asserted through the real reconcile path
+// rather than the helper in isolation. This is deliberately the *first* reconcile (no Ready
+// condition), which is when the operator would otherwise also push a credentials clear — so
+// it covers both the metadata-owned diff and the CIMD credential skip.
+func TestPushOIDCClientState_CIMDDoesNotDrift(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	cr := cimdClientCR("metadata-app", nil)
+	r := newPushStateOIDCReconciler(scheme, cr)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		t.Errorf("unexpected %s %s: a CIMD client in sync on its writable fields must not be pushed",
+			req.Method, req.URL.Path)
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	apiClient, _ := pocketid.NewClient(ts.URL, "")
+
+	updated, err := r.pushOIDCClientState(ctx, cr, apiClient, cimdCurrent())
+	if err != nil {
+		t.Fatalf("pushOIDCClientState returned error: %v", err)
+	}
+	if updated {
+		t.Error("expected no update for a CIMD client that differs only on metadata-owned fields")
+	}
+}
+
+// The counterpart: a writable field must still be pushed, and the payload must carry the
+// metadata document's values rather than the CR's, so nothing is clobbered on the way.
+func TestPushOIDCClientState_CIMDPushesWritableFields(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	cr := cimdClientCR("metadata-app", func(c *pocketidinternalv1alpha1.PocketIDOIDCClient) {
+		c.Spec.SkipConsent = true
+		c.Spec.AccessTokenDurationMinutes = 15
+		c.Status.Conditions = readyCondition()
+	})
+	r := newPushStateOIDCReconciler(scheme, cr)
+
+	var body map[string]any
+	encodedPath := "/api/oidc/clients/~" + base64.RawURLEncoding.EncodeToString([]byte("https://apps.example.com/meta.json"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPut || req.URL.EscapedPath() != encodedPath {
+			t.Errorf("unexpected %s %s", req.Method, req.URL.EscapedPath())
+			http.NotFound(w, req)
+			return
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		okOIDCClientResponse(w, "https://apps.example.com/meta.json", "My App")
+	}))
+	defer ts.Close()
+	apiClient, _ := pocketid.NewClient(ts.URL, "")
+
+	if _, err := r.pushOIDCClientState(ctx, cr, apiClient, cimdCurrent()); err != nil {
+		t.Fatalf("pushOIDCClientState returned error: %v", err)
+	}
+
+	if body == nil {
+		t.Fatal("expected an update when a writable field changed")
+	}
+	if got, _ := body["skipConsent"].(bool); !got {
+		t.Error("expected skipConsent to be pushed")
+	}
+	if got, _ := body["accessTokenDurationMinutes"].(float64); got != 15 {
+		t.Errorf("accessTokenDurationMinutes: got %v, want 15", body["accessTokenDurationMinutes"])
+	}
+	if got, _ := body["name"].(string); got != "My App" {
+		t.Errorf("name must carry the document value, got %q", got)
+	}
+	if got, _ := body["isPublic"].(bool); !got {
+		t.Error("isPublic must carry the document value (true), not the CR default")
+	}
+}
+
 // A CIMD client's metadata document must declare token_endpoint_auth_method "none", so it
 // is always public and the operator must never try to mint or rotate a secret for it.
 func TestIsPublicClient_TreatsCIMDAsPublic(t *testing.T) {
@@ -210,6 +326,34 @@ func TestIsPublicClient_TreatsCIMDAsPublic(t *testing.T) {
 	oidcClient.Status.ClientType = pocketid.ClientTypeCIMD
 	if !isPublicClient(oidcClient) {
 		t.Error("a CIMD client must be treated as public regardless of spec.isPublic")
+	}
+}
+
+// The isPublicClient guard in effect, not just in isolation: a CIMD client leaves
+// spec.isPublic false (admission rejects setting it), so without the guard ReconcileSecret
+// would take the mint path and try to regenerate a secret on adoption. A nil apiClient
+// makes any such call fail loudly instead of passing silently.
+func TestReconcileSecret_CIMDClientSkipsSecretMinting(t *testing.T) {
+	oidcClient := cimdClientCR("metadata-app", nil)
+	instance := &pocketidinternalv1alpha1.PocketIDInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-instance", Namespace: testNamespace},
+	}
+	r := declaredSecretReconciler(t, oidcClient, instance)
+
+	if err := r.ReconcileSecret(context.Background(), oidcClient, instance, nil); err != nil {
+		t.Fatalf("ReconcileSecret returned error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: r.GetSecretName(oidcClient), Namespace: testNamespace}
+	if err := r.Get(context.Background(), key, secret); err != nil {
+		t.Fatalf("expected the managed secret to be created: %v", err)
+	}
+	if _, ok := secret.Data[r.GetSecretKeys(oidcClient).ClientSecret]; ok {
+		t.Error("a CIMD client is always public and must never have a client_secret stored")
+	}
+	if got := string(secret.Data[r.GetSecretKeys(oidcClient).ClientID]); got != oidcClient.Status.ClientID {
+		t.Errorf("client_id: got %q, want %q", got, oidcClient.Status.ClientID)
 	}
 }
 

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -60,6 +60,9 @@ const (
 	// regenerateClientSecretAnnotation is set by a user to force an immediate secret
 	// rotation, bypassing the scheduled-rotation gates.
 	regenerateClientSecretAnnotation = "pocketid.internal/regenerate-client-secret"
+	// refreshClientMetadataAnnotation is set by a user to force a CIMD client to re-fetch
+	// its metadata document ahead of the cache TTL.
+	refreshClientMetadataAnnotation = "pocketid.internal/refresh-client-metadata"
 
 	defaultLogoTemplate     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}.png"
 	defaultDarkLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}-dark.png"
@@ -148,6 +151,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	apiClient, result, err := r.GetAPIClientOrRequeue(ctx, oidcClient, instance)
 	if result != nil {
 		return *result, err
+	}
+
+	if err := r.refreshClientMetadata(ctx, oidcClient, apiClient); err != nil {
+		log.Error(err, "Failed to refresh client metadata document")
+		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "MetadataRefreshError", err.Error())
+		return ctrl.Result{RequeueAfter: common.Requeue}, nil
 	}
 
 	// No client ID yet, create or adopt
@@ -256,6 +265,7 @@ type PocketIDOIDCClientAPI interface {
 	GetOIDCClient(ctx context.Context, id string) (*pocketid.OIDCClient, error)
 	UpdateOIDCClient(ctx context.Context, id string, input pocketid.OIDCClientInput) (*pocketid.OIDCClient, error)
 	UpdateOIDCClientAllowedGroups(ctx context.Context, id string, groupIDs []string) error
+	RefreshOIDCClientMetadata(ctx context.Context, id string) (*pocketid.OIDCClient, error)
 	SetOIDCClientSecret(ctx context.Context, id, secret string) (string, error)
 	GetOIDCClientSCIMServiceProvider(ctx context.Context, oidcClientID string) (*pocketid.SCIMServiceProvider, error)
 	CreateSCIMServiceProvider(ctx context.Context, input pocketid.SCIMServiceProviderInput) (*pocketid.SCIMServiceProvider, error)
@@ -263,10 +273,34 @@ type PocketIDOIDCClientAPI interface {
 	DeleteSCIMServiceProvider(ctx context.Context, id string) error
 }
 
+// refreshClientMetadata services the refresh-client-metadata annotation by forcing an
+// adopted CIMD client to re-fetch its metadata document ahead of the cache TTL.
+func (r *Reconciler) refreshClientMetadata(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, apiClient PocketIDOIDCClientAPI) error {
+	removed, err := helpers.CheckAndRemoveAnnotation(ctx, r.Client, oidcClient, refreshClientMetadataAnnotation, "true")
+	if err != nil || !removed {
+		return err
+	}
+
+	id := oidcClient.Status.ClientID
+	if id == "" {
+		return stderrors.New("cannot refresh client metadata: the client has not been adopted yet")
+	}
+
+	if _, err := apiClient.RefreshOIDCClientMetadata(ctx, id); err != nil {
+		return err
+	}
+
+	logf.FromContext(ctx).Info("Refreshed client metadata document", "clientID", id)
+	return nil
+}
+
 // FindExistingOIDCClient checks if an OIDC client already exists in Pocket-ID.
 // If specClientID is non-empty, it looks up by client ID directly.
 // Otherwise, it searches by name and returns an exact match.
 // Returns the existing client if found, or nil if no matching client exists.
+// A CIMD client is only ever adopted through an explicit spec.clientID: a name match is
+// refused so a document-supplied client_name colliding with a CR name cannot silently
+// pull an unrelated self-registered client under management.
 func (r *Reconciler) FindExistingOIDCClient(ctx context.Context, apiClient PocketIDOIDCClientAPI, specClientID, name string) (*pocketid.OIDCClient, error) {
 	log := logf.FromContext(ctx)
 
@@ -292,6 +326,10 @@ func (r *Reconciler) FindExistingOIDCClient(ctx context.Context, apiClient Pocke
 
 	for _, c := range clients {
 		if c.Name == name {
+			if c.IsCIMD() {
+				return nil, fmt.Errorf(
+					"OIDC client %q matched by name is a CIMD client; set spec.clientID to its metadata document URL to manage it", c.ID)
+			}
 			log.Info("Found existing OIDC client with matching name", "name", name, "clientID", c.ID)
 			return c, nil
 		}
@@ -346,6 +384,25 @@ func (r *Reconciler) createOrAdoptOIDCClient(ctx context.Context, oidcClient *po
 		log.Info("No existing OIDC client found by name, creating new", "name", name)
 	}
 
+	// Pocket-ID materializes a CIMD client from its metadata document on the app's first
+	// authorization request; the operator can only ever adopt one. Falling through to
+	// CreateOrAdopt would try to register a standard client under the document URL.
+	if pocketid.LooksLikeCIMDID(oidcClient.Spec.ClientID) {
+		existing, err := r.FindExistingOIDCClient(ctx, apiClient, oidcClient.Spec.ClientID, name)
+		if err != nil {
+			return false, err
+		}
+		if existing == nil {
+			return false, errAwaitingCIMD
+		}
+		log.Info("Adopting CIMD client", "clientID", existing.ID)
+		metrics.ResourceOperations.WithLabelValues("PocketIDOIDCClient", "adopted").Inc()
+		if err := r.setClientID(ctx, oidcClient, existing.ID); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
 	result, err := common.CreateOrAdopt(ctx, common.CreateOrAdoptConfig[*pocketid.OIDCClient]{
 		ResourceKind: "OIDC client",
 		ResourceID:   resourceID,
@@ -388,6 +445,19 @@ func (r *Reconciler) createOrAdoptOIDCClient(ctx context.Context, oidcClient *po
 	return true, nil
 }
 
+// preserveMetadataOwnedFields adopts the observed values for the fields Pocket-ID refuses
+// to write on a CIMD client, whose metadata document owns them. Without this the operator
+// would diff against values the server discards and re-push them on every reconcile.
+// Admission rejects these fields in the spec, so this only overwrites CRD defaults.
+func preserveMetadataOwnedFields(desired *pocketid.OIDCClientInput, current *pocketid.OIDCClient) {
+	desired.Name = current.Name
+	desired.CallbackURLs = current.CallbackURLs
+	desired.LogoutCallbackURLs = current.LogoutCallbackURLs
+	desired.IsPublic = current.IsPublic
+	desired.PKCEEnabled = current.PKCEEnabled
+	desired.Credentials = nil
+}
+
 // pushOIDCClientState compares the desired state from the CR spec against the current
 // state fetched from Pocket ID and only pushes updates if they differ.
 func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, apiClient *pocketid.Client, current *pocketid.OIDCClient) (bool, error) {
@@ -408,14 +478,19 @@ func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocket
 
 	desired := r.OidcClientInput(oidcClient, current, logoURL, darkLogoURL)
 	desired.IsGroupRestricted = len(groupIDs) > 0
+	if current.IsCIMD() {
+		preserveMetadataOwnedFields(&desired, current)
+	}
 
 	currentInput := current.ToInput()
 	clientChanged := !desired.Equal(currentInput)
 	hasCredentials := desired.Credentials != nil
 	groupsChanged := !pocketid.SortedEqual(groupIDs, current.AllowedUserGroupIDs)
 
-	// Clear any existing credentials if the CR doesn't specify any when adopting
-	firstReconcile := !helpers.IsResourceReady(oidcClient.Status.Conditions)
+	// Clear any existing credentials if the CR doesn't specify any when adopting.
+	// A CIMD client's credentials are metadata-owned and discarded on write, so clearing
+	// them would only cost a pointless PUT on every adoption.
+	firstReconcile := !helpers.IsResourceReady(oidcClient.Status.Conditions) && !current.IsCIMD()
 	if firstReconcile && !hasCredentials {
 		desired.Credentials = &pocketid.OIDCClientCredentials{FederatedIdentities: []pocketid.OIDCClientFederatedIdentity{}}
 	}
@@ -519,14 +594,31 @@ func reconcileErrorReason(err error) string {
 	if stderrors.Is(err, helpers.ErrUserGroupNotFound) {
 		return "UserGroupNotFound"
 	}
+	if stderrors.Is(err, errAwaitingCIMD) {
+		return "AwaitingFirstAuthorization"
+	}
 	return "ReconcileError"
 }
+
+// errAwaitingCIMD reports that a metadata-document client does not exist in Pocket-ID yet.
+// The row appears when the app first authorizes, so this is a normal waiting state rather
+// than a misconfiguration.
+var errAwaitingCIMD = stderrors.New(
+	"CIMD client does not exist yet; Pocket-ID creates it on the app's first authorization request")
 
 // setClientID persists only the client ID to status.
 func (r *Reconciler) setClientID(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, id string) error {
 	base := oidcClient.DeepCopy()
 	oidcClient.Status.ClientID = id
 	return r.Status().Patch(ctx, oidcClient, client.MergeFrom(base))
+}
+
+// isPublicClient reports whether the client has no client secret to manage. A CIMD client
+// is always public — its metadata document must declare token_endpoint_auth_method "none",
+// since Pocket-ID does not persist key material for one — so the operator must never try
+// to mint or rotate a secret for it, regardless of what spec.isPublic says.
+func isPublicClient(oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) bool {
+	return oidcClient.Spec.IsPublic || oidcClient.Status.ClientType == pocketid.ClientTypeCIMD
 }
 
 // oidcClientName returns the Pocket-ID name for the given OIDC client:
@@ -840,6 +932,7 @@ func (r *Reconciler) UpdateOIDCClientStatus(ctx context.Context, oidcClient *poc
 	base := oidcClient.DeepCopy()
 	oidcClient.Status.ClientID = current.ID
 	oidcClient.Status.Name = current.Name
+	oidcClient.Status.ClientType = current.ClientType
 	oidcClient.Status.CallbackURLs = current.CallbackURLs
 	oidcClient.Status.LogoutCallbackURLs = current.LogoutCallbackURLs
 	oidcClient.Status.AllowedUserGroupIDs = current.AllowedUserGroupIDs
@@ -989,7 +1082,7 @@ func (r *Reconciler) ReconcileSecret(ctx context.Context, oidcClient *pocketidin
 	// Only regenerate if the secret doesn't exist yet or if explicitly requested via annotation.
 	var rotatedAt *metav1.Time
 	var scheduledRotation bool
-	if !oidcClient.Spec.IsPublic && oidcClient.Status.ClientID != "" {
+	if !isPublicClient(oidcClient) && oidcClient.Status.ClientID != "" {
 		var err error
 		rotatedAt, scheduledRotation, err = r.reconcileClientSecretData(ctx, oidcClient, instance, apiClient, secretName, keys, secretData)
 		if err != nil {

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -68,6 +68,13 @@ const (
 	defaultDarkLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}-dark.png"
 )
 
+// errAwaitingCIMD reports that a metadata-document client does not exist in Pocket-ID yet.
+// The row appears when the app first authorizes, so this is a normal waiting state rather
+// than a misconfiguration, and it is requeued on the resync interval instead of the much
+// shorter error interval.
+var errAwaitingCIMD = stderrors.New(
+	"CIMD client does not exist yet; Pocket-ID creates it on the app's first authorization request")
+
 // Reconciler reconciles a PocketIDOIDCClient object
 type Reconciler struct {
 	client.Client
@@ -162,6 +169,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// No client ID yet, create or adopt
 	if oidcClient.Status.ClientID == "" {
 		requeue, err := r.createOrAdoptOIDCClient(ctx, oidcClient, apiClient)
+		if stderrors.Is(err, errAwaitingCIMD) {
+			// Normal for a metadata document whose app has not authorized yet, which can
+			// last indefinitely: resync rather than hammering the API every few seconds.
+			log.V(1).Info("Waiting for Pocket-ID to materialize the CIMD client", "clientID", oidcClient.Spec.ClientID)
+			_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, reconcileErrorReason(err), err.Error())
+			return common.ApplyResync(ctrl.Result{}), nil
+		}
 		if err != nil {
 			log.Error(err, "Failed to create or adopt OIDC client")
 			_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, reconcileErrorReason(err), err.Error())
@@ -265,7 +279,7 @@ type PocketIDOIDCClientAPI interface {
 	GetOIDCClient(ctx context.Context, id string) (*pocketid.OIDCClient, error)
 	UpdateOIDCClient(ctx context.Context, id string, input pocketid.OIDCClientInput) (*pocketid.OIDCClient, error)
 	UpdateOIDCClientAllowedGroups(ctx context.Context, id string, groupIDs []string) error
-	RefreshOIDCClientMetadata(ctx context.Context, id string) (*pocketid.OIDCClient, error)
+	RefreshOIDCClientMetadata(ctx context.Context, id string) error
 	SetOIDCClientSecret(ctx context.Context, id, secret string) (string, error)
 	GetOIDCClientSCIMServiceProvider(ctx context.Context, oidcClientID string) (*pocketid.SCIMServiceProvider, error)
 	CreateSCIMServiceProvider(ctx context.Context, input pocketid.SCIMServiceProviderInput) (*pocketid.SCIMServiceProvider, error)
@@ -286,7 +300,7 @@ func (r *Reconciler) refreshClientMetadata(ctx context.Context, oidcClient *pock
 		return stderrors.New("cannot refresh client metadata: the client has not been adopted yet")
 	}
 
-	if _, err := apiClient.RefreshOIDCClientMetadata(ctx, id); err != nil {
+	if err := apiClient.RefreshOIDCClientMetadata(ctx, id); err != nil {
 		return err
 	}
 
@@ -298,9 +312,9 @@ func (r *Reconciler) refreshClientMetadata(ctx context.Context, oidcClient *pock
 // If specClientID is non-empty, it looks up by client ID directly.
 // Otherwise, it searches by name and returns an exact match.
 // Returns the existing client if found, or nil if no matching client exists.
-// A CIMD client is only ever adopted through an explicit spec.clientID: a name match is
-// refused so a document-supplied client_name colliding with a CR name cannot silently
-// pull an unrelated self-registered client under management.
+// A CIMD client is only ever adopted through an explicit spec.clientID: name matches skip
+// them so a document-supplied client_name colliding with a CR name cannot silently pull an
+// unrelated self-registered client under management.
 func (r *Reconciler) FindExistingOIDCClient(ctx context.Context, apiClient PocketIDOIDCClientAPI, specClientID, name string) (*pocketid.OIDCClient, error) {
 	log := logf.FromContext(ctx)
 
@@ -325,14 +339,19 @@ func (r *Reconciler) FindExistingOIDCClient(ctx context.Context, apiClient Pocke
 	}
 
 	for _, c := range clients {
-		if c.Name == name {
-			if c.IsCIMD() {
-				return nil, fmt.Errorf(
-					"OIDC client %q matched by name is a CIMD client; set spec.clientID to its metadata document URL to manage it", c.ID)
-			}
-			log.Info("Found existing OIDC client with matching name", "name", name, "clientID", c.ID)
-			return c, nil
+		if c.Name != name {
+			continue
 		}
+		// A CIMD client's name comes from a document the app publishes about itself, so a
+		// collision is not the operator's to resolve: skipping keeps a self-registered app
+		// from blocking an unrelated client that only ever wanted to be created by name.
+		if c.IsCIMD() {
+			log.Info("Skipping CIMD client with matching name; set spec.clientID to its metadata document URL to manage it",
+				"name", name, "clientID", c.ID)
+			continue
+		}
+		log.Info("Found existing OIDC client with matching name", "name", name, "clientID", c.ID)
+		return c, nil
 	}
 
 	log.Info("No OIDC client found with matching name", "name", name)
@@ -599,12 +618,6 @@ func reconcileErrorReason(err error) string {
 	}
 	return "ReconcileError"
 }
-
-// errAwaitingCIMD reports that a metadata-document client does not exist in Pocket-ID yet.
-// The row appears when the app first authorizes, so this is a normal waiting state rather
-// than a misconfiguration.
-var errAwaitingCIMD = stderrors.New(
-	"CIMD client does not exist yet; Pocket-ID creates it on the app's first authorization request")
 
 // setClientID persists only the client ID to status.
 func (r *Reconciler) setClientID(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, id string) error {

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -2597,6 +2597,9 @@ func (f *fakeSCIMAPI) UpdateOIDCClient(_ context.Context, _ string, _ pocketid.O
 func (f *fakeSCIMAPI) UpdateOIDCClientAllowedGroups(_ context.Context, _ string, _ []string) error {
 	panic("not implemented")
 }
+func (f *fakeSCIMAPI) RefreshOIDCClientMetadata(_ context.Context, _ string) (*pocketid.OIDCClient, error) {
+	panic("not implemented")
+}
 func (f *fakeSCIMAPI) SetOIDCClientSecret(_ context.Context, _, _ string) (string, error) {
 	panic("not implemented")
 }

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -2597,7 +2597,7 @@ func (f *fakeSCIMAPI) UpdateOIDCClient(_ context.Context, _ string, _ pocketid.O
 func (f *fakeSCIMAPI) UpdateOIDCClientAllowedGroups(_ context.Context, _ string, _ []string) error {
 	panic("not implemented")
 }
-func (f *fakeSCIMAPI) RefreshOIDCClientMetadata(_ context.Context, _ string) (*pocketid.OIDCClient, error) {
+func (f *fakeSCIMAPI) RefreshOIDCClientMetadata(_ context.Context, _ string) error {
 	panic("not implemented")
 }
 func (f *fakeSCIMAPI) SetOIDCClientSecret(_ context.Context, _, _ string) (string, error) {

--- a/internal/controller/oidcclient/existence_test.go
+++ b/internal/controller/oidcclient/existence_test.go
@@ -3,6 +3,7 @@ package oidcclient
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
@@ -16,6 +17,7 @@ type mockPocketIDOIDCClientClient struct {
 	getOIDCClientFunc                 func(ctx context.Context, id string) (*pocketid.OIDCClient, error)
 	updateOIDCClientFunc              func(ctx context.Context, id string, input pocketid.OIDCClientInput) (*pocketid.OIDCClient, error)
 	updateOIDCClientAllowedGroupsFunc func(ctx context.Context, id string, groupIDs []string) error
+	refreshOIDCClientMetadataFunc     func(ctx context.Context, id string) (*pocketid.OIDCClient, error)
 }
 
 func (m *mockPocketIDOIDCClientClient) ListOIDCClients(ctx context.Context, search string) ([]*pocketid.OIDCClient, error) {
@@ -61,6 +63,13 @@ func (m *mockPocketIDOIDCClientClient) UpdateOIDCClientAllowedGroups(ctx context
 		return m.updateOIDCClientAllowedGroupsFunc(ctx, id, groupIDs)
 	}
 	return nil
+}
+
+func (m *mockPocketIDOIDCClientClient) RefreshOIDCClientMetadata(ctx context.Context, id string) (*pocketid.OIDCClient, error) {
+	if m.refreshOIDCClientMetadataFunc != nil {
+		return m.refreshOIDCClientMetadataFunc(ctx, id)
+	}
+	return &pocketid.OIDCClient{ID: id, ClientType: pocketid.ClientTypeCIMD}, nil
 }
 
 func (m *mockPocketIDOIDCClientClient) SetOIDCClientSecret(_ context.Context, _, secret string) (string, error) {
@@ -308,6 +317,69 @@ func TestOIDCClientAdoption_ExistingClientByName(t *testing.T) {
 	}
 	if createCalled {
 		t.Fatal("CreateOIDCClient should not have been called for existing client")
+	}
+}
+
+// An explicit spec.clientID is the opt-in for CIMD management, so a by-ID lookup adopts.
+func TestFindExistingOIDCClient_AdoptsCIMDClientByID(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockPocketIDOIDCClientClient{
+		getOIDCClientFunc: func(_ context.Context, id string) (*pocketid.OIDCClient, error) {
+			return &pocketid.OIDCClient{ID: id, Name: "metadata-app", ClientType: pocketid.ClientTypeCIMD}, nil
+		},
+	}
+
+	found, err := (&Reconciler{}).FindExistingOIDCClient(ctx, mockClient, "https://apps.example.com/meta.json", "metadata-app")
+	if err != nil {
+		t.Fatalf("FindExistingOIDCClient returned unexpected error: %v", err)
+	}
+	if found == nil || !found.IsCIMD() {
+		t.Fatalf("expected the CIMD client to be adopted, got %+v", found)
+	}
+}
+
+// A name match is not an opt-in: a document-supplied client_name colliding with a CR name
+// must never pull an unrelated self-registered client under management.
+func TestFindExistingOIDCClient_RefusesCIMDClientByName(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockPocketIDOIDCClientClient{
+		listOIDCClientsFunc: func(_ context.Context, _ string) ([]*pocketid.OIDCClient, error) {
+			return []*pocketid.OIDCClient{
+				{ID: "other", Name: "other-app"},
+				{ID: "https://apps.example.com/meta.json", Name: "metadata-app", ClientType: pocketid.ClientTypeCIMD},
+			}, nil
+		},
+	}
+
+	found, err := (&Reconciler{}).FindExistingOIDCClient(ctx, mockClient, "", "metadata-app")
+	if err == nil {
+		t.Fatal("expected an error for a CIMD client, got nil")
+	}
+	if found != nil {
+		t.Fatalf("expected no client to be adopted, got %+v", found)
+	}
+	if !strings.Contains(err.Error(), "spec.clientID") {
+		t.Errorf("expected the error to point at spec.clientID, got %q", err.Error())
+	}
+}
+
+func TestFindExistingOIDCClient_AdoptsStandardClient(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockPocketIDOIDCClientClient{
+		getOIDCClientFunc: func(_ context.Context, id string) (*pocketid.OIDCClient, error) {
+			return &pocketid.OIDCClient{ID: id, Name: "grafana", ClientType: "standard"}, nil
+		},
+	}
+
+	found, err := (&Reconciler{}).FindExistingOIDCClient(ctx, mockClient, "grafana-id", "grafana")
+	if err != nil {
+		t.Fatalf("FindExistingOIDCClient returned unexpected error: %v", err)
+	}
+	if found == nil || found.ID != "grafana-id" {
+		t.Fatalf("expected the standard client to be adopted, got %+v", found)
 	}
 }
 

--- a/internal/controller/oidcclient/existence_test.go
+++ b/internal/controller/oidcclient/existence_test.go
@@ -3,7 +3,6 @@ package oidcclient
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
@@ -17,7 +16,7 @@ type mockPocketIDOIDCClientClient struct {
 	getOIDCClientFunc                 func(ctx context.Context, id string) (*pocketid.OIDCClient, error)
 	updateOIDCClientFunc              func(ctx context.Context, id string, input pocketid.OIDCClientInput) (*pocketid.OIDCClient, error)
 	updateOIDCClientAllowedGroupsFunc func(ctx context.Context, id string, groupIDs []string) error
-	refreshOIDCClientMetadataFunc     func(ctx context.Context, id string) (*pocketid.OIDCClient, error)
+	refreshOIDCClientMetadataFunc     func(ctx context.Context, id string) error
 }
 
 func (m *mockPocketIDOIDCClientClient) ListOIDCClients(ctx context.Context, search string) ([]*pocketid.OIDCClient, error) {
@@ -65,11 +64,11 @@ func (m *mockPocketIDOIDCClientClient) UpdateOIDCClientAllowedGroups(ctx context
 	return nil
 }
 
-func (m *mockPocketIDOIDCClientClient) RefreshOIDCClientMetadata(ctx context.Context, id string) (*pocketid.OIDCClient, error) {
+func (m *mockPocketIDOIDCClientClient) RefreshOIDCClientMetadata(ctx context.Context, id string) error {
 	if m.refreshOIDCClientMetadataFunc != nil {
 		return m.refreshOIDCClientMetadataFunc(ctx, id)
 	}
-	return &pocketid.OIDCClient{ID: id, ClientType: pocketid.ClientTypeCIMD}, nil
+	return nil
 }
 
 func (m *mockPocketIDOIDCClientClient) SetOIDCClientSecret(_ context.Context, _, secret string) (string, error) {
@@ -340,8 +339,10 @@ func TestFindExistingOIDCClient_AdoptsCIMDClientByID(t *testing.T) {
 }
 
 // A name match is not an opt-in: a document-supplied client_name colliding with a CR name
-// must never pull an unrelated self-registered client under management.
-func TestFindExistingOIDCClient_RefusesCIMDClientByName(t *testing.T) {
+// must never pull an unrelated self-registered client under management. client_name is
+// chosen by the app itself, so the collision is skipped rather than raised — erroring would
+// let any allowlisted app permanently block a CR that only wanted to be created by name.
+func TestFindExistingOIDCClient_SkipsCIMDClientMatchedByName(t *testing.T) {
 	ctx := context.Background()
 
 	mockClient := &mockPocketIDOIDCClientClient{
@@ -354,14 +355,33 @@ func TestFindExistingOIDCClient_RefusesCIMDClientByName(t *testing.T) {
 	}
 
 	found, err := (&Reconciler{}).FindExistingOIDCClient(ctx, mockClient, "", "metadata-app")
-	if err == nil {
-		t.Fatal("expected an error for a CIMD client, got nil")
+	if err != nil {
+		t.Fatalf("FindExistingOIDCClient returned unexpected error: %v", err)
 	}
 	if found != nil {
-		t.Fatalf("expected no client to be adopted, got %+v", found)
+		t.Fatalf("expected the CIMD client to be skipped so a new one is created, got %+v", found)
 	}
-	if !strings.Contains(err.Error(), "spec.clientID") {
-		t.Errorf("expected the error to point at spec.clientID, got %q", err.Error())
+}
+
+// A standard client with the same name still adopts, even when a CIMD client shadows it.
+func TestFindExistingOIDCClient_AdoptsStandardClientShadowedByCIMDName(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockPocketIDOIDCClientClient{
+		listOIDCClientsFunc: func(_ context.Context, _ string) ([]*pocketid.OIDCClient, error) {
+			return []*pocketid.OIDCClient{
+				{ID: "https://apps.example.com/meta.json", Name: "grafana", ClientType: pocketid.ClientTypeCIMD},
+				{ID: "grafana-id", Name: "grafana", ClientType: "standard"},
+			}, nil
+		},
+	}
+
+	found, err := (&Reconciler{}).FindExistingOIDCClient(ctx, mockClient, "", "grafana")
+	if err != nil {
+		t.Fatalf("FindExistingOIDCClient returned unexpected error: %v", err)
+	}
+	if found == nil || found.ID != "grafana-id" {
+		t.Fatalf("expected the standard client to be adopted, got %+v", found)
 	}
 }
 

--- a/internal/controller/pocketidoidcclient_controller_test.go
+++ b/internal/controller/pocketidoidcclient_controller_test.go
@@ -728,6 +728,28 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 			}), "always public and has no client secret")
 		})
 
+		// The pre-existing clientPermissions rule keys on spec.isPublic, which a CIMD
+		// client must leave false even though the client itself is public.
+		It("rejects apiAccess clientPermissions on a CIMD client", func() {
+			expectRejectedWith(newClient("cimd-cel-client-perms", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.APIAccess = []pocketidinternalv1alpha1.OIDCClientAPIAccess{{
+					APIRef:            pocketidinternalv1alpha1.NamespacedAPIReference{Name: "my-api"},
+					ClientPermissions: []string{"read"},
+				}}
+			}), "clientPermissions require a confidential client")
+		})
+
+		It("accepts apiAccess delegatedPermissions on a CIMD client", func() {
+			resource := newClient("cimd-cel-delegated-perms", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.APIAccess = []pocketidinternalv1alpha1.OIDCClientAPIAccess{{
+					APIRef:               pocketidinternalv1alpha1.NamespacedAPIReference{Name: "my-api"},
+					DelegatedPermissions: []string{"read"},
+				}}
+			})
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, resource) })
+		})
+
 		It("allows an ordinary client ID up to 128 characters and rejects longer ones", func() {
 			ok := &pocketidinternalv1alpha1.PocketIDOIDCClient{
 				ObjectMeta: metav1.ObjectMeta{Name: "cimd-cel-len-ok", Namespace: namespace},

--- a/internal/controller/pocketidoidcclient_controller_test.go
+++ b/internal/controller/pocketidoidcclient_controller_test.go
@@ -659,6 +659,104 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 		})
 	})
 
+	// Admission is what keeps a CIMD resource from declaring fields its metadata document
+	// owns. Without these rules the operator would silently ignore them instead.
+	Context("CIMD client validation", func() {
+		const metadataURL = "https://apps.example.com/myapp/client-metadata.json"
+
+		newClient := func(name string, mutate func(*pocketidinternalv1alpha1.PocketIDOIDCClientSpec)) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+			spec := pocketidinternalv1alpha1.PocketIDOIDCClientSpec{ClientID: metadataURL}
+			mutate(&spec)
+			return &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec:       spec,
+			}
+		}
+		expectRejectedWith := func(resource *pocketidinternalv1alpha1.PocketIDOIDCClient, substring string) {
+			err := k8sClient.Create(ctx, resource)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(substring))
+		}
+
+		It("accepts a CIMD client setting only the fields Pocket-ID persists", func() {
+			resource := newClient("cimd-cel-ok", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.Description = "Self-registered app"
+				s.LaunchURL = "https://apps.example.com/myapp"
+				s.SkipConsent = true
+				s.RequiresReauthentication = true
+				s.AccessTokenDurationMinutes = 15
+				s.AllowedUserGroups = []pocketidinternalv1alpha1.NamespacedUserGroupReference{{GroupName: "platform"}}
+			})
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, resource) })
+		})
+
+		DescribeTable("rejects metadata-owned fields",
+			func(mutate func(*pocketidinternalv1alpha1.PocketIDOIDCClientSpec)) {
+				expectRejectedWith(newClient("cimd-cel-owned", mutate),
+					"owned by the client ID metadata document")
+			},
+			Entry("name", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) { s.Name = "My App" }),
+			Entry("callbackUrls", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.CallbackURLs = []string{"https://apps.example.com/cb"}
+			}),
+			Entry("logoutCallbackUrls", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.LogoutCallbackURLs = []string{"https://apps.example.com/logout"}
+			}),
+			Entry("isPublic", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) { s.IsPublic = true }),
+			Entry("pkceEnabled", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) { s.PKCEEnabled = true }),
+			Entry("federatedIdentities", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.FederatedIdentities = []pocketidinternalv1alpha1.OIDCClientFederatedIdentity{{Issuer: "https://issuer.example.com"}}
+			}),
+		)
+
+		It("rejects clientSecretRef on a CIMD client", func() {
+			expectRejectedWith(newClient("cimd-cel-secret-ref", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.ClientSecretRef = &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+					Key:                  "secret",
+				}
+			}), "always public and has no client secret")
+		})
+
+		It("rejects enabling clientSecretRotation on a CIMD client", func() {
+			expectRejectedWith(newClient("cimd-cel-rotation", func(s *pocketidinternalv1alpha1.PocketIDOIDCClientSpec) {
+				s.ClientSecretRotation = &pocketidinternalv1alpha1.ClientSecretRotation{
+					Enabled:  true,
+					Interval: &metav1.Duration{Duration: 720 * time.Hour},
+				}
+			}), "always public and has no client secret")
+		})
+
+		It("allows an ordinary client ID up to 128 characters and rejects longer ones", func() {
+			ok := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "cimd-cel-len-ok", Namespace: namespace},
+				Spec:       pocketidinternalv1alpha1.PocketIDOIDCClientSpec{ClientID: strings.Repeat("a", 128)},
+			}
+			Expect(k8sClient.Create(ctx, ok)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, ok) })
+
+			long := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "cimd-cel-len-bad", Namespace: namespace},
+				Spec:       pocketidinternalv1alpha1.PocketIDOIDCClientSpec{ClientID: strings.Repeat("a", 129)},
+			}
+			err := k8sClient.Create(ctx, long)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("at most 128 characters"))
+		})
+
+		It("allows a metadata document URL longer than 128 characters", func() {
+			resource := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "cimd-cel-long-url", Namespace: namespace},
+				Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+					ClientID: "https://apps.example.com/" + strings.Repeat("deep/", 25) + "client-metadata.json",
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, resource) })
+		})
+	})
+
 	Context("Updating OIDC client status", func() {
 		const clientName = "test-oidc-status-update"
 

--- a/internal/pocketid/client.go
+++ b/internal/pocketid/client.go
@@ -98,57 +98,26 @@ func (c *OIDCClient) IsCIMD() bool {
 }
 
 // LooksLikeCIMDID reports whether a client ID is a metadata document URL. Pocket-ID
-// restricts registered client IDs to [a-zA-Z0-9._-]+, so "://" can only come from one.
-// Unlike IsCIMD this needs no API round trip, which is what makes it usable for admission
-// validation and before a client has been resolved.
+// restricts registered client IDs to [a-zA-Z0-9._-]+, so an "https://" prefix can only come
+// from a metadata document. Unlike IsCIMD this needs no API round trip, which is what makes
+// it usable before a client has been resolved. It matches the CRD's CEL admission rules and
+// upstream's fosite.LooksLikeCIMDURL, which both require the https scheme.
 func LooksLikeCIMDID(id string) bool {
-	return strings.Contains(id, "://")
+	return strings.HasPrefix(id, "https://")
 }
 
 // clientIDPathParam encodes a client ID for use as a URL path parameter. A CIMD client ID
 // is a full https URL whose slashes cannot survive a single path segment, so Pocket-ID
 // accepts it base64url-encoded behind a "~" prefix and decodes it in middleware. Ordinary
 // client IDs are passed through untouched.
+//
+// Every call that takes an OIDC client ID as a path parameter must apply this;
+// TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs enumerates them.
 func clientIDPathParam(id string) string {
 	if !LooksLikeCIMDID(id) {
 		return id
 	}
 	return "~" + base64.RawURLEncoding.EncodeToString([]byte(id))
-}
-
-// clientIDEncodingTransport applies clientIDPathParam to every path parameter the generated
-// client writes.
-//
-// Every other path parameter Pocket-ID takes is a server-generated ID that cannot contain a
-// scheme separator, so the encoding is a no-op for them.
-type clientIDEncodingTransport struct {
-	runtime.ContextualTransport
-}
-
-func (t clientIDEncodingTransport) Submit(op *runtime.ClientOperation) (any, error) {
-	return t.ContextualTransport.Submit(encodePathParams(op))
-}
-
-func (t clientIDEncodingTransport) SubmitContext(ctx context.Context, op *runtime.ClientOperation) (any, error) {
-	return t.ContextualTransport.SubmitContext(ctx, encodePathParams(op))
-}
-
-// encodePathParams wraps the operation's parameter writer so it sees a request whose
-// SetPathParam encodes CIMD client IDs.
-func encodePathParams(op *runtime.ClientOperation) *runtime.ClientOperation {
-	inner := op.Params
-	op.Params = runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
-		return inner.WriteToRequest(clientIDPathParamWriter{ClientRequest: req}, reg)
-	})
-	return op
-}
-
-type clientIDPathParamWriter struct {
-	runtime.ClientRequest
-}
-
-func (w clientIDPathParamWriter) SetPathParam(name, value string) error {
-	return w.ClientRequest.SetPathParam(name, clientIDPathParam(value))
 }
 
 // ToInput converts an OIDCClient into an OIDCClientInput for comparison with desired state.
@@ -372,7 +341,7 @@ func NewClient(baseURL string, apiKey string) (*Client, error) {
 		)
 	}
 
-	raw := apiclient.New(clientIDEncodingTransport{ContextualTransport: transport}, strfmt.Default)
+	raw := apiclient.New(transport, strfmt.Default)
 
 	return &Client{
 		raw:     raw,
@@ -658,7 +627,7 @@ func (c *Client) CreateOIDCClient(ctx context.Context, input OIDCClientInput) (*
 
 func (c *Client) UpdateOIDCClient(ctx context.Context, id string, input OIDCClientInput) (*OIDCClient, error) {
 	params := oidc.NewPutAPIOidcClientsIDParams().
-		WithID(id).
+		WithID(clientIDPathParam(id)).
 		WithClient(&models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientUpdateDto{
 			Name:                                &input.Name,
 			Description:                         input.Description,
@@ -692,7 +661,7 @@ func (c *Client) UpdateOIDCClient(ctx context.Context, id string, input OIDCClie
 
 func (c *Client) GetOIDCClient(ctx context.Context, id string) (*OIDCClient, error) {
 	params := oidc.NewGetAPIOidcClientsIDParams().
-		WithID(id)
+		WithID(clientIDPathParam(id))
 
 	start := time.Now()
 	resp, err := c.raw.OIDc.GetAPIOidcClientsIDContext(ctx, params)
@@ -705,25 +674,26 @@ func (c *Client) GetOIDCClient(ctx context.Context, id string) (*OIDCClient, err
 }
 
 // RefreshOIDCClientMetadata forces a re-fetch of a CIMD client's metadata document,
-// bypassing the cache TTL, and returns the refreshed client. Pocket-ID rejects the
-// call for standard clients and when no CIMD allowlist is configured.
-func (c *Client) RefreshOIDCClientMetadata(ctx context.Context, id string) (*OIDCClient, error) {
+// bypassing the cache TTL. Pocket-ID rejects the call for standard clients and when no
+// CIMD allowlist is configured. The refreshed client is discarded: the reconcile that
+// triggers this re-reads the canonical state immediately afterwards.
+func (c *Client) RefreshOIDCClientMetadata(ctx context.Context, id string) error {
 	params := oidc.NewPostAPIOidcClientsIDRefreshParams().
-		WithID(id)
+		WithID(clientIDPathParam(id))
 
 	start := time.Now()
-	resp, err := c.raw.OIDc.PostAPIOidcClientsIDRefreshContext(ctx, params)
+	_, err := c.raw.OIDc.PostAPIOidcClientsIDRefreshContext(ctx, params)
 	recordCall("refresh_oidc_client_metadata", err, time.Since(start))
 	if err != nil {
-		return nil, fmt.Errorf("refresh OIDC client metadata failed: %w", err)
+		return fmt.Errorf("refresh OIDC client metadata failed: %w", err)
 	}
 
-	return oidcClientFromAllowedGroupsDTO(resp.Payload), nil
+	return nil
 }
 
 func (c *Client) DeleteOIDCClient(ctx context.Context, id string) error {
 	params := oidc.NewDeleteAPIOidcClientsIDParams().
-		WithID(id)
+		WithID(clientIDPathParam(id))
 
 	start := time.Now()
 	_, err := c.raw.OIDc.DeleteAPIOidcClientsIDContext(ctx, params)
@@ -748,7 +718,7 @@ func (c *Client) UpdateOIDCClientAllowedGroups(ctx context.Context, id string, g
 			}
 		}
 		params := oidc.NewPutAPIOidcClientsIDAllowedUserGroupsParams().
-			WithID(id).
+			WithID(clientIDPathParam(id)).
 			WithGroups(&models.GithubComPocketIDPocketIDBackendInternalDtoOidcUpdateAllowedUserGroupsDto{
 				UserGroupIds: groupIDs,
 			})
@@ -786,7 +756,7 @@ func (c *Client) SetOIDCClientSecret(ctx context.Context, id, secret string) (st
 // payload lets Pocket-ID generate one; a non-nil payload requests a specific value.
 func (c *Client) postOIDCClientSecret(ctx context.Context, operation, id string, payload *models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientSecretDto) (string, error) {
 	params := oidc.NewPostAPIOidcClientsIDSecretParams().
-		WithID(id)
+		WithID(clientIDPathParam(id))
 	if payload != nil {
 		params = params.WithPayload(payload)
 	}
@@ -818,7 +788,7 @@ func (c *Client) postOIDCClientSecret(ctx context.Context, operation, id string,
 // Returns nil, nil if no SCIM service provider is configured (404).
 func (c *Client) GetOIDCClientSCIMServiceProvider(ctx context.Context, oidcClientID string) (*SCIMServiceProvider, error) {
 	params := oidc.NewGetAPIOidcClientsIDScimServiceProviderParams().
-		WithID(oidcClientID)
+		WithID(clientIDPathParam(oidcClientID))
 
 	start := time.Now()
 	resp, err := c.raw.OIDc.GetAPIOidcClientsIDScimServiceProviderContext(ctx, params)
@@ -1034,7 +1004,7 @@ func (c *Client) UpdateAPIPermissions(ctx context.Context, id string, permission
 
 // GetClientAPIAccess returns the API permissions currently granted to an OIDC client.
 func (c *Client) GetClientAPIAccess(ctx context.Context, clientID string) (*ClientAPIAccess, error) {
-	params := apis.NewGetAPIAPIAccessClientIDParams().WithClientID(clientID)
+	params := apis.NewGetAPIAPIAccessClientIDParams().WithClientID(clientIDPathParam(clientID))
 
 	start := time.Now()
 	resp, err := c.raw.Apis.GetAPIAPIAccessClientIDContext(ctx, params)
@@ -1048,7 +1018,7 @@ func (c *Client) GetClientAPIAccess(ctx context.Context, clientID string) (*Clie
 // UpdateClientAPIAccess replaces the full set of API permissions granted to an OIDC client.
 func (c *Client) UpdateClientAPIAccess(ctx context.Context, clientID string, access ClientAPIAccess) (*ClientAPIAccess, error) {
 	params := apis.NewPutAPIAPIAccessClientIDParams().
-		WithClientID(clientID).
+		WithClientID(clientIDPathParam(clientID)).
 		WithAccess(&models.APIClientAPIAccessUpdateDto{
 			ClientPermissionIds:        access.ClientPermissionIDs,
 			UserDelegatedPermissionIds: access.UserDelegatedPermissionIDs,

--- a/internal/pocketid/client.go
+++ b/internal/pocketid/client.go
@@ -116,6 +116,41 @@ func clientIDPathParam(id string) string {
 	return "~" + base64.RawURLEncoding.EncodeToString([]byte(id))
 }
 
+// clientIDEncodingTransport applies clientIDPathParam to every path parameter the generated
+// client writes.
+//
+// Every other path parameter Pocket-ID takes is a server-generated ID that cannot contain a
+// scheme separator, so the encoding is a no-op for them.
+type clientIDEncodingTransport struct {
+	runtime.ContextualTransport
+}
+
+func (t clientIDEncodingTransport) Submit(op *runtime.ClientOperation) (any, error) {
+	return t.ContextualTransport.Submit(encodePathParams(op))
+}
+
+func (t clientIDEncodingTransport) SubmitContext(ctx context.Context, op *runtime.ClientOperation) (any, error) {
+	return t.ContextualTransport.SubmitContext(ctx, encodePathParams(op))
+}
+
+// encodePathParams wraps the operation's parameter writer so it sees a request whose
+// SetPathParam encodes CIMD client IDs.
+func encodePathParams(op *runtime.ClientOperation) *runtime.ClientOperation {
+	inner := op.Params
+	op.Params = runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
+		return inner.WriteToRequest(clientIDPathParamWriter{ClientRequest: req}, reg)
+	})
+	return op
+}
+
+type clientIDPathParamWriter struct {
+	runtime.ClientRequest
+}
+
+func (w clientIDPathParamWriter) SetPathParam(name, value string) error {
+	return w.ClientRequest.SetPathParam(name, clientIDPathParam(value))
+}
+
 // ToInput converts an OIDCClient into an OIDCClientInput for comparison with desired state.
 // ID and Credentials are not included since they aren't returned by the GET API.
 // LogoURL and DarkLogoURL are write-only (not returned by the API); logo presence is
@@ -337,7 +372,7 @@ func NewClient(baseURL string, apiKey string) (*Client, error) {
 		)
 	}
 
-	raw := apiclient.New(transport, strfmt.Default)
+	raw := apiclient.New(clientIDEncodingTransport{ContextualTransport: transport}, strfmt.Default)
 
 	return &Client{
 		raw:     raw,
@@ -623,7 +658,7 @@ func (c *Client) CreateOIDCClient(ctx context.Context, input OIDCClientInput) (*
 
 func (c *Client) UpdateOIDCClient(ctx context.Context, id string, input OIDCClientInput) (*OIDCClient, error) {
 	params := oidc.NewPutAPIOidcClientsIDParams().
-		WithID(clientIDPathParam(id)).
+		WithID(id).
 		WithClient(&models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientUpdateDto{
 			Name:                                &input.Name,
 			Description:                         input.Description,
@@ -657,7 +692,7 @@ func (c *Client) UpdateOIDCClient(ctx context.Context, id string, input OIDCClie
 
 func (c *Client) GetOIDCClient(ctx context.Context, id string) (*OIDCClient, error) {
 	params := oidc.NewGetAPIOidcClientsIDParams().
-		WithID(clientIDPathParam(id))
+		WithID(id)
 
 	start := time.Now()
 	resp, err := c.raw.OIDc.GetAPIOidcClientsIDContext(ctx, params)
@@ -674,7 +709,7 @@ func (c *Client) GetOIDCClient(ctx context.Context, id string) (*OIDCClient, err
 // call for standard clients and when no CIMD allowlist is configured.
 func (c *Client) RefreshOIDCClientMetadata(ctx context.Context, id string) (*OIDCClient, error) {
 	params := oidc.NewPostAPIOidcClientsIDRefreshParams().
-		WithID(clientIDPathParam(id))
+		WithID(id)
 
 	start := time.Now()
 	resp, err := c.raw.OIDc.PostAPIOidcClientsIDRefreshContext(ctx, params)
@@ -688,7 +723,7 @@ func (c *Client) RefreshOIDCClientMetadata(ctx context.Context, id string) (*OID
 
 func (c *Client) DeleteOIDCClient(ctx context.Context, id string) error {
 	params := oidc.NewDeleteAPIOidcClientsIDParams().
-		WithID(clientIDPathParam(id))
+		WithID(id)
 
 	start := time.Now()
 	_, err := c.raw.OIDc.DeleteAPIOidcClientsIDContext(ctx, params)
@@ -713,7 +748,7 @@ func (c *Client) UpdateOIDCClientAllowedGroups(ctx context.Context, id string, g
 			}
 		}
 		params := oidc.NewPutAPIOidcClientsIDAllowedUserGroupsParams().
-			WithID(clientIDPathParam(id)).
+			WithID(id).
 			WithGroups(&models.GithubComPocketIDPocketIDBackendInternalDtoOidcUpdateAllowedUserGroupsDto{
 				UserGroupIds: groupIDs,
 			})
@@ -751,7 +786,7 @@ func (c *Client) SetOIDCClientSecret(ctx context.Context, id, secret string) (st
 // payload lets Pocket-ID generate one; a non-nil payload requests a specific value.
 func (c *Client) postOIDCClientSecret(ctx context.Context, operation, id string, payload *models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientSecretDto) (string, error) {
 	params := oidc.NewPostAPIOidcClientsIDSecretParams().
-		WithID(clientIDPathParam(id))
+		WithID(id)
 	if payload != nil {
 		params = params.WithPayload(payload)
 	}
@@ -783,7 +818,7 @@ func (c *Client) postOIDCClientSecret(ctx context.Context, operation, id string,
 // Returns nil, nil if no SCIM service provider is configured (404).
 func (c *Client) GetOIDCClientSCIMServiceProvider(ctx context.Context, oidcClientID string) (*SCIMServiceProvider, error) {
 	params := oidc.NewGetAPIOidcClientsIDScimServiceProviderParams().
-		WithID(clientIDPathParam(oidcClientID))
+		WithID(oidcClientID)
 
 	start := time.Now()
 	resp, err := c.raw.OIDc.GetAPIOidcClientsIDScimServiceProviderContext(ctx, params)

--- a/internal/pocketid/client.go
+++ b/internal/pocketid/client.go
@@ -3,9 +3,11 @@ package pocketid
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-openapi/runtime"
@@ -81,6 +83,37 @@ type OIDCClient struct {
 	AccessTokenDurationMinutes          int64
 	RefreshTokenDurationMinutes         int64
 	AllowedUserGroupIDs                 []string
+	// ClientType is "standard" or "cimd". Read-only; Pocket-ID sets it at registration.
+	ClientType string
+}
+
+// ClientTypeCIMD marks a client synthesized from an OAuth Client ID Metadata Document.
+// Its ID is the https URL of that document, and Pocket-ID persists only a subset of
+// columns on an admin update, leaving the rest to the metadata refresh.
+const ClientTypeCIMD = "cimd"
+
+// IsCIMD reports whether the client is backed by an OAuth Client ID Metadata Document.
+func (c *OIDCClient) IsCIMD() bool {
+	return c.ClientType == ClientTypeCIMD
+}
+
+// LooksLikeCIMDID reports whether a client ID is a metadata document URL. Pocket-ID
+// restricts registered client IDs to [a-zA-Z0-9._-]+, so "://" can only come from one.
+// Unlike IsCIMD this needs no API round trip, which is what makes it usable for admission
+// validation and before a client has been resolved.
+func LooksLikeCIMDID(id string) bool {
+	return strings.Contains(id, "://")
+}
+
+// clientIDPathParam encodes a client ID for use as a URL path parameter. A CIMD client ID
+// is a full https URL whose slashes cannot survive a single path segment, so Pocket-ID
+// accepts it base64url-encoded behind a "~" prefix and decodes it in middleware. Ordinary
+// client IDs are passed through untouched.
+func clientIDPathParam(id string) string {
+	if !LooksLikeCIMDID(id) {
+		return id
+	}
+	return "~" + base64.RawURLEncoding.EncodeToString([]byte(id))
 }
 
 // ToInput converts an OIDCClient into an OIDCClientInput for comparison with desired state.
@@ -590,7 +623,7 @@ func (c *Client) CreateOIDCClient(ctx context.Context, input OIDCClientInput) (*
 
 func (c *Client) UpdateOIDCClient(ctx context.Context, id string, input OIDCClientInput) (*OIDCClient, error) {
 	params := oidc.NewPutAPIOidcClientsIDParams().
-		WithID(id).
+		WithID(clientIDPathParam(id)).
 		WithClient(&models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientUpdateDto{
 			Name:                                &input.Name,
 			Description:                         input.Description,
@@ -624,7 +657,7 @@ func (c *Client) UpdateOIDCClient(ctx context.Context, id string, input OIDCClie
 
 func (c *Client) GetOIDCClient(ctx context.Context, id string) (*OIDCClient, error) {
 	params := oidc.NewGetAPIOidcClientsIDParams().
-		WithID(id)
+		WithID(clientIDPathParam(id))
 
 	start := time.Now()
 	resp, err := c.raw.OIDc.GetAPIOidcClientsIDContext(ctx, params)
@@ -636,9 +669,26 @@ func (c *Client) GetOIDCClient(ctx context.Context, id string) (*OIDCClient, err
 	return oidcClientFromAllowedGroupsDTO(resp.Payload), nil
 }
 
+// RefreshOIDCClientMetadata forces a re-fetch of a CIMD client's metadata document,
+// bypassing the cache TTL, and returns the refreshed client. Pocket-ID rejects the
+// call for standard clients and when no CIMD allowlist is configured.
+func (c *Client) RefreshOIDCClientMetadata(ctx context.Context, id string) (*OIDCClient, error) {
+	params := oidc.NewPostAPIOidcClientsIDRefreshParams().
+		WithID(clientIDPathParam(id))
+
+	start := time.Now()
+	resp, err := c.raw.OIDc.PostAPIOidcClientsIDRefreshContext(ctx, params)
+	recordCall("refresh_oidc_client_metadata", err, time.Since(start))
+	if err != nil {
+		return nil, fmt.Errorf("refresh OIDC client metadata failed: %w", err)
+	}
+
+	return oidcClientFromAllowedGroupsDTO(resp.Payload), nil
+}
+
 func (c *Client) DeleteOIDCClient(ctx context.Context, id string) error {
 	params := oidc.NewDeleteAPIOidcClientsIDParams().
-		WithID(id)
+		WithID(clientIDPathParam(id))
 
 	start := time.Now()
 	_, err := c.raw.OIDc.DeleteAPIOidcClientsIDContext(ctx, params)
@@ -663,7 +713,7 @@ func (c *Client) UpdateOIDCClientAllowedGroups(ctx context.Context, id string, g
 			}
 		}
 		params := oidc.NewPutAPIOidcClientsIDAllowedUserGroupsParams().
-			WithID(id).
+			WithID(clientIDPathParam(id)).
 			WithGroups(&models.GithubComPocketIDPocketIDBackendInternalDtoOidcUpdateAllowedUserGroupsDto{
 				UserGroupIds: groupIDs,
 			})
@@ -701,7 +751,7 @@ func (c *Client) SetOIDCClientSecret(ctx context.Context, id, secret string) (st
 // payload lets Pocket-ID generate one; a non-nil payload requests a specific value.
 func (c *Client) postOIDCClientSecret(ctx context.Context, operation, id string, payload *models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientSecretDto) (string, error) {
 	params := oidc.NewPostAPIOidcClientsIDSecretParams().
-		WithID(id)
+		WithID(clientIDPathParam(id))
 	if payload != nil {
 		params = params.WithPayload(payload)
 	}
@@ -733,7 +783,7 @@ func (c *Client) postOIDCClientSecret(ctx context.Context, operation, id string,
 // Returns nil, nil if no SCIM service provider is configured (404).
 func (c *Client) GetOIDCClientSCIMServiceProvider(ctx context.Context, oidcClientID string) (*SCIMServiceProvider, error) {
 	params := oidc.NewGetAPIOidcClientsIDScimServiceProviderParams().
-		WithID(oidcClientID)
+		WithID(clientIDPathParam(oidcClientID))
 
 	start := time.Now()
 	resp, err := c.raw.OIDc.GetAPIOidcClientsIDScimServiceProviderContext(ctx, params)
@@ -1227,6 +1277,7 @@ func oidcClientFromListDTO(dto *models.GithubComPocketIDPocketIDBackendInternalD
 		AccessTokenDurationMinutes:          dto.AccessTokenDurationMinutes,
 		RefreshTokenDurationMinutes:         dto.RefreshTokenDurationMinutes,
 		AllowedUserGroupIDs:                 []string{},
+		ClientType:                          dto.ClientType,
 	}
 }
 
@@ -1260,6 +1311,7 @@ func oidcClientFromAllowedGroupsDTO(dto *models.GithubComPocketIDPocketIDBackend
 		AccessTokenDurationMinutes:          dto.AccessTokenDurationMinutes,
 		RefreshTokenDurationMinutes:         dto.RefreshTokenDurationMinutes,
 		AllowedUserGroupIDs:                 groupIDs,
+		ClientType:                          dto.ClientType,
 	}
 }
 

--- a/internal/pocketid/client_test.go
+++ b/internal/pocketid/client_test.go
@@ -66,8 +66,8 @@ func TestGetOIDCClient_ReadsTokenDurations(t *testing.T) {
 	}
 }
 
-// clientType drives the operator's refusal to manage CIMD clients, so both read paths
-// used for adoption have to carry it through.
+// clientType decides which fields the operator may push, so both read paths used for
+// adoption have to carry it through.
 func TestOIDCClientReads_CarryClientType(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -130,8 +130,24 @@ func TestClientIDPathParam_EncodesMetadataDocumentURLs(t *testing.T) {
 	if got := clientIDPathParam("grafana"); got != "grafana" {
 		t.Errorf("an ordinary client ID must pass through untouched, got %q", got)
 	}
-	if !LooksLikeCIMDID(metadataURL) || LooksLikeCIMDID("grafana") {
-		t.Error("LooksLikeCIMDID should key on the scheme separator")
+}
+
+// LooksLikeCIMDID has to agree with the CRD's CEL rules and upstream's
+// fosite.LooksLikeCIMDURL, both of which require the https scheme. A looser test (any
+// "://") would route a mistyped "http://" client ID down the adopt-only path, where it
+// waits forever for a client Pocket-ID will never materialize, while admission had already
+// waved through the metadata-owned fields the CEL rules exist to reject.
+func TestLooksLikeCIMDID_RequiresHTTPSScheme(t *testing.T) {
+	for id, want := range map[string]bool{
+		"https://apps.example.com/myapp/client-metadata.json": true,
+		"http://apps.example.com/myapp/client-metadata.json":  false,
+		"ftp://apps.example.com/meta.json":                    false,
+		"grafana":                                             false,
+		"my-client.id_2":                                      false,
+	} {
+		if got := LooksLikeCIMDID(id); got != want {
+			t.Errorf("LooksLikeCIMDID(%q) = %v, want %v", id, got, want)
+		}
 	}
 }
 
@@ -187,7 +203,7 @@ func TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs(t *testing.T)
 	if _, err := client.GetOIDCClient(ctx, metadataURL); err != nil {
 		t.Errorf("GetOIDCClient: %v", err)
 	}
-	if _, err := client.RefreshOIDCClientMetadata(ctx, metadataURL); err != nil {
+	if err := client.RefreshOIDCClientMetadata(ctx, metadataURL); err != nil {
 		t.Errorf("RefreshOIDCClientMetadata: %v", err)
 	}
 	if _, err := client.UpdateOIDCClient(ctx, metadataURL, OIDCClientInput{Name: "My App"}); err != nil {
@@ -252,15 +268,11 @@ func TestRefreshOIDCClientMetadata_PostsToRefreshEndpoint(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	got, err := client.RefreshOIDCClientMetadata(context.Background(), "test-id")
-	if err != nil {
+	if err := client.RefreshOIDCClientMetadata(context.Background(), "test-id"); err != nil {
 		t.Fatalf("RefreshOIDCClientMetadata: %v", err)
 	}
 	if calls != 1 {
 		t.Errorf("expected 1 call to the refresh endpoint, got %d", calls)
-	}
-	if got == nil || !got.IsCIMD() {
-		t.Errorf("expected the refreshed CIMD client to be returned, got %+v", got)
 	}
 }
 
@@ -275,7 +287,7 @@ func TestRefreshOIDCClientMetadata_PropagatesError(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	if _, err := client.RefreshOIDCClientMetadata(context.Background(), "test-id"); err == nil {
+	if err := client.RefreshOIDCClientMetadata(context.Background(), "test-id"); err == nil {
 		t.Fatal("expected an error when the refresh is rejected")
 	}
 }

--- a/internal/pocketid/client_test.go
+++ b/internal/pocketid/client_test.go
@@ -143,14 +143,26 @@ func TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs(t *testing.T)
 
 	seen := map[string]bool{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+
+		// API access lives on its own route prefix, so it needs encoding independently of
+		// the /api/oidc/clients ones.
+		if apiAccess := "/api/api-access/" + encoded; path == apiAccess {
+			seen[r.Method+" api-access"] = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clientPermissionIds": []string{}, "userDelegatedPermissionIds": []string{},
+			})
+			return
+		}
+
 		prefix := "/api/oidc/clients/" + encoded
-		if !strings.HasPrefix(r.URL.EscapedPath(), prefix) {
+		if !strings.HasPrefix(path, prefix) {
 			http.NotFound(w, r)
 			return
 		}
-		suffix := strings.TrimPrefix(r.URL.EscapedPath(), prefix)
+		suffix := strings.TrimPrefix(path, prefix)
 		seen[r.Method+" "+suffix] = true
-		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodDelete:
 			w.WriteHeader(http.StatusNoContent)
@@ -192,6 +204,15 @@ func TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs(t *testing.T)
 	if _, err := client.SetOIDCClientSecret(ctx, metadataURL, "a-declared-secret-value"); err != nil {
 		t.Errorf("SetOIDCClientSecret: %v", err)
 	}
+	// Reachable for CIMD: admission allows apiAccess.delegatedPermissions on one.
+	if _, err := client.GetClientAPIAccess(ctx, metadataURL); err != nil {
+		t.Errorf("GetClientAPIAccess: %v", err)
+	}
+	if _, err := client.UpdateClientAPIAccess(ctx, metadataURL, ClientAPIAccess{
+		UserDelegatedPermissionIDs: []string{"perm-1"},
+	}); err != nil {
+		t.Errorf("UpdateClientAPIAccess: %v", err)
+	}
 	if err := client.DeleteOIDCClient(ctx, metadataURL); err != nil {
 		t.Errorf("DeleteOIDCClient: %v", err)
 	}
@@ -199,6 +220,7 @@ func TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs(t *testing.T)
 	for _, want := range []string{
 		"GET ", "POST /refresh", "PUT ", "PUT /allowed-user-groups", "DELETE ",
 		"GET /scim-service-provider", "POST /secret",
+		"GET api-access", "PUT api-access",
 	} {
 		if !seen[want] {
 			t.Errorf("no request reached the encoded route for %q (seen: %v)", want, seen)

--- a/internal/pocketid/client_test.go
+++ b/internal/pocketid/client_test.go
@@ -2,9 +2,11 @@ package pocketid
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -21,6 +23,7 @@ type oidcClientResponse struct {
 	IsPublic           bool     `json:"isPublic"`
 	IsGroupRestricted  bool     `json:"isGroupRestricted"`
 	PkceEnabled        bool     `json:"pkceEnabled"`
+	ClientType         string   `json:"clientType"`
 	AllowedUserGroups  []any    `json:"allowedUserGroups"`
 
 	AccessTokenDurationMinutes  int64 `json:"accessTokenDurationMinutes"`
@@ -60,6 +63,181 @@ func TestGetOIDCClient_ReadsTokenDurations(t *testing.T) {
 	}
 	if got.RefreshTokenDurationMinutes != 1440 {
 		t.Errorf("RefreshTokenDurationMinutes: got %d, want 1440", got.RefreshTokenDurationMinutes)
+	}
+}
+
+// clientType drives the operator's refusal to manage CIMD clients, so both read paths
+// used for adoption have to carry it through.
+func TestOIDCClientReads_CarryClientType(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		cimd := oidcClientResponse{
+			ID:                "https://apps.example.com/meta.json",
+			Name:              "metadata-app",
+			ClientType:        ClientTypeCIMD,
+			AllowedUserGroups: []any{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/oidc/clients/test-id":
+			_ = json.NewEncoder(w).Encode(cimd)
+		case "/api/oidc/clients":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []oidcClientResponse{cimd}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	got, err := client.GetOIDCClient(context.Background(), "test-id")
+	if err != nil {
+		t.Fatalf("GetOIDCClient: %v", err)
+	}
+	if !got.IsCIMD() {
+		t.Errorf("GetOIDCClient clientType: got %q, want %q", got.ClientType, ClientTypeCIMD)
+	}
+
+	listed, err := client.ListOIDCClients(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListOIDCClients: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 listed client, got %d", len(listed))
+	}
+	if !listed[0].IsCIMD() {
+		t.Errorf("ListOIDCClients clientType: got %q, want %q", listed[0].ClientType, ClientTypeCIMD)
+	}
+}
+
+// A CIMD client ID is a full https URL. Raw, its slashes become extra path segments and
+// gin never matches the route, so Pocket-ID takes it base64url-encoded behind a "~" and
+// decodes it in middleware. Every client-ID path param has to go through that encoding.
+func TestClientIDPathParam_EncodesMetadataDocumentURLs(t *testing.T) {
+	const metadataURL = "https://apps.example.com/myapp/client-metadata.json"
+	want := "~" + base64.RawURLEncoding.EncodeToString([]byte(metadataURL))
+
+	if got := clientIDPathParam(metadataURL); got != want {
+		t.Errorf("clientIDPathParam(%q) = %q, want %q", metadataURL, got, want)
+	}
+	if got := clientIDPathParam("grafana"); got != "grafana" {
+		t.Errorf("an ordinary client ID must pass through untouched, got %q", got)
+	}
+	if !LooksLikeCIMDID(metadataURL) || LooksLikeCIMDID("grafana") {
+		t.Error("LooksLikeCIMDID should key on the scheme separator")
+	}
+}
+
+// Exercises the encoding through the real request path: the stub only answers the encoded
+// route, so a regression in any client-ID path param shows up as a 404 here.
+func TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs(t *testing.T) {
+	const metadataURL = "https://apps.example.com/myapp/client-metadata.json"
+	encoded := "~" + base64.RawURLEncoding.EncodeToString([]byte(metadataURL))
+
+	seen := map[string]bool{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		prefix := "/api/oidc/clients/" + encoded
+		if !strings.HasPrefix(r.URL.EscapedPath(), prefix) {
+			http.NotFound(w, r)
+			return
+		}
+		seen[r.Method+" "+strings.TrimPrefix(r.URL.EscapedPath(), prefix)] = true
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oidcClientResponse{
+			ID: metadataURL, Name: "My App", ClientType: ClientTypeCIMD, AllowedUserGroups: []any{},
+		})
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := context.Background()
+
+	if _, err := client.GetOIDCClient(ctx, metadataURL); err != nil {
+		t.Errorf("GetOIDCClient: %v", err)
+	}
+	if _, err := client.RefreshOIDCClientMetadata(ctx, metadataURL); err != nil {
+		t.Errorf("RefreshOIDCClientMetadata: %v", err)
+	}
+	if _, err := client.UpdateOIDCClient(ctx, metadataURL, OIDCClientInput{Name: "My App"}); err != nil {
+		t.Errorf("UpdateOIDCClient: %v", err)
+	}
+	if err := client.UpdateOIDCClientAllowedGroups(ctx, metadataURL, []string{"g1"}); err != nil {
+		t.Errorf("UpdateOIDCClientAllowedGroups: %v", err)
+	}
+	if err := client.DeleteOIDCClient(ctx, metadataURL); err != nil {
+		t.Errorf("DeleteOIDCClient: %v", err)
+	}
+
+	for _, want := range []string{"GET ", "POST /refresh", "PUT ", "PUT /allowed-user-groups", "DELETE "} {
+		if !seen[want] {
+			t.Errorf("no request reached the encoded route for %q (seen: %v)", want, seen)
+		}
+	}
+}
+
+func TestRefreshOIDCClientMetadata_PostsToRefreshEndpoint(t *testing.T) {
+	var calls int
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/oidc/clients/test-id/refresh" {
+			http.NotFound(w, r)
+			return
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oidcClientResponse{
+			ID:                "test-id",
+			Name:              "metadata-app",
+			ClientType:        ClientTypeCIMD,
+			AllowedUserGroups: []any{},
+		})
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	got, err := client.RefreshOIDCClientMetadata(context.Background(), "test-id")
+	if err != nil {
+		t.Fatalf("RefreshOIDCClientMetadata: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call to the refresh endpoint, got %d", calls)
+	}
+	if got == nil || !got.IsCIMD() {
+		t.Errorf("expected the refreshed CIMD client to be returned, got %+v", got)
+	}
+}
+
+func TestRefreshOIDCClientMetadata_PropagatesError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(ts.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, err := client.RefreshOIDCClientMetadata(context.Background(), "test-id"); err == nil {
+		t.Fatal("expected an error when the refresh is rejected")
 	}
 }
 

--- a/internal/pocketid/client_test.go
+++ b/internal/pocketid/client_test.go
@@ -148,15 +148,21 @@ func TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs(t *testing.T)
 			http.NotFound(w, r)
 			return
 		}
-		seen[r.Method+" "+strings.TrimPrefix(r.URL.EscapedPath(), prefix)] = true
-		if r.Method == http.MethodDelete {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
+		suffix := strings.TrimPrefix(r.URL.EscapedPath(), prefix)
+		seen[r.Method+" "+suffix] = true
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(oidcClientResponse{
-			ID: metadataURL, Name: "My App", ClientType: ClientTypeCIMD, AllowedUserGroups: []any{},
-		})
+		switch {
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		case suffix == "/secret":
+			_ = json.NewEncoder(w).Encode(map[string]any{"secret": "a-declared-secret-value"})
+		case suffix == "/scim-service-provider":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "scim-1", "endpoint": "https://scim.example.com"})
+		default:
+			_ = json.NewEncoder(w).Encode(oidcClientResponse{
+				ID: metadataURL, Name: "My App", ClientType: ClientTypeCIMD, AllowedUserGroups: []any{},
+			})
+		}
 	}))
 	defer ts.Close()
 
@@ -178,11 +184,22 @@ func TestOIDCClientOperations_UseEncodedPathForMetadataDocumentIDs(t *testing.T)
 	if err := client.UpdateOIDCClientAllowedGroups(ctx, metadataURL, []string{"g1"}); err != nil {
 		t.Errorf("UpdateOIDCClientAllowedGroups: %v", err)
 	}
+	// ReconcileSCIM calls this on the first reconcile of every client, SCIM spec or not,
+	// so it is on the adoption path for every CIMD client.
+	if _, err := client.GetOIDCClientSCIMServiceProvider(ctx, metadataURL); err != nil {
+		t.Errorf("GetOIDCClientSCIMServiceProvider: %v", err)
+	}
+	if _, err := client.SetOIDCClientSecret(ctx, metadataURL, "a-declared-secret-value"); err != nil {
+		t.Errorf("SetOIDCClientSecret: %v", err)
+	}
 	if err := client.DeleteOIDCClient(ctx, metadataURL); err != nil {
 		t.Errorf("DeleteOIDCClient: %v", err)
 	}
 
-	for _, want := range []string{"GET ", "POST /refresh", "PUT ", "PUT /allowed-user-groups", "DELETE "} {
+	for _, want := range []string{
+		"GET ", "POST /refresh", "PUT ", "PUT /allowed-user-groups", "DELETE ",
+		"GET /scim-service-provider", "POST /secret",
+	} {
 		if !seen[want] {
 			t.Errorf("no request reached the encoded route for %q (seen: %v)", want, seen)
 		}

--- a/test/e2e/cimd_test.go
+++ b/test/e2e/cimd_test.go
@@ -60,8 +60,12 @@ var _ = Describe("Client ID Metadata Documents", Ordered, func() {
 		waitForConditionReason("pocketidoidcclient", clientName, userNS, "Ready", "AwaitingFirstAuthorization")
 
 		By("verifying no client ID was ever assigned")
-		Expect(kubectlGet("pocketidoidcclient", clientName, userNS, "-o", "jsonpath={.status.clientID}")).To(BeEmpty(),
-			"the operator must not create a client for an unmaterialized metadata document")
+		// Asserted via the whole status, not jsonpath={.status.clientID}: kubectlGet returns
+		// "" when the command itself fails, so an empty-string assertion cannot tell an
+		// absent client ID from a broken query.
+		Expect(kubectlGet("pocketidoidcclient", clientName, "-n", userNS, "-o", "jsonpath={.status}")).
+			NotTo(ContainSubstring(`"clientID"`),
+				"the operator must not create a client for an unmaterialized metadata document")
 	})
 
 	Context("with a materialized CIMD client", Ordered, func() {
@@ -89,9 +93,9 @@ var _ = Describe("Client ID Metadata Documents", Ordered, func() {
 			waitForReady("pocketidoidcclient", clientName, userNS)
 
 			By("verifying status reports the adopted client")
-			Expect(kubectlGet("pocketidoidcclient", clientName, userNS, "-o", "jsonpath={.status.clientType}")).
+			Expect(kubectlGet("pocketidoidcclient", clientName, "-n", userNS, "-o", "jsonpath={.status.clientType}")).
 				To(Equal("cimd"))
-			Expect(kubectlGet("pocketidoidcclient", clientName, userNS, "-o", "jsonpath={.status.clientID}")).
+			Expect(kubectlGet("pocketidoidcclient", clientName, "-n", userNS, "-o", "jsonpath={.status.clientID}")).
 				To(Equal(cimdMetadataURL))
 		})
 

--- a/test/e2e/cimd_test.go
+++ b/test/e2e/cimd_test.go
@@ -1,0 +1,183 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// cimdMetadataURL is the OAuth Client ID Metadata Document this suite registers against.
+// It is served from test/e2e/testdata/cimd-client-metadata.json in this repository via
+// jsDelivr, which returns application/json (raw.githubusercontent.com returns text/plain,
+// which Pocket-ID's fetcher rejects). The document's own client_id field must match this
+// string exactly, and the shared instance allowlists it in e2e_suite_test.go.
+//
+// Pocket-ID's metadata fetcher refuses private, loopback and other special-use addresses
+// with no runtime opt-out, so the document cannot be served from inside the cluster: this
+// is why the URL is external and why the cluster needs egress to cdn.jsdelivr.net.
+const cimdMetadataURL = "https://cdn.jsdelivr.net/gh/aclerici38/pocket-id-operator@main/" +
+	"test/e2e/testdata/cimd-client-metadata.json"
+
+var _ = Describe("Client ID Metadata Documents", Ordered, func() {
+	It("advertises client_id_metadata_document_supported once the allowlist is set", func() {
+		By("reading the instance's discovery document")
+		script := fmt.Sprintf("curl -sf %s/.well-known/openid-configuration", formatInstanceURL())
+		applyYAML(createCurlPodYAML("cimd-discovery", instanceNS, script))
+		body := getPodLogs("cimd-discovery", instanceNS)
+		kubectlDelete("pod", "cimd-discovery", instanceNS)
+
+		By("verifying Pocket-ID enabled CIMD from CIMD_URL_ALLOWLIST")
+		Expect(body).To(ContainSubstring(`"client_id_metadata_document_supported":true`),
+			"spec.cimdUrlAllowlist should reach Pocket-ID as a JSON array and enable CIMD")
+	})
+
+	// Hermetic: no metadata document is fetched, because the point is that the operator
+	// waits instead of registering a standard client under the document URL.
+	It("waits for a CIMD client to be materialized instead of creating one", func() {
+		const clientName = "test-cimd-awaiting"
+
+		By("creating a PocketIDOIDCClient for a document that was never authorized against")
+		createOIDCClient(OIDCClientOptions{
+			Name:     clientName,
+			ClientID: "https://apps.example.com/never-authorized/client-metadata.json",
+		})
+		DeferCleanup(func() {
+			kubectlDelete("pocketidoidcclient", clientName, userNS)
+			waitForResourceDeleted("pocketidoidcclient", clientName, userNS)
+		})
+
+		By("verifying it reports AwaitingFirstAuthorization rather than going Ready")
+		waitForConditionReason("pocketidoidcclient", clientName, userNS, "Ready", "AwaitingFirstAuthorization")
+
+		By("verifying no client ID was ever assigned")
+		Expect(kubectlGet("pocketidoidcclient", clientName, userNS, "-o", "jsonpath={.status.clientID}")).To(BeEmpty(),
+			"the operator must not create a client for an unmaterialized metadata document")
+	})
+
+	Context("with a materialized CIMD client", Ordered, func() {
+		const clientName = "test-cimd-managed"
+
+		BeforeAll(func() {
+			By("checking the metadata document is published")
+			if !cimdDocumentReachable() {
+				Skip("metadata document is not reachable at " + cimdMetadataURL +
+					" — it is served from this repo via jsDelivr, so it only resolves once " +
+					"test/e2e/testdata/cimd-client-metadata.json is merged to main")
+			}
+
+			By("triggering materialization via the unauthenticated device authorization endpoint")
+			materializeCIMDClient()
+		})
+
+		It("adopts the client and records its type", func() {
+			By("creating a PocketIDOIDCClient that sets only the fields Pocket-ID persists for CIMD")
+			createOIDCClient(OIDCClientOptions{
+				Name:                       clientName,
+				ClientID:                   cimdMetadataURL,
+				Description:                "managed by e2e",
+				SkipConsent:                true,
+				AccessTokenDurationMinutes: 15,
+			})
+
+			By("waiting for the client to be ready")
+			waitForReady("pocketidoidcclient", clientName, userNS)
+
+			By("verifying status reports the adopted client")
+			Expect(kubectlGet("pocketidoidcclient", clientName, userNS, "-o", "jsonpath={.status.clientType}")).
+				To(Equal("cimd"))
+			Expect(kubectlGet("pocketidoidcclient", clientName, userNS, "-o", "jsonpath={.status.clientID}")).
+				To(Equal(cimdMetadataURL))
+		})
+
+		It("pushes the writable fields and leaves the metadata-owned ones alone", func() {
+			body := getOIDCClientFromPocketID("cimd-verify", userNS, encodeCIMDClientID(cimdMetadataURL))
+
+			By("verifying the fields Pocket-ID persists for a CIMD client were applied")
+			Expect(body).To(ContainSubstring(`"description":"managed by e2e"`))
+			Expect(body).To(ContainSubstring(`"skipConsent":true`))
+			Expect(body).To(ContainSubstring(`"accessTokenDurationMinutes":15`))
+
+			By("verifying the metadata document still owns name and callback URLs")
+			Expect(body).To(ContainSubstring(`"clientType":"cimd"`))
+			Expect(body).To(ContainSubstring(`"Pocket ID Operator E2E CIMD"`),
+				"the operator must not overwrite the document-supplied client_name")
+			Expect(body).To(ContainSubstring("https://cimd.example.com/callback"),
+				"the operator must not overwrite the document-supplied redirect_uris")
+		})
+
+		// The drift loop this whole design exists to prevent: the operator diffs against
+		// fields Pocket-ID discards, so it would push, read back, and push again forever.
+		It("settles instead of drifting", func() {
+			By("recording the current state and letting several reconciles pass")
+			before := getOIDCClientFromPocketID("cimd-drift-1", userNS, encodeCIMDClientID(cimdMetadataURL))
+			time.Sleep(30 * time.Second)
+			after := getOIDCClientFromPocketID("cimd-drift-2", userNS, encodeCIMDClientID(cimdMetadataURL))
+
+			Expect(after).To(Equal(before), "a managed CIMD client must reach a stable state")
+			waitForReady("pocketidoidcclient", clientName, userNS)
+		})
+
+		AfterAll(func() {
+			kubectlDelete("pocketidoidcclient", clientName, userNS)
+			waitForResourceDeleted("pocketidoidcclient", clientName, userNS)
+		})
+	})
+})
+
+// encodeCIMDClientID mirrors the operator's path-parameter encoding: a CIMD client ID is a
+// URL whose slashes cannot survive a path segment, so Pocket-ID accepts it base64url-encoded
+// behind a "~" and decodes it in middleware.
+func encodeCIMDClientID(id string) string {
+	return "~" + base64.RawURLEncoding.EncodeToString([]byte(id))
+}
+
+// cimdDocumentReachable reports whether the metadata document resolves from inside the
+// cluster with the content type and client_id Pocket-ID requires. It runs before the
+// managed-client specs so an unpublished document skips them with a clear reason instead
+// of failing as though the operator were broken.
+func cimdDocumentReachable() bool {
+	script := fmt.Sprintf(`CODE=$(curl -s -o /tmp/doc -w '%%{http_code}' -H 'Accept: application/json' %q)
+if [ "$CODE" != "200" ]; then echo "unreachable: HTTP $CODE"; exit 0; fi
+grep -q %q /tmp/doc && echo reachable || echo "unreachable: client_id mismatch"`,
+		cimdMetadataURL, cimdMetadataURL)
+
+	applyYAML(createCurlPodYAML("cimd-preflight", instanceNS, script))
+	out := getPodLogs("cimd-preflight", instanceNS)
+	kubectlDelete("pod", "cimd-preflight", instanceNS)
+	if out != "reachable" {
+		GinkgoWriter.Printf("CIMD preflight: %s\n", out)
+	}
+	return out == "reachable"
+}
+
+// materializeCIMDClient makes Pocket-ID fetch the metadata document and persist the client.
+// POST /api/oidc/device/authorize needs no session and no client authentication (a CIMD
+// client is always public), and the CIMD resolver is wired into fosite as its ClientResolver,
+// so the client is resolved on any OAuth flow rather than only a browser /authorize.
+func materializeCIMDClient() {
+	script := fmt.Sprintf(`RESPONSE=$(curl -s -w '\n%%{http_code}' -X POST \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'client_id=%s' \
+  --data-urlencode 'scope=openid' \
+  %s/api/oidc/device/authorize)
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+echo "$BODY"
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "device authorization failed with HTTP $HTTP_CODE" >&2
+  exit 1
+fi`, cimdMetadataURL, formatInstanceURL())
+
+	applyYAML(createCurlPodYAML("cimd-materialize", instanceNS, script))
+	body := getPodLogs("cimd-materialize", instanceNS)
+	kubectlDelete("pod", "cimd-materialize", instanceNS)
+
+	Expect(body).To(ContainSubstring("device_code"),
+		"the device authorization request should have resolved and materialized the CIMD client")
+}

--- a/test/e2e/cimd_test.go
+++ b/test/e2e/cimd_test.go
@@ -21,7 +21,11 @@ import (
 // Pocket-ID's metadata fetcher refuses private, loopback and other special-use addresses
 // with no runtime opt-out, so the document cannot be served from inside the cluster: this
 // is why the URL is external and why the cluster needs egress to cdn.jsdelivr.net.
-const cimdMetadataURL = "https://cdn.jsdelivr.net/gh/aclerici38/pocket-id-operator@main/" +
+//
+// TODO: swap the @cimd ref for @main before merging, here and in the client_id field of
+// test/e2e/testdata/cimd-client-metadata.json. The two must always agree, and the
+// document only resolves from the branch it is actually pushed to.
+const cimdMetadataURL = "https://cdn.jsdelivr.net/gh/aclerici38/pocket-id-operator@cimd/" +
 	"test/e2e/testdata/cimd-client-metadata.json"
 
 var _ = Describe("Client ID Metadata Documents", Ordered, func() {
@@ -65,11 +69,7 @@ var _ = Describe("Client ID Metadata Documents", Ordered, func() {
 
 		BeforeAll(func() {
 			By("checking the metadata document is published")
-			if !cimdDocumentReachable() {
-				Skip("metadata document is not reachable at " + cimdMetadataURL +
-					" — it is served from this repo via jsDelivr, so it only resolves once " +
-					"test/e2e/testdata/cimd-client-metadata.json is merged to main")
-			}
+			requireCIMDDocumentReachable()
 
 			By("triggering materialization via the unauthenticated device authorization endpoint")
 			materializeCIMDClient()
@@ -137,23 +137,26 @@ func encodeCIMDClientID(id string) string {
 	return "~" + base64.RawURLEncoding.EncodeToString([]byte(id))
 }
 
-// cimdDocumentReachable reports whether the metadata document resolves from inside the
-// cluster with the content type and client_id Pocket-ID requires. It runs before the
-// managed-client specs so an unpublished document skips them with a clear reason instead
-// of failing as though the operator were broken.
-func cimdDocumentReachable() bool {
+// requireCIMDDocumentReachable fails the suite unless the metadata document resolves from
+// inside the cluster with the content type and client_id Pocket-ID requires. It runs before
+// the managed-client specs, which are the only coverage of adoption and of the anti-drift
+// behaviour: skipping on an unreachable document would let that coverage disappear
+// silently, which is exactly how a stale branch ref goes unnoticed.
+func requireCIMDDocumentReachable() {
 	script := fmt.Sprintf(`CODE=$(curl -s -o /tmp/doc -w '%%{http_code}' -H 'Accept: application/json' %q)
-if [ "$CODE" != "200" ]; then echo "unreachable: HTTP $CODE"; exit 0; fi
-grep -q %q /tmp/doc && echo reachable || echo "unreachable: client_id mismatch"`,
+if [ "$CODE" != "200" ]; then echo "HTTP $CODE"; exit 0; fi
+grep -q %q /tmp/doc && echo reachable || echo "client_id in the document does not match its URL"`,
 		cimdMetadataURL, cimdMetadataURL)
 
 	applyYAML(createCurlPodYAML("cimd-preflight", instanceNS, script))
 	out := getPodLogs("cimd-preflight", instanceNS)
 	kubectlDelete("pod", "cimd-preflight", instanceNS)
-	if out != "reachable" {
-		GinkgoWriter.Printf("CIMD preflight: %s\n", out)
-	}
-	return out == "reachable"
+
+	Expect(out).To(Equal("reachable"),
+		"the metadata document at %s is not usable (%s).\nIt is served from this repo via "+
+			"jsDelivr, so cimdMetadataURL and the document's own client_id field must both name "+
+			"the branch the file is pushed to — see the TODO on cimdMetadataURL.",
+		cimdMetadataURL, out)
 }
 
 // materializeCIMDClient makes Pocket-ID fetch the metadata document and persist the client.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -86,7 +86,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}))
 
 	By("creating the shared e2e instance")
-	createInstance(InstanceOptions{})
+	// The CIMD allowlist is set on the shared instance rather than a dedicated one because
+	// SelectInstance rejects a selector matching more than one PocketIDInstance, so a
+	// long-lived second instance would break every client that omits instanceSelector.
+	createInstance(InstanceOptions{CIMDURLAllowlist: []string{cimdMetadataURL}})
 
 	By("waiting for the shared instance to be Ready")
 	Eventually(func(g Gomega) {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -402,8 +402,9 @@ func (o OIDCClientOptions) withDefaults() OIDCClientOptions {
 		o.Namespace = userNS
 	}
 	// A CIMD client's callback URLs come from its metadata document and are rejected in
-	// the spec, so the default must not be injected for one.
-	if len(o.CallbackURLs) == 0 && !strings.Contains(o.ClientID, "://") {
+	// the spec, so the default must not be injected for one. The https prefix is what both
+	// the CRD's CEL rules and pocketid.LooksLikeCIMDID key on.
+	if len(o.CallbackURLs) == 0 && !strings.HasPrefix(o.ClientID, "https://") {
 		o.CallbackURLs = []string{"https://example.com/callback"}
 	}
 	return o

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -34,6 +34,7 @@ type InstanceOptions struct {
 	PersistenceEnabled *bool
 	PersistenceSize    string
 	ExistingClaim      string
+	CIMDURLAllowlist   []string
 }
 
 const defaultPocketIDImage = "ghcr.io/pocket-id/pocket-id:v2.13.0-distroless@sha256:ccb590169770feb5b23ba16d49386514a2c26a77e95bb687b442ae09f17c15da"
@@ -79,6 +80,15 @@ func buildInstanceYAML(opts InstanceOptions) string {
 			persistence += fmt.Sprintf("    size: %s\n", opts.PersistenceSize)
 		}
 	}
+
+	var cimd string
+	if len(opts.CIMDURLAllowlist) > 0 {
+		cimd = "  cimdUrlAllowlist:\n"
+		for _, pattern := range opts.CIMDURLAllowlist {
+			cimd += fmt.Sprintf("  - %q\n", pattern)
+		}
+	}
+	persistence += cimd
 
 	return fmt.Sprintf(`apiVersion: pocketid.internal/v1alpha1
 kind: PocketIDInstance
@@ -391,7 +401,9 @@ func (o OIDCClientOptions) withDefaults() OIDCClientOptions {
 	if o.Namespace == "" {
 		o.Namespace = userNS
 	}
-	if len(o.CallbackURLs) == 0 {
+	// A CIMD client's callback URLs come from its metadata document and are rejected in
+	// the spec, so the default must not be injected for one.
+	if len(o.CallbackURLs) == 0 && !strings.Contains(o.ClientID, "://") {
 		o.CallbackURLs = []string{"https://example.com/callback"}
 	}
 	return o
@@ -407,7 +419,8 @@ func buildOIDCClientYAML(opts OIDCClientOptions) string {
 	}
 
 	if opts.ClientID != "" {
-		spec.WriteString(fmt.Sprintf("  clientID: %s\n", opts.ClientID))
+		// Quoted because a CIMD client ID is a URL.
+		spec.WriteString(fmt.Sprintf("  clientID: %q\n", opts.ClientID))
 	}
 
 	if opts.Description != "" {
@@ -452,9 +465,11 @@ func buildOIDCClientYAML(opts OIDCClientOptions) string {
 		}
 	}
 
-	spec.WriteString("  callbackUrls:\n")
-	for _, url := range opts.CallbackURLs {
-		spec.WriteString(fmt.Sprintf("  - %s\n", url))
+	if len(opts.CallbackURLs) > 0 {
+		spec.WriteString("  callbackUrls:\n")
+		for _, url := range opts.CallbackURLs {
+			spec.WriteString(fmt.Sprintf("  - %s\n", url))
+		}
 	}
 
 	if len(opts.LogoutCallbackURLs) > 0 {

--- a/test/e2e/testdata/cimd-client-metadata.json
+++ b/test/e2e/testdata/cimd-client-metadata.json
@@ -1,5 +1,5 @@
 {
-  "client_id": "https://cdn.jsdelivr.net/gh/aclerici38/pocket-id-operator@main/test/e2e/testdata/cimd-client-metadata.json",
+  "client_id": "https://cdn.jsdelivr.net/gh/aclerici38/pocket-id-operator@cimd/test/e2e/testdata/cimd-client-metadata.json",
   "client_name": "Pocket ID Operator E2E CIMD",
   "client_uri": "https://github.com/aclerici38/pocket-id-operator",
   "token_endpoint_auth_method": "none",

--- a/test/e2e/testdata/cimd-client-metadata.json
+++ b/test/e2e/testdata/cimd-client-metadata.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "TODO: swap the @cimd ref for @main before merging, here and in cimdMetadataURL in test/e2e/cimd_test.go. This client_id must equal the URL the document is served from.",
   "client_id": "https://cdn.jsdelivr.net/gh/aclerici38/pocket-id-operator@cimd/test/e2e/testdata/cimd-client-metadata.json",
   "client_name": "Pocket ID Operator E2E CIMD",
   "client_uri": "https://github.com/aclerici38/pocket-id-operator",

--- a/test/e2e/testdata/cimd-client-metadata.json
+++ b/test/e2e/testdata/cimd-client-metadata.json
@@ -1,0 +1,19 @@
+{
+  "client_id": "https://cdn.jsdelivr.net/gh/aclerici38/pocket-id-operator@main/test/e2e/testdata/cimd-client-metadata.json",
+  "client_name": "Pocket ID Operator E2E CIMD",
+  "client_uri": "https://github.com/aclerici38/pocket-id-operator",
+  "token_endpoint_auth_method": "none",
+  "grant_types": [
+    "authorization_code",
+    "urn:ietf:params:oauth:grant-type:device_code"
+  ],
+  "response_types": [
+    "code"
+  ],
+  "redirect_uris": [
+    "https://cimd.example.com/callback"
+  ],
+  "post_logout_redirect_uris": [
+    "https://cimd.example.com/logout"
+  ]
+}


### PR DESCRIPTION
This is kinda jank, CIMD oidcclients aren't configured through pocket-id so they cannot be deleted aside from removing the allowed url in the PocketIDInstance. In addition, only a few cosmetic fields are able to be managed. The only reason I chose to support them is for usergroup assignments, those need to reference an oidcclient custom resource and that logic is already too messy to add another element into the mix. In addition the allowed userGroups is empty by default so it makes sense to want to limit access

Closes #536 
Closes #539 
Closes #538