### PR TITLE
fix: keep resource condition ready when a delete is blocked

### DIFF
--- a/internal/controller/api/controller.go
+++ b/internal/controller/api/controller.go
@@ -378,6 +378,8 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, api *pocketidinternalv
 	}
 	if referencedByOIDCClient {
 		logf.FromContext(ctx).Info("API is referenced by PocketIDOIDCClient, blocking deletion", "api", api.Name)
+		// The resource still exists in Pocket-ID, so it must stay Ready for dependents to resolve it.
+		_ = r.SetReadyCondition(ctx, api, metav1.ConditionTrue, "DeletionBlocked", "Deletion is blocked while referenced by a PocketIDOIDCClient")
 		if _, err := helpers.EnsureFinalizer(ctx, r.Client, api, OIDCClientAPIFinalizer); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/api/deletion_blocked_test.go
+++ b/internal/controller/api/deletion_blocked_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+)
+
+// An API whose deletion is blocked still exists in Pocket-ID, so it must report
+// Ready or the OIDC clients granted access to it stop reconciling.
+func TestReconcileDelete_BlockedAPIBecomesReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	now := metav1.NewTime(time.Now())
+	api := &pocketidinternalv1alpha1.PocketIDAPI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "blocked-api",
+			Namespace:         "default",
+			Finalizers:        []string{APIFinalizer, OIDCClientAPIFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Status: pocketidinternalv1alpha1.PocketIDAPIStatus{
+			APIID: "api-id",
+			Conditions: []metav1.Condition{{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             "InstanceNotReady",
+				LastTransitionTime: now,
+			}},
+		},
+	}
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client", Namespace: "default"},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			APIAccess: []pocketidinternalv1alpha1.OIDCClientAPIAccess{
+				{APIRef: pocketidinternalv1alpha1.NamespacedAPIReference{Name: api.Name, Namespace: api.Namespace}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(api, oidcClient).
+		WithStatusSubresource(api).
+		Build()
+
+	r := &Reconciler{Client: c, APIReader: c, Scheme: scheme}
+	result, err := r.ReconcileDelete(context.Background(), api)
+	if err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue while blocked, got %s", result.RequeueAfter)
+	}
+
+	updated := &pocketidinternalv1alpha1.PocketIDAPI{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: api.Name, Namespace: api.Namespace}, updated); err != nil {
+		t.Fatalf("failed to get updated API: %v", err)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Ready=True while deletion is blocked, got %+v", ready)
+	}
+	if ready.Reason != "DeletionBlocked" {
+		t.Fatalf("expected reason DeletionBlocked, got %q", ready.Reason)
+	}
+}

--- a/internal/controller/helpers/deletion_blocked_test.go
+++ b/internal/controller/helpers/deletion_blocked_test.go
@@ -1,0 +1,52 @@
+package helpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pocketidv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+)
+
+// A group can sit terminating indefinitely while the operator refuses to delete
+// it, but it is still live in Pocket-ID. Dependents must keep resolving it, or a
+// single blocked delete takes down every OIDC client that references the group.
+func TestResolveUserGroupReferences_ResolvesBlockedDeletion(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	group := &pocketidv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "blocked-group",
+			Namespace:         "default",
+			Finalizers:        []string{"pocketid.internal/oidc-client-finalizer"},
+			DeletionTimestamp: &now,
+		},
+		Status: pocketidv1alpha1.PocketIDUserGroupStatus{
+			GroupID: "group-id",
+			Conditions: []metav1.Condition{{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "DeletionBlocked",
+				LastTransitionTime: now,
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(group).Build()
+
+	ids, err := ResolveUserGroupReferences(
+		context.Background(),
+		c,
+		&fakeUserGroupLookup{},
+		[]pocketidv1alpha1.NamespacedUserGroupReference{{Name: group.Name, Namespace: group.Namespace}},
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("expected a blocked-deletion group to resolve, got error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "group-id" {
+		t.Fatalf("expected [group-id], got %v", ids)
+	}
+}

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -1021,6 +1021,8 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, oidcClient *pocketidin
 	}
 	if referencedByUserGroup {
 		logf.FromContext(ctx).Info("OIDC client is referenced by PocketIDUserGroup, blocking deletion", "oidcClient", oidcClient.Name)
+		// The resource still exists in Pocket-ID, so it must stay Ready for dependents to resolve it.
+		_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionTrue, "DeletionBlocked", "Deletion is blocked while referenced by a PocketIDUserGroup")
 		if _, err := helpers.EnsureFinalizer(ctx, r.Client, oidcClient, UserGroupOIDCClientFinalizer); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/oidcclient/deletion_blocked_test.go
+++ b/internal/controller/oidcclient/deletion_blocked_test.go
@@ -1,0 +1,76 @@
+package oidcclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+)
+
+// An OIDC client whose deletion is blocked still exists in Pocket-ID, so it must
+// report Ready or the user groups granting access to it stop reconciling.
+func TestReconcileDelete_BlockedOIDCClientBecomesReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	now := metav1.NewTime(time.Now())
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "blocked-client",
+			Namespace:         "default",
+			Finalizers:        []string{oidcClientFinalizer, UserGroupOIDCClientFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
+			ClientID: "client-id",
+			Conditions: []metav1.Condition{{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             "InstanceNotReady",
+				LastTransitionTime: now,
+			}},
+		},
+	}
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "group", Namespace: "default"},
+		Spec: pocketidinternalv1alpha1.PocketIDUserGroupSpec{
+			AllowedOIDCClients: []pocketidinternalv1alpha1.NamespacedOIDCClientReference{
+				{Name: oidcClient.Name, Namespace: oidcClient.Namespace},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(oidcClient, group).
+		WithStatusSubresource(oidcClient).
+		Build()
+
+	r := &Reconciler{Client: c, APIReader: c, Scheme: scheme}
+	result, err := r.ReconcileDelete(context.Background(), oidcClient)
+	if err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue while blocked, got %s", result.RequeueAfter)
+	}
+
+	updated := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: oidcClient.Name, Namespace: oidcClient.Namespace}, updated); err != nil {
+		t.Fatalf("failed to get updated OIDC client: %v", err)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Ready=True while deletion is blocked, got %+v", ready)
+	}
+	if ready.Reason != "DeletionBlocked" {
+		t.Fatalf("expected reason DeletionBlocked, got %q", ready.Reason)
+	}
+}

--- a/internal/controller/user/controller.go
+++ b/internal/controller/user/controller.go
@@ -252,6 +252,7 @@ func userGroupHasUserRef(group *pocketidinternalv1alpha1.PocketIDUserGroup, user
 // ReconcileDelete handles user deletion
 func (r *Reconciler) ReconcileDelete(ctx context.Context, user *pocketidinternalv1alpha1.PocketIDUser) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
+	r.EnsureClient(r.Client)
 
 	// Check if user is referenced by user groups
 	referencedByUserGroup, err := r.isUserReferencedByUserGroup(ctx, user.Name, user.Namespace)
@@ -261,6 +262,8 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, user *pocketidinternal
 	}
 	if referencedByUserGroup {
 		log.Info("User is referenced by PocketIDUserGroup, blocking deletion", "user", user.Name)
+		// The resource still exists in Pocket-ID, so it must stay Ready for dependents to resolve it.
+		_ = r.SetReadyCondition(ctx, user, metav1.ConditionTrue, "DeletionBlocked", "Deletion is blocked while referenced by a PocketIDUserGroup")
 		if _, err := helpers.EnsureFinalizer(ctx, r.Client, user, UserGroupUserFinalizer); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/user/deletion_blocked_test.go
+++ b/internal/controller/user/deletion_blocked_test.go
@@ -1,0 +1,82 @@
+package user
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+)
+
+// A user whose deletion is blocked still exists in Pocket-ID, so it must report
+// Ready. Regression: the blocked branch used to return without touching status,
+// freezing a stale Ready=False that propagated to every group referencing it.
+func TestReconcileDelete_BlockedUserBecomesReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	now := metav1.NewTime(time.Now())
+	user := &pocketidinternalv1alpha1.PocketIDUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "blocked-user",
+			Namespace:         "default",
+			Finalizers:        []string{UserFinalizer, UserGroupUserFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Status: pocketidinternalv1alpha1.PocketIDUserStatus{
+			UserID: "user-id",
+			Conditions: []metav1.Condition{{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             "InstanceNotReady",
+				LastTransitionTime: now,
+			}},
+		},
+	}
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "group", Namespace: "default"},
+		Spec: pocketidinternalv1alpha1.PocketIDUserGroupSpec{
+			Users: &pocketidinternalv1alpha1.UserGroupUsers{
+				UserRefs: []pocketidinternalv1alpha1.NamespacedUserReference{
+					{Name: user.Name, Namespace: user.Namespace},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user, group).
+		WithStatusSubresource(user).
+		Build()
+
+	r := &Reconciler{Client: c, APIReader: c, Scheme: scheme}
+	result, err := r.ReconcileDelete(context.Background(), user)
+	if err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue while blocked, got %s", result.RequeueAfter)
+	}
+
+	updated := &pocketidinternalv1alpha1.PocketIDUser{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, updated); err != nil {
+		t.Fatalf("failed to get updated user: %v", err)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Ready=True while deletion is blocked, got %+v", ready)
+	}
+	if ready.Reason != "DeletionBlocked" {
+		t.Fatalf("expected reason DeletionBlocked, got %q", ready.Reason)
+	}
+	if !containsFinalizer(updated.Finalizers, UserGroupUserFinalizer) {
+		t.Fatalf("expected blocking finalizer to remain, got %v", updated.Finalizers)
+	}
+}

--- a/internal/controller/usergroup/controller.go
+++ b/internal/controller/usergroup/controller.go
@@ -549,6 +549,8 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, userGroup *pocketidint
 	}
 	if referencedByOIDCClient {
 		logf.FromContext(ctx).Info("User group is referenced by PocketIDOIDCClient, blocking deletion", "userGroup", userGroup.Name)
+		// The resource still exists in Pocket-ID, so it must stay Ready for dependents to resolve it.
+		_ = r.SetReadyCondition(ctx, userGroup, metav1.ConditionTrue, "DeletionBlocked", "Deletion is blocked while referenced by a PocketIDOIDCClient")
 		if _, err := helpers.EnsureFinalizer(ctx, r.Client, userGroup, OIDCClientUserGroupFinalizer); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/usergroup/deletion_blocked_test.go
+++ b/internal/controller/usergroup/deletion_blocked_test.go
@@ -1,0 +1,128 @@
+package usergroup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
+)
+
+// A group whose deletion is blocked still exists in Pocket-ID, so it must report
+// Ready. Regression: the blocked branch used to return without touching status,
+// freezing a stale Ready=False and breaking every OIDC client that referenced it.
+func TestReconcileDelete_BlockedGroupBecomesReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	now := metav1.NewTime(time.Now())
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "blocked-group",
+			Namespace:         "default",
+			Finalizers:        []string{UserGroupFinalizer, OIDCClientUserGroupFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Status: pocketidinternalv1alpha1.PocketIDUserGroupStatus{
+			GroupID: "group-id",
+			Conditions: []metav1.Condition{{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             "InstanceNotReady",
+				LastTransitionTime: now,
+			}},
+		},
+	}
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "client", Namespace: "default"},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			AllowedUserGroups: []pocketidinternalv1alpha1.NamespacedUserGroupReference{
+				{Name: group.Name, Namespace: group.Namespace},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(group, oidcClient).
+		WithStatusSubresource(group).
+		Build()
+
+	r := &Reconciler{Client: c, APIReader: c, Scheme: scheme}
+	result, err := r.ReconcileDelete(context.Background(), group)
+	if err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Fatalf("expected requeue while blocked, got %s", result.RequeueAfter)
+	}
+
+	updated := &pocketidinternalv1alpha1.PocketIDUserGroup{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: group.Name, Namespace: group.Namespace}, updated); err != nil {
+		t.Fatalf("failed to get updated group: %v", err)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Ready=True while deletion is blocked, got %+v", ready)
+	}
+	if ready.Reason != "DeletionBlocked" {
+		t.Fatalf("expected reason DeletionBlocked, got %q", ready.Reason)
+	}
+	if !containsString(updated.Finalizers, OIDCClientUserGroupFinalizer) {
+		t.Fatalf("expected blocking finalizer to remain, got %v", updated.Finalizers)
+	}
+}
+
+// Once nothing references the group the delete must proceed rather than parking
+// it on DeletionBlocked forever.
+func TestReconcileDelete_UnreferencedGroupIsNotBlocked(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	now := metav1.NewTime(time.Now())
+	group := &pocketidinternalv1alpha1.PocketIDUserGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "unreferenced-group",
+			Namespace:         "default",
+			Finalizers:        []string{UserGroupFinalizer, OIDCClientUserGroupFinalizer},
+			DeletionTimestamp: &now,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(group).
+		WithStatusSubresource(group).
+		Build()
+
+	r := &Reconciler{Client: c, APIReader: c, Scheme: scheme}
+	if _, err := r.ReconcileDelete(context.Background(), group); err != nil {
+		t.Fatalf("ReconcileDelete returned error: %v", err)
+	}
+
+	updated := &pocketidinternalv1alpha1.PocketIDUserGroup{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: group.Name, Namespace: group.Namespace}, updated); err != nil {
+		t.Fatalf("failed to get updated group: %v", err)
+	}
+	if containsString(updated.Finalizers, OIDCClientUserGroupFinalizer) {
+		t.Fatalf("expected blocking finalizer to be dropped, got %v", updated.Finalizers)
+	}
+	if ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready"); ready != nil && ready.Reason == "DeletionBlocked" {
+		t.Fatal("unreferenced group must not be marked DeletionBlocked")
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, v := range values {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
when a resource was deleted but blocked by finalizers the status updated to not ready, which blocked anything dependent on it from continuing to reconcile. Something blocked from deletion is not deleted in pocket-id so it makes sense to keep it "ready" for the rest of the resources to continue reconciling. Deletion failure is marked under status.Conditions.Reason