### PR TITLE
refactor: read the structured error codes from pocket-id

### DIFF
--- a/internal/controller/api/controller.go
+++ b/internal/controller/api/controller.go
@@ -115,7 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err != nil {
 			log.Error(err, "Failed to create or adopt API")
 			_ = r.SetReadyCondition(ctx, api, metav1.ConditionFalse, "ReconcileError", err.Error())
-			return ctrl.Result{RequeueAfter: common.Requeue}, nil
+			return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 		}
 		if requeue {
 			return ctrl.Result{Requeue: true}, nil
@@ -135,7 +135,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{Requeue: true}, nil
 		}
 		_ = r.SetReadyCondition(ctx, api, metav1.ConditionFalse, "GetError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.updateAPIStatus(ctx, api, current); err != nil {
@@ -155,7 +155,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		log.Error(err, "Failed to push API state")
 		_ = r.SetReadyCondition(ctx, api, metav1.ConditionFalse, "ReconcileError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	_ = r.SetReadyCondition(ctx, api, metav1.ConditionTrue, "Reconciled", "API is in sync")

--- a/internal/controller/common/backoff.go
+++ b/internal/controller/common/backoff.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"time"
+
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
+)
+
+// MaxRateLimitRequeue keeps an unexpected Retry-After from parking a resource indefinitely.
+const MaxRateLimitRequeue = 5 * time.Minute
+
+// RequeueAfterFor returns how long to wait before retrying a failed reconcile. A throttled
+// call waits as long as Pocket-ID asked; every other failure keeps the standard delay.
+func RequeueAfterFor(err error) time.Duration {
+	apiErr := pocketid.AsAPIError(err)
+	if apiErr == nil || !pocketid.IsRateLimitedError(err) || apiErr.RetryAfter < Requeue {
+		return Requeue
+	}
+	return min(apiErr.RetryAfter, MaxRateLimitRequeue)
+}

--- a/internal/controller/common/base_reconciler.go
+++ b/internal/controller/common/base_reconciler.go
@@ -190,11 +190,15 @@ func (r *BaseReconciler) ReconcileDeleteWithPocketID(
 		return ctrl.Result{}, err
 	}
 
-	// Delete from PocketID
+	// An object already gone from Pocket-ID is the outcome the delete wanted, so it must
+	// not hold the finalizer.
 	logger.Info("Deleting from PocketID", "statusID", statusID)
 	if err := deleteFunc(ctx, apiClient, statusID); err != nil {
-		logger.Error(err, "Failed to delete from PocketID")
-		return ctrl.Result{}, err
+		if !pocketid.IsNotFoundError(err) {
+			logger.Error(err, "Failed to delete from PocketID")
+			return ctrl.Result{}, err
+		}
+		logger.Info("Already absent from PocketID, treating delete as complete", "statusID", statusID)
 	}
 
 	// Remove finalizer

--- a/internal/controller/common/base_reconciler_test.go
+++ b/internal/controller/common/base_reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -80,7 +81,7 @@ func TestReconcileDeleteWithPocketID_TolerantOfMissingResource(t *testing.T) {
 	if !called {
 		t.Fatal("the delete never reached Pocket-ID, so this proves nothing about a 404")
 	}
-	if result.RequeueAfter != 0 || result.Requeue {
+	if result != (ctrl.Result{}) {
 		t.Errorf("result: got %+v, want no requeue", result)
 	}
 

--- a/internal/controller/common/base_reconciler_test.go
+++ b/internal/controller/common/base_reconciler_test.go
@@ -1,0 +1,153 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	runtimeclient "github.com/go-openapi/runtime"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
+)
+
+const testFinalizer = "pocketid.internal/test-finalizer"
+
+func deleteScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	if err := pocketidinternalv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add pocketid to scheme: %v", err)
+	}
+	return scheme
+}
+
+// deletingUserGroup is mid-deletion, still carrying the finalizer and a Pocket-ID ID.
+func deletingUserGroup() *pocketidinternalv1alpha1.PocketIDUserGroup {
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "group",
+			Namespace:  "pocket-id",
+			Finalizers: []string{testFinalizer},
+		},
+	}
+	group.Status.GroupID = "group-id"
+	return group
+}
+
+// deleteReconciler wires a reconciler against a fake cluster holding the resource, one
+// external instance, and the Secret its API key comes from.
+func deleteReconciler(t *testing.T, obj client.Object) (*BaseReconciler, client.Client) {
+	t.Helper()
+	instance := externalInstance("admin-token", "token")
+	secret := apiKeySecret("pocket-id", "admin-token", "token", "key")
+
+	k8s := fake.NewClientBuilder().
+		WithScheme(deleteScheme(t)).
+		WithObjects(obj, instance, secret).
+		Build()
+
+	return &BaseReconciler{Client: k8s, APIReader: k8s}, k8s
+}
+
+// A resource whose Pocket-ID counterpart is already gone must still finish terminating.
+func TestReconcileDeleteWithPocketID_TolerantOfMissingResource(t *testing.T) {
+	group := deletingUserGroup()
+	reconciler, k8s := deleteReconciler(t, group)
+
+	notFound := runtimeclient.NewAPIError("DeleteAPIUserGroupsID", nil, http.StatusNotFound)
+	called := false
+	result, err := reconciler.ReconcileDeleteWithPocketID(
+		context.Background(), group, group.Status.GroupID, nil, testFinalizer,
+		func(context.Context, *pocketid.Client, string) error {
+			called = true
+			return notFound
+		},
+	)
+	if err != nil {
+		t.Fatalf("ReconcileDeleteWithPocketID: %v", err)
+	}
+	if !called {
+		t.Fatal("the delete never reached Pocket-ID, so this proves nothing about a 404")
+	}
+	if result.RequeueAfter != 0 || result.Requeue {
+		t.Errorf("result: got %+v, want no requeue", result)
+	}
+
+	stored := &pocketidinternalv1alpha1.PocketIDUserGroup{}
+	if err := k8s.Get(context.Background(), client.ObjectKeyFromObject(group), stored); err != nil {
+		t.Fatalf("get user group: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(stored, testFinalizer) {
+		t.Error("finalizer still present after deleting an already-absent resource")
+	}
+}
+
+// Any other failure keeps the finalizer, or the object is left behind in Pocket-ID.
+func TestReconcileDeleteWithPocketID_KeepsFinalizerOnRealFailure(t *testing.T) {
+	group := deletingUserGroup()
+	reconciler, k8s := deleteReconciler(t, group)
+
+	serverError := runtimeclient.NewAPIError("DeleteAPIUserGroupsID", nil, http.StatusInternalServerError)
+	_, err := reconciler.ReconcileDeleteWithPocketID(
+		context.Background(), group, group.Status.GroupID, nil, testFinalizer,
+		func(context.Context, *pocketid.Client, string) error { return serverError },
+	)
+	if err == nil {
+		t.Fatal("ReconcileDeleteWithPocketID: expected the delete failure to surface")
+	}
+
+	stored := &pocketidinternalv1alpha1.PocketIDUserGroup{}
+	if err := k8s.Get(context.Background(), client.ObjectKeyFromObject(group), stored); err != nil {
+		t.Fatalf("get user group: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(stored, testFinalizer) {
+		t.Error("finalizer removed even though the delete failed")
+	}
+}
+
+func TestRequeueAfterFor(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "plain failure", err: errors.New("boom"), want: "standard"},
+		{name: "not found", err: runtimeclient.NewAPIError("op", nil, http.StatusNotFound), want: "standard"},
+		{name: "throttled without a delay", err: runtimeclient.NewAPIError("op", nil, http.StatusTooManyRequests), want: "standard"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RequeueAfterFor(test.err); got != Requeue {
+				t.Errorf("RequeueAfterFor: got %v, want %v", got, Requeue)
+			}
+		})
+	}
+}
+
+// A Retry-After above the standard delay is honored, and an excessive one is capped.
+func TestRequeueAfterFor_HonorsRetryAfter(t *testing.T) {
+	throttled := &pocketid.APIError{
+		StatusCode: http.StatusTooManyRequests,
+		Code:       "rate_limited",
+		RetryAfter: 30 * Requeue,
+	}
+	if got := RequeueAfterFor(throttled); got != 30*Requeue {
+		t.Errorf("RequeueAfterFor: got %v, want %v", got, 30*Requeue)
+	}
+
+	throttled.RetryAfter = 2 * MaxRateLimitRequeue
+	if got := RequeueAfterFor(throttled); got != MaxRateLimitRequeue {
+		t.Errorf("RequeueAfterFor: got %v, want the cap %v", got, MaxRateLimitRequeue)
+	}
+}

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -163,7 +163,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := r.refreshClientMetadata(ctx, oidcClient, apiClient); err != nil {
 		log.Error(err, "Failed to refresh client metadata document")
 		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "MetadataRefreshError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	// No client ID yet, create or adopt
@@ -179,7 +179,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err != nil {
 			log.Error(err, "Failed to create or adopt OIDC client")
 			_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, reconcileErrorReason(err), err.Error())
-			return ctrl.Result{RequeueAfter: common.Requeue}, nil
+			return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 		}
 		if requeue {
 			return ctrl.Result{Requeue: true}, nil
@@ -199,7 +199,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{Requeue: true}, nil
 		}
 		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "GetError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.UpdateOIDCClientStatus(ctx, oidcClient, current); err != nil {
@@ -223,31 +223,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		log.Error(err, "Failed to push OIDC client state")
 		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, reconcileErrorReason(err), err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.ReconcileSCIM(ctx, oidcClient, apiClient); err != nil {
 		log.Error(err, "Failed to reconcile SCIM service provider")
 		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "SCIMReconcileError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.ReconcileAPIAccess(ctx, oidcClient, apiClient); err != nil {
 		log.Error(err, "Failed to reconcile API access")
 		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "APIAccessReconcileError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.SyncDeclaredClientSecret(ctx, oidcClient, apiClient, current.Secrets); err != nil {
 		log.Error(err, "Failed to sync declared client secret")
 		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "ClientSecretSyncError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.ReconcileSecret(ctx, oidcClient, instance, apiClient, current.Secrets); err != nil {
 		log.Error(err, "Failed to reconcile OIDC client secret")
 		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionFalse, "SecretReconcileError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if removed, err := helpers.CheckAndRemoveAnnotation(ctx, r.Client, oidcClient, regenerateClientSecretAnnotation, "true"); err != nil {

--- a/internal/controller/user/controller.go
+++ b/internal/controller/user/controller.go
@@ -128,7 +128,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err != nil {
 			log.Error(err, "Failed to create or adopt user")
 			_ = r.SetReadyCondition(ctx, user, metav1.ConditionFalse, "ReconcileError", err.Error())
-			return ctrl.Result{RequeueAfter: common.Requeue}, nil
+			return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 		}
 		if requeue {
 			return ctrl.Result{Requeue: true}, nil
@@ -148,7 +148,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{Requeue: true}, nil
 		}
 		_ = r.SetReadyCondition(ctx, user, metav1.ConditionFalse, "GetError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.updateUserStatus(ctx, user, pUser); err != nil {
@@ -168,18 +168,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		log.Error(err, "Failed to push user state")
 		_ = r.SetReadyCondition(ctx, user, metav1.ConditionFalse, "ReconcileError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.reconcileAPIKeys(ctx, user, apiClient, instance.Namespace, instance.Name); err != nil {
 		log.Error(err, "Failed to reconcile API keys")
 		_ = r.SetReadyCondition(ctx, user, metav1.ConditionFalse, "APIKeyError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.createOneTimeToken(ctx, user, apiClient, instance); err != nil {
 		log.Error(err, "Failed to create one-time login token")
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	cleanupResult, err := r.cleanupOneTimeToken(ctx, user)
@@ -301,11 +301,16 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, user *pocketidinternal
 				return ctrl.Result{}, err
 			}
 			log.Info("Deleting user from Pocket-ID", "userID", user.Status.UserID)
+			// A user already gone from Pocket-ID must not hold the finalizer.
 			if err := apiClient.DeleteUser(ctx, user.Status.UserID); err != nil {
-				log.Error(err, "Failed to delete user from Pocket-ID")
-				return ctrl.Result{}, err
+				if !pocketid.IsNotFoundError(err) {
+					log.Error(err, "Failed to delete user from Pocket-ID")
+					return ctrl.Result{}, err
+				}
+				log.Info("User already absent from Pocket-ID, treating delete as complete", "userID", user.Status.UserID)
+			} else {
+				metrics.ResourceOperations.WithLabelValues("PocketIDUser", "deleted").Inc()
 			}
-			metrics.ResourceOperations.WithLabelValues("PocketIDUser", "deleted").Inc()
 		}
 	} else if user.Status.UserID != "" {
 		log.Info("Skipping Pocket-ID user deletion (annotation not set)", "userID", user.Status.UserID, "annotation", DeleteFromPocketIDAnnotation)

--- a/internal/controller/user/finalizer_test.go
+++ b/internal/controller/user/finalizer_test.go
@@ -2,6 +2,8 @@ package user
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -458,6 +460,84 @@ func TestReconcileDelete_AttemptsPocketIDDeletionWithAnnotation(t *testing.T) {
 			t.Fatalf("expected finalizer to be removed, got %v", updatedUser.Finalizers)
 		}
 	} else if !errors.IsNotFound(err) {
+		t.Fatalf("failed to get updated user: %v", err)
+	}
+}
+
+// deletedInPocketIDServer answers the way pocket-id does for something already gone.
+func deletedInPocketIDServer(t *testing.T, calls *int) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-ID", "req-gone")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"User not found","code":"user_not_found","request_id":"req-gone"}`))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// Deleting the user in Pocket-ID first and the resource second must not wedge the
+// finalizer.
+func TestReconcileDelete_UserAlreadyDeletedInPocketID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	calls := 0
+	ts := deletedInPocketIDServer(t, &calls)
+
+	now := metav1.NewTime(time.Now())
+	user := &pocketidinternalv1alpha1.PocketIDUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "auth-user",
+			Namespace:         "default",
+			Finalizers:        []string{UserFinalizer},
+			DeletionTimestamp: &now,
+			Annotations:       map[string]string{DeleteFromPocketIDAnnotation: "true"},
+		},
+	}
+	user.Status.UserID = "already-gone"
+
+	instance := &pocketidinternalv1alpha1.PocketIDInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: "default"},
+		Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+			External: &pocketidinternalv1alpha1.ExternalInstanceConfig{
+				URL: ts.URL,
+				APIKeySecretRef: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "admin-token"},
+					Key:                  "token",
+				},
+			},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-token", Namespace: "default"},
+		Data:       map[string][]byte{"token": []byte("key")},
+	}
+
+	k8s := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user, instance, secret).
+		Build()
+
+	reconciler := &Reconciler{Client: k8s, APIReader: k8s, Scheme: scheme}
+	if _, err := reconciler.ReconcileDelete(context.Background(), user); err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+	if calls == 0 {
+		t.Fatal("the delete never reached Pocket-ID, so this proves nothing about a 404")
+	}
+
+	updatedUser := &pocketidinternalv1alpha1.PocketIDUser{}
+	err := k8s.Get(context.Background(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, updatedUser)
+	switch {
+	case err == nil:
+		if containsFinalizer(updatedUser.Finalizers, UserFinalizer) {
+			t.Fatalf("finalizer still present after the user was already gone: %v", updatedUser.Finalizers)
+		}
+	case !errors.IsNotFound(err):
 		t.Fatalf("failed to get updated user: %v", err)
 	}
 }

--- a/internal/controller/usergroup/controller.go
+++ b/internal/controller/usergroup/controller.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err != nil {
 			log.Error(err, "Failed to create or adopt user group")
 			_ = r.SetReadyCondition(ctx, userGroup, metav1.ConditionFalse, "ReconcileError", err.Error())
-			return ctrl.Result{RequeueAfter: common.Requeue}, nil
+			return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 		}
 		if requeue {
 			return ctrl.Result{Requeue: true}, nil
@@ -138,7 +138,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{Requeue: true}, nil
 		}
 		_ = r.SetReadyCondition(ctx, userGroup, metav1.ConditionFalse, "GetError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	if err := r.updateUserGroupStatus(ctx, userGroup, current); err != nil {
@@ -158,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		log.Error(err, "Failed to push user group state")
 		_ = r.SetReadyCondition(ctx, userGroup, metav1.ConditionFalse, "ReconcileError", err.Error())
-		return ctrl.Result{RequeueAfter: common.Requeue}, nil
+		return ctrl.Result{RequeueAfter: common.RequeueAfterFor(err)}, nil
 	}
 
 	_ = r.SetReadyCondition(ctx, userGroup, metav1.ConditionTrue, "Reconciled", "User group is in sync")

--- a/internal/pocketid/client.go
+++ b/internal/pocketid/client.go
@@ -400,7 +400,7 @@ func NewClient(baseURL string, apiKey string, opts ...ClientOption) (*Client, er
 		opt(c)
 	}
 
-	transport := httptransport.NewWithClient(parsed.Host, "/", []string{parsed.Scheme}, c.httpClient)
+	transport := httptransport.NewWithClient(parsed.Host, "/", []string{parsed.Scheme}, errorCapturingClient(c.httpClient))
 
 	if apiKey != "" {
 		transport.DefaultAuthentication = runtime.ClientAuthInfoWriterFunc(
@@ -410,15 +410,30 @@ func NewClient(baseURL string, apiKey string, opts ...ClientOption) (*Client, er
 		)
 	}
 
-	// Every operation declares a default error response, so go-swagger deserializes
-	// error bodies instead of just recording the status code.
+	// Drain non-JSON bodies rather than letting go-swagger lose the status code behind a
+	// decode error.
 	for _, mime := range []string{runtime.TextMime, runtime.HTMLMime, runtime.DefaultMime} {
 		transport.Consumers[mime] = discardingConsumer{}
 	}
 
-	c.raw = apiclient.New(transport, strfmt.Default)
+	c.raw = apiclient.New(&classifyingTransport{inner: transport}, strfmt.Default)
 
 	return c, nil
+}
+
+// errorCapturingClient copies base so its round trips keep failed responses long enough
+// to classify. A nil base yields the client go-openapi would have built itself.
+func errorCapturingClient(base *http.Client) *http.Client {
+	var httpClient http.Client
+	if base != nil {
+		httpClient = *base
+	}
+	next := httpClient.Transport
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	httpClient.Transport = &errorCapturingTransport{next: next}
+	return &httpClient
 }
 
 // discardingConsumer drains a response body without decoding it, so the surrounding

--- a/internal/pocketid/errors.go
+++ b/internal/pocketid/errors.go
@@ -3,35 +3,130 @@ package pocketid
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
+	"strings"
+	"time"
 
 	"github.com/go-openapi/runtime"
+
+	"github.com/aclerici38/pocket-id-go-client/v2/models"
 )
 
-// hasStatus reports whether err carries one of the given HTTP status codes. Operations that
-// declare a default response yield a generated per-operation error type rather than
-// runtime.APIError; ClientResponseStatus is the interface both satisfy.
-func hasStatus(err error, codes ...int) bool {
-	var status runtime.ClientResponseStatus
-	if !errors.As(err, &status) {
-		return false
+// APIError is a failed Pocket-ID call carrying the structured error envelope:
+//
+//	{"error": "...", "code": "already_in_use", "details": {...}, "request_id": "..."}
+type APIError struct {
+	Operation  string
+	StatusCode int
+	// Code is empty when something other than Pocket-ID answered — a proxy, an ingress
+	// controller — and classification falls back to StatusCode.
+	Code    models.ApperrorCode
+	Message string
+	// RequestID matches the entry in Pocket-ID's own logs.
+	RequestID string
+	// Details is the envelope's extra context, e.g. {"property": "email"}.
+	Details map[string]any
+	// RetryAfter is set only on rate-limited responses.
+	RetryAfter time.Duration
+
+	// err is kept so errors.As still finds the generated response types underneath.
+	err error
+}
+
+// Error renders as "[PostAPIOidcClients] status 409: Client ID is already in use
+// (code client_id_already_exists, request_id req-42)". The request ID goes in the message
+// so it reaches both the operator's logs and the resource's Ready condition.
+func (e *APIError) Error() string {
+	message := e.Message
+	if message == "" && e.err != nil {
+		message = e.err.Error()
 	}
-	return slices.ContainsFunc(codes, status.IsCode)
+
+	var attrs []string
+	if e.Code != "" {
+		attrs = append(attrs, "code "+string(e.Code))
+	}
+	if e.RequestID != "" {
+		attrs = append(attrs, "request_id "+e.RequestID)
+	}
+
+	text := fmt.Sprintf("[%s] status %d: %s", e.Operation, e.StatusCode, message)
+	if len(attrs) > 0 {
+		text += " (" + strings.Join(attrs, ", ") + ")"
+	}
+	return text
 }
 
-// IsNotFoundError returns true if the error indicates the resource was not found (HTTP 404).
+func (e *APIError) Unwrap() error { return e.err }
+
+// AsAPIError returns the *APIError in err's chain, or nil if the call never got a response.
+func AsAPIError(err error) *APIError {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr
+	}
+	return nil
+}
+
+// classify reports whether err carries one of codes. A code is authoritative: if one is
+// present and not in the list the answer is no, whatever the status says. Only an
+// envelope-less failure falls back to fallbackStatuses.
+func classify(err error, codes []models.ApperrorCode, fallbackStatuses ...int) bool {
+	if apiErr := AsAPIError(err); apiErr != nil && apiErr.Code != "" {
+		return slices.Contains(codes, apiErr.Code)
+	}
+	var status runtime.ClientResponseStatus
+	return errors.As(err, &status) && slices.ContainsFunc(fallbackStatuses, status.IsCode)
+}
+
+// setup_not_available also answers 404, but means the setup endpoint is closed rather than
+// a managed resource missing.
+var notFoundCodes = []models.ApperrorCode{
+	models.ApperrorCodeNotFound,
+	models.ApperrorCodeUserNotFound,
+	models.ApperrorCodeAPIKeyNotFound,
+	models.ApperrorCodeImageNotFound,
+}
+
+var alreadyExistsCodes = []models.ApperrorCode{
+	models.ApperrorCodeAlreadyInUse,
+	models.ApperrorCodeClientIDAlreadyExists,
+}
+
+var validationCodes = []models.ApperrorCode{
+	models.ApperrorCodeValidationFailed,
+	models.ApperrorCodeInvalidRequestBody,
+	models.ApperrorCodeOidcInvalidCallbackURL,
+	models.ApperrorCodeReservedClaim,
+	models.ApperrorCodeDuplicateClaim,
+	models.ApperrorCodeInvalidAPIKeyExpiration,
+}
+
 func IsNotFoundError(err error) bool {
-	return hasStatus(err, http.StatusNotFound)
+	return classify(err, notFoundCodes, http.StatusNotFound)
 }
 
-// IsServerError returns true if the error is an HTTP 500 internal server error.
 func IsServerError(err error) bool {
-	return hasStatus(err, http.StatusInternalServerError)
+	return classify(err, []models.ApperrorCode{models.ApperrorCodeInternalError}, http.StatusInternalServerError)
 }
 
-// IsAlreadyExistsError returns true if the error indicates the resource already exists (HTTP 400 or 409).
-// Pocket-ID returns HTTP 400 with "already in use" or "already exists" messages for duplicate resources.
+// IsAlreadyExistsError reports a uniqueness conflict. The status fallback is 409 only: a
+// bare 400 is a validation failure, and adopting an existing resource in response to one
+// would hide a bad callback URL or an out-of-range token duration.
 func IsAlreadyExistsError(err error) bool {
-	return hasStatus(err, http.StatusBadRequest, http.StatusConflict)
+	return classify(err, alreadyExistsCodes, http.StatusConflict)
+}
+
+// IsValidationError reports a request Pocket-ID rejected on its contents. Retrying is
+// pointless until the resource spec changes.
+func IsValidationError(err error) bool {
+	return classify(err, validationCodes, http.StatusBadRequest)
+}
+
+// IsRateLimitedError pairs with AsAPIError().RetryAfter to back off for as long as
+// Pocket-ID asked.
+func IsRateLimitedError(err error) bool {
+	return classify(err, []models.ApperrorCode{models.ApperrorCodeRateLimited}, http.StatusTooManyRequests)
 }

--- a/internal/pocketid/errors_test.go
+++ b/internal/pocketid/errors_test.go
@@ -1,0 +1,245 @@
+package pocketid
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/aclerici38/pocket-id-go-client/v2/models"
+)
+
+// errorEnvelope is the JSON shape pocket-id returns for every failure.
+type errorEnvelope struct {
+	Error     string         `json:"error"`
+	Code      string         `json:"code"`
+	Details   map[string]any `json:"details,omitempty"`
+	RequestID string         `json:"request_id"`
+}
+
+// envelopeServer answers every request with the given status and envelope.
+func envelopeServer(t *testing.T, status int, envelope errorEnvelope, headers map[string]string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-ID", envelope.RequestID)
+		for name, value := range headers {
+			w.Header().Set(name, value)
+		}
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(envelope)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	client, err := NewClient(baseURL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+// Operations that declare a default response decode the envelope themselves, so the code
+// has to survive the generated response type.
+func TestAPIError_TypedDefaultResponse(t *testing.T) {
+	ts := envelopeServer(t, http.StatusConflict, errorEnvelope{
+		Error:     "Email is already in use",
+		Code:      string(models.ApperrorCodeAlreadyInUse),
+		Details:   map[string]any{"property": "email"},
+		RequestID: "req-typed",
+	}, nil)
+
+	_, err := newTestClient(t, ts.URL).CreateUser(context.Background(), UserInput{Username: "someone"})
+	if err == nil {
+		t.Fatal("CreateUser: expected an error")
+	}
+
+	apiErr := AsAPIError(err)
+	if apiErr == nil {
+		t.Fatalf("AsAPIError: got nil for %v", err)
+	}
+	if apiErr.Code != models.ApperrorCodeAlreadyInUse {
+		t.Errorf("Code: got %q, want %q", apiErr.Code, models.ApperrorCodeAlreadyInUse)
+	}
+	if apiErr.StatusCode != http.StatusConflict {
+		t.Errorf("StatusCode: got %d, want %d", apiErr.StatusCode, http.StatusConflict)
+	}
+	if apiErr.RequestID != "req-typed" {
+		t.Errorf("RequestID: got %q, want %q", apiErr.RequestID, "req-typed")
+	}
+	if apiErr.Message != "Email is already in use" {
+		t.Errorf("Message: got %q", apiErr.Message)
+	}
+	if got := apiErr.Details["property"]; got != "email" {
+		t.Errorf("Details[property]: got %v, want email", got)
+	}
+	if !IsAlreadyExistsError(err) {
+		t.Error("IsAlreadyExistsError: got false, want true")
+	}
+}
+
+// The /api/apis endpoints declare no default response, so the client discards the body and
+// hands back a bare status. The envelope has to come off the wire instead.
+func TestAPIError_UntypedResponse(t *testing.T) {
+	ts := envelopeServer(t, http.StatusNotFound, errorEnvelope{
+		Error:     "Resource not found",
+		Code:      string(models.ApperrorCodeNotFound),
+		RequestID: "req-untyped",
+	}, nil)
+
+	_, err := newTestClient(t, ts.URL).GetAPI(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("GetAPI: expected an error")
+	}
+
+	apiErr := AsAPIError(err)
+	if apiErr == nil {
+		t.Fatalf("AsAPIError: got nil for %v", err)
+	}
+	if apiErr.Code != models.ApperrorCodeNotFound {
+		t.Errorf("Code: got %q, want %q", apiErr.Code, models.ApperrorCodeNotFound)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode: got %d, want %d", apiErr.StatusCode, http.StatusNotFound)
+	}
+	if apiErr.RequestID != "req-untyped" {
+		t.Errorf("RequestID: got %q, want %q", apiErr.RequestID, "req-untyped")
+	}
+	if !IsNotFoundError(err) {
+		t.Error("IsNotFoundError: got false, want true")
+	}
+	if apiErr.Operation != "GetAPIApisID" {
+		t.Errorf("Operation: got %q, want GetAPIApisID", apiErr.Operation)
+	}
+}
+
+// A rejected callback URL or an out-of-range token duration is a 400; treating one as a
+// conflict would send it down the adopt path.
+func TestValidationFailureIsNotAConflict(t *testing.T) {
+	ts := envelopeServer(t, http.StatusBadRequest, errorEnvelope{
+		Error:     "Callback URL is invalid",
+		Code:      string(models.ApperrorCodeValidationFailed),
+		RequestID: "req-validation",
+	}, nil)
+
+	_, err := newTestClient(t, ts.URL).CreateOIDCClient(context.Background(), OIDCClientInput{Name: "app"})
+	if err == nil {
+		t.Fatal("CreateOIDCClient: expected an error")
+	}
+	if IsAlreadyExistsError(err) {
+		t.Error("IsAlreadyExistsError: got true for a validation failure, want false")
+	}
+	if !IsValidationError(err) {
+		t.Error("IsValidationError: got false, want true")
+	}
+}
+
+// Failures with no envelope classify on their status alone.
+func TestBareStatusFallback(t *testing.T) {
+	notFound := runtime.NewAPIError("op", nil, http.StatusNotFound)
+	if !IsNotFoundError(notFound) {
+		t.Error("IsNotFoundError: got false for a bare 404, want true")
+	}
+
+	conflict := runtime.NewAPIError("op", nil, http.StatusConflict)
+	if !IsAlreadyExistsError(conflict) {
+		t.Error("IsAlreadyExistsError: got false for a bare 409, want true")
+	}
+
+	badRequest := runtime.NewAPIError("op", nil, http.StatusBadRequest)
+	if IsAlreadyExistsError(badRequest) {
+		t.Error("IsAlreadyExistsError: got true for a bare 400, want false")
+	}
+
+	serverError := runtime.NewAPIError("op", nil, http.StatusInternalServerError)
+	if !IsServerError(serverError) {
+		t.Error("IsServerError: got false for a bare 500, want true")
+	}
+}
+
+// A 404 that is not a missing resource must not read as one.
+func TestCodeBeatsStatus(t *testing.T) {
+	ts := envelopeServer(t, http.StatusNotFound, errorEnvelope{
+		Error:     "Initial setup is not available",
+		Code:      string(models.ApperrorCodeSetupNotAvailable),
+		RequestID: "req-setup",
+	}, nil)
+
+	_, err := newTestClient(t, ts.URL).GetAPI(context.Background(), "whatever")
+	if err == nil {
+		t.Fatal("GetAPI: expected an error")
+	}
+	if IsNotFoundError(err) {
+		t.Error("IsNotFoundError: got true for setup_not_available, want false")
+	}
+}
+
+// Pocket-ID rate limits the whole /api group and says how long to wait.
+func TestRateLimited(t *testing.T) {
+	ts := envelopeServer(t, http.StatusTooManyRequests, errorEnvelope{
+		Error:     "Too many requests",
+		Code:      string(models.ApperrorCodeRateLimited),
+		RequestID: "req-limited",
+	}, map[string]string{"Retry-After": "7"})
+
+	_, err := newTestClient(t, ts.URL).GetUser(context.Background(), "someone")
+	if err == nil {
+		t.Fatal("GetUser: expected an error")
+	}
+	if !IsRateLimitedError(err) {
+		t.Error("IsRateLimitedError: got false, want true")
+	}
+	if delay := AsAPIError(err).RetryAfter; delay != 7*time.Second {
+		t.Errorf("RetryAfter: got %v, want 7s", delay)
+	}
+}
+
+// Something other than pocket-id answering leaves no envelope to classify on.
+func TestNonEnvelopeErrorPage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html><body>502 Bad Gateway</body></html>"))
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := newTestClient(t, ts.URL).GetUserGroup(context.Background(), "group")
+	if err == nil {
+		t.Fatal("GetUserGroup: expected an error")
+	}
+	apiErr := AsAPIError(err)
+	if apiErr == nil {
+		t.Fatalf("AsAPIError: got nil for %v", err)
+	}
+	if apiErr.Code != "" {
+		t.Errorf("Code: got %q, want empty", apiErr.Code)
+	}
+	if apiErr.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode: got %d, want %d", apiErr.StatusCode, http.StatusBadGateway)
+	}
+	if IsNotFoundError(err) || IsAlreadyExistsError(err) || IsServerError(err) {
+		t.Error("a 502 from a proxy should not classify as anything the operator acts on")
+	}
+}
+
+// The request ID has to reach the operator's logs, which read the error's message.
+func TestErrorMessageCarriesRequestID(t *testing.T) {
+	apiErr := &APIError{
+		Operation:  "PostAPIOidcClients",
+		StatusCode: http.StatusConflict,
+		Code:       models.ApperrorCodeClientIDAlreadyExists,
+		Message:    "Client ID is already in use",
+		RequestID:  "req-42",
+	}
+	want := "[PostAPIOidcClients] status 409: Client ID is already in use (code client_id_already_exists, request_id req-42)"
+	if got := apiErr.Error(); got != want {
+		t.Errorf("Error():\n got %q\nwant %q", got, want)
+	}
+}

--- a/internal/pocketid/transport.go
+++ b/internal/pocketid/transport.go
@@ -1,0 +1,110 @@
+package pocketid
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/aclerici38/pocket-id-go-client/v2/models"
+)
+
+const maxErrorBodyBytes = 64 << 10
+
+// responseCapture is what one round trip disclosed, filled in by errorCapturingTransport
+// and read by the classifyingTransport call that put it in the request context.
+type responseCapture struct {
+	statusCode int
+	header     http.Header
+	body       []byte
+}
+
+type captureContextKey struct{}
+
+// errorCapturingTransport takes failed responses off the wire as they go past. It has to
+// happen here: go-openapi closes the response body before returning the error
+// (client/runtime.go: `defer res.Body.Close()`), and the generated client discards the
+// body outright for operations whose swagger declares no default response — every
+// /api/apis and /api/api-keys endpoint.
+type errorCapturingTransport struct {
+	next http.RoundTripper
+}
+
+func (t *errorCapturingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.next.RoundTrip(req)
+	capture, ok := req.Context().Value(captureContextKey{}).(*responseCapture)
+	if err != nil || !ok {
+		return resp, err
+	}
+
+	capture.statusCode = resp.StatusCode
+	capture.header = resp.Header
+	if resp.StatusCode < http.StatusBadRequest {
+		return resp, nil
+	}
+
+	capture.body, _ = io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+	_ = resp.Body.Close()
+	// Hand the body back unread: operations that do model their error response still
+	// decode it themselves.
+	resp.Body = io.NopCloser(bytes.NewReader(capture.body))
+	return resp, nil
+}
+
+// classifyingTransport turns the generated client's errors into *APIError.
+type classifyingTransport struct {
+	inner runtime.ContextualTransport
+}
+
+func (t *classifyingTransport) Submit(operation *runtime.ClientOperation) (any, error) {
+	ctx := operation.Context //nolint:staticcheck // the generated client's non-context methods carry it here
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return t.SubmitContext(ctx, operation)
+}
+
+func (t *classifyingTransport) SubmitContext(ctx context.Context, operation *runtime.ClientOperation) (any, error) {
+	capture := &responseCapture{}
+	result, err := t.inner.SubmitContext(context.WithValue(ctx, captureContextKey{}, capture), operation)
+	// A refused connection or a DNS failure has no response to classify, and is already as
+	// descriptive as it is going to get.
+	if err == nil || capture.statusCode == 0 {
+		return result, err
+	}
+
+	// A body that is not the envelope leaves every field zero.
+	var envelope models.GithubComPocketIDPocketIDBackendInternalDtoErrorDto
+	_ = json.Unmarshal(capture.body, &envelope)
+
+	requestID := envelope.RequestID
+	if requestID == "" {
+		requestID = capture.header.Get("X-Request-ID")
+	}
+
+	return result, &APIError{
+		Operation:  operation.ID,
+		StatusCode: capture.statusCode,
+		Code:       envelope.Code,
+		Message:    envelope.Error,
+		RequestID:  requestID,
+		Details:    envelope.Details,
+		RetryAfter: parseRetryAfter(capture.header.Get("Retry-After")),
+		err:        err,
+	}
+}
+
+// parseRetryAfter reads a Retry-After header. Pocket-ID sends whole seconds, never the
+// HTTP-date form the RFC also allows.
+func parseRetryAfter(value string) time.Duration {
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}


### PR DESCRIPTION
closes #537 and #545

Use the structured error messages for better granularity/meaning than just the http response code. Also adds logic in the controllers to make decisions based on the structured lines