### PR TITLE
fix: actually reconcile default pocket-id version

### DIFF
--- a/.github/helm-test-values-instance.yaml
+++ b/.github/helm-test-values-instance.yaml
@@ -2,7 +2,6 @@
 # yaml-language-server: $schema=../charts/pocket-id-instance/values.schema.json
 instance:
   spec:
-    image: ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94
     encryptionKey:
       value: "test-key-16chars"
 

--- a/.github/helm-test-values.yaml
+++ b/.github/helm-test-values.yaml
@@ -10,7 +10,6 @@ pocket-id-instance:
   instance:
     enabled: true
     spec:
-      image: ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94
       encryptionKey:
         value: "test-key-16chars"
   users:

--- a/api/v1alpha1/pocketidinstance_types.go
+++ b/api/v1alpha1/pocketidinstance_types.go
@@ -498,8 +498,8 @@ type PocketIDInstanceSpec struct {
 	// +kubebuilder:default=Deployment
 	DeploymentType string `json:"deploymentType,omitempty"`
 
-	// Container image to run. Defaults to the latest distroless version at time of operator release
-	// +kubebuilder:default="ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94"
+	// Container image to run. When empty the operator supplies the latest distroless
+	// version tested against this release.
 	Image string `json:"image,omitempty"`
 
 	// Encryption Key

--- a/charts/pocket-id-instance/values.schema.json
+++ b/charts/pocket-id-instance/values.schema.json
@@ -1500,8 +1500,7 @@
                 ]
               },
               "image": {
-                "default": "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94",
-                "description": "Container image to run. Defaults to the latest distroless version at time of operator release",
+                "description": "Container image to run. When empty the operator supplies the latest distroless\nversion tested against this release.",
                 "type": [
                   "string",
                   "null"

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidinstances.yaml
@@ -1085,9 +1085,9 @@ spec:
                   Defaults to true
                 type: boolean
               image:
-                default: ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94
-                description: Container image to run. Defaults to the latest distroless
-                  version at time of operator release
+                description: |-
+                  Container image to run. When empty the operator supplies the latest distroless
+                  version tested against this release.
                 type: string
               internalAppUrl:
                 description: Internal base URL for OIDC .well-known endpoints (for

--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -1506,8 +1506,7 @@
                     ]
                   },
                   "image": {
-                    "default": "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94",
-                    "description": "Container image to run. Defaults to the latest distroless version at time of operator release",
+                    "description": "Container image to run. When empty the operator supplies the latest distroless\nversion tested against this release.",
                     "type": [
                       "string",
                       "null"
@@ -7132,8 +7131,7 @@
                 ]
               },
               "image": {
-                "default": "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94",
-                "description": "Container image to run. Defaults to the latest distroless version at time of operator release",
+                "description": "Container image to run. When empty the operator supplies the latest distroless\nversion tested against this release.",
                 "type": [
                   "string",
                   "null"

--- a/config/crd/bases/pocketid.internal_pocketidinstances.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidinstances.yaml
@@ -1085,9 +1085,9 @@ spec:
                   Defaults to true
                 type: boolean
               image:
-                default: ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94
-                description: Container image to run. Defaults to the latest distroless
-                  version at time of operator release
+                description: |-
+                  Container image to run. When empty the operator supplies the latest distroless
+                  version tested against this release.
                 type: string
               internalAppUrl:
                 description: Internal base URL for OIDC .well-known endpoints (for

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -1366,9 +1366,9 @@ spec:
                   Defaults to true
                 type: boolean
               image:
-                default: ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94
-                description: Container image to run. Defaults to the latest distroless
-                  version at time of operator release
+                description: |-
+                  Container image to run. When empty the operator supplies the latest distroless
+                  version tested against this release.
                 type: string
               internalAppUrl:
                 description: Internal base URL for OIDC .well-known endpoints (for

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1375,9 +1375,9 @@ spec:
                   Defaults to true
                 type: boolean
               image:
-                default: ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94
-                description: Container image to run. Defaults to the latest distroless
-                  version at time of operator release
+                description: |-
+                  Container image to run. When empty the operator supplies the latest distroless
+                  version tested against this release.
                 type: string
               internalAppUrl:
                 description: Internal base URL for OIDC .well-known endpoints (for

--- a/dist/schemas/helmrelease_v2_pocket-id-instance.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-instance.json
@@ -2809,8 +2809,7 @@
                         ]
                       },
                       "image": {
-                        "default": "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94",
-                        "description": "Container image to run. Defaults to the latest distroless version at time of operator release",
+                        "description": "Container image to run. When empty the operator supplies the latest distroless\nversion tested against this release.",
                         "type": [
                           "string",
                           "null"

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -2815,8 +2815,7 @@
                             ]
                           },
                           "image": {
-                            "default": "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94",
-                            "description": "Container image to run. Defaults to the latest distroless version at time of operator release",
+                            "description": "Container image to run. When empty the operator supplies the latest distroless\nversion tested against this release.",
                             "type": [
                               "string",
                               "null"
@@ -8441,8 +8440,7 @@
                         ]
                       },
                       "image": {
-                        "default": "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94",
-                        "description": "Container image to run. Defaults to the latest distroless version at time of operator release",
+                        "description": "Container image to run. When empty the operator supplies the latest distroless\nversion tested against this release.",
                         "type": [
                           "string",
                           "null"

--- a/dist/schemas/pocketidinstance_v1alpha1.json
+++ b/dist/schemas/pocketidinstance_v1alpha1.json
@@ -1445,8 +1445,7 @@
           ]
         },
         "image": {
-          "default": "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94",
-          "description": "Container image to run. Defaults to the latest distroless version at time of operator release",
+          "description": "Container image to run. When empty the operator supplies the latest distroless\nversion tested against this release.",
           "type": [
             "string",
             "null"

--- a/docs/pocketidinstance.md
+++ b/docs/pocketidinstance.md
@@ -86,6 +86,31 @@ spec:
   localIPv6Ranges: "fd00::/8,fe80::/10"
 ```
 
+## Image
+
+`spec.image` is optional. When it is omitted the operator runs the Pocket-ID version it
+was released and tested against.
+
+Set it to pin a specific version:
+
+```yaml
+spec:
+  image: ghcr.io/pocket-id/pocket-id:v2.14.0-distroless
+```
+
+> [!IMPORTANT]
+> I finally learned how CRDs work. Instances created before v0.14.2 (08/24/26) have an image written into `spec.image` even if they
+> never set one. Earlier operators declared the default in the CRD schema, so the API
+> server stamped it into the object at creation, leaving those
+> instances pinned to whichever Pocket-ID version was current when they were created,
+> and eventually below the operator's minimum supported version. To hand the image back
+> to the operator, drop the field:
+>
+> ```sh
+> kubectl patch pocketidinstance <name> -n <namespace> \
+>   --type=json -p '[{"op":"remove","path":"/spec/image"}]'
+> ```
+
 ## S3 File Backend
 
 When the `s3` block is present, the operator automatically sets `FILE_BACKEND=s3`.

--- a/internal/controller/instance/controller.go
+++ b/internal/controller/instance/controller.go
@@ -71,6 +71,9 @@ const (
 	// on an instance crashloops the operator to prevent unwanted changes via an incompatible api
 	firstUnsupportedPocketIDVersion = "v3.0.0"
 
+	// DefaultPocketIDImage is the image used when spec.image is empty.
+	DefaultPocketIDImage = "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless@sha256:e0f83a42a78d0759b6d2d8c7380ef0fa8a4c95dfa01ad88740a073ae9cc4ba94"
+
 	// Environment variable mapping
 	envEncryptionKey      = "ENCRYPTION_KEY"
 	envDBConnectionString = "DB_CONNECTION_STRING"
@@ -293,6 +296,15 @@ func specToApplyConfig[T any](spec any) (*T, error) {
 	return &out, nil
 }
 
+// resolveImage returns the pocket-id image to run: spec.image when set, otherwise the
+// default for this operator release.
+func resolveImage(instance *pocketidinternalv1alpha1.PocketIDInstance) string {
+	if instance.Spec.Image != "" {
+		return instance.Spec.Image
+	}
+	return DefaultPocketIDImage
+}
+
 func (r *Reconciler) buildPodTemplate(instance *pocketidinternalv1alpha1.PocketIDInstance, staticAPIKeyHash string) corev1.PodTemplateSpec {
 	var pt corev1.PodTemplateSpec
 	if instance.Spec.PodTemplate != nil {
@@ -368,7 +380,7 @@ func (r *Reconciler) buildPodTemplate(instance *pocketidinternalv1alpha1.PocketI
 
 	container := corev1.Container{
 		Name:            appName,
-		Image:           instance.Spec.Image,
+		Image:           resolveImage(instance),
 		SecurityContext: buildContainerSecurityContext(instance),
 		Resources:       buildResources(instance),
 		Env:             buildEnvVars(instance),

--- a/internal/controller/instance/image_test.go
+++ b/internal/controller/instance/image_test.go
@@ -1,0 +1,135 @@
+package instance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/mod/semver"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// imageVersion extracts the tag from a pinned image reference, dropping any digest.
+func imageVersion(t *testing.T, image string) string {
+	t.Helper()
+	ref, _, _ := strings.Cut(image, "@")
+	idx := strings.LastIndex(ref, ":")
+	if idx < 0 {
+		t.Fatalf("image %q carries no tag", image)
+	}
+	return ref[idx+1:]
+}
+
+// An instance that never set spec.image runs whatever this operator release ships.
+// This is the whole point of resolving the default in the controller: it is re-evaluated
+// on every reconcile, so upgrading the operator moves an unpinned instance forward.
+func TestResolveImage_DefaultsWhenUnset(t *testing.T) {
+	inst := minimalInstance()
+
+	if got := resolveImage(inst); got != DefaultPocketIDImage {
+		t.Errorf("resolveImage on an unpinned instance = %q, want %q", got, DefaultPocketIDImage)
+	}
+}
+
+// An explicit pin is still honoured verbatim; the fallback must never override it.
+func TestResolveImage_ExplicitPinWins(t *testing.T) {
+	const pinned = "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless"
+
+	inst := minimalInstance()
+	inst.Spec.Image = pinned
+
+	if got := resolveImage(inst); got != pinned {
+		t.Errorf("resolveImage on a pinned instance = %q, want %q", got, pinned)
+	}
+}
+
+// The default has to reach the container, not just resolveImage.
+func TestBuildPodTemplate_DefaultsImageWhenUnset(t *testing.T) {
+	inst := minimalInstance()
+
+	pt := (&Reconciler{}).buildPodTemplate(inst, "")
+
+	if got := pt.Spec.Containers[0].Image; got != DefaultPocketIDImage {
+		t.Errorf("container image = %q, want the operator default %q", got, DefaultPocketIDImage)
+	}
+}
+
+// DefaultPocketIDImage and latestTestedPocketIDVersion are bumped by two different
+// Renovate managers (the image regex and the `// renovate:` comment). Nothing else
+// forces them to move together, so an upgrade PR that lands only one would silently
+// ship a default the operator has not been tested against.
+func TestDefaultPocketIDImage_TracksLatestTestedVersion(t *testing.T) {
+	tag := imageVersion(t, DefaultPocketIDImage)
+
+	if tag != latestTestedPocketIDVersion && !strings.HasPrefix(tag, latestTestedPocketIDVersion+"-") {
+		t.Errorf("default image tag %q does not match latestTestedPocketIDVersion %q; bump both together",
+			tag, latestTestedPocketIDVersion)
+	}
+}
+
+// A default outside the supported range would halt the operator on the first reconcile
+// of any instance that did not pin an image, which is exactly the failure this default
+// exists to prevent.
+func TestDefaultPocketIDImage_WithinSupportedRange(t *testing.T) {
+	tag := imageVersion(t, DefaultPocketIDImage)
+
+	if !semver.IsValid(tag) {
+		t.Fatalf("default image tag %q is not a valid semver version", tag)
+	}
+	if isBelowMinimumVersion(tag) {
+		t.Errorf("default image %q is below minimumSupportedPocketIDVersion %q; unpinned instances would crash loop",
+			DefaultPocketIDImage, minimumSupportedPocketIDVersion)
+	}
+	if isUnsupportedVersion(tag) {
+		t.Errorf("default image %q is at or above firstUnsupportedPocketIDVersion %q; unpinned instances would crash loop",
+			DefaultPocketIDImage, firstUnsupportedPocketIDVersion)
+	}
+}
+
+// The regression guard for the bug this default replaced. A `+kubebuilder:default` on
+// spec.image makes the API server stamp the value into the stored object on first write
+// and never revisit it, so instances stay on the image of whichever operator created
+// them — invisibly, until a later operator's version floor halts on them. The property
+// that matters is in the generated CRD, not in the Go marker, so assert on the CRD.
+func TestCRD_DoesNotDefaultImage(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "config", "crd", "bases", "pocketid.internal_pocketidinstances.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read CRD: %v", err)
+	}
+
+	var crd struct {
+		Spec struct {
+			Versions []struct {
+				Name   string `json:"name"`
+				Schema struct {
+					OpenAPIV3Schema struct {
+						Properties struct {
+							Spec struct {
+								Properties map[string]map[string]any `json:"properties"`
+							} `json:"spec"`
+						} `json:"properties"`
+					} `json:"openAPIV3Schema"`
+				} `json:"schema"`
+			} `json:"versions"`
+		} `json:"spec"`
+	}
+	if err := k8syaml.Unmarshal(data, &crd); err != nil {
+		t.Fatalf("parse CRD: %v", err)
+	}
+	if len(crd.Spec.Versions) == 0 {
+		t.Fatal("CRD declares no versions; the parse above is wrong")
+	}
+
+	for _, version := range crd.Spec.Versions {
+		image, ok := version.Schema.OpenAPIV3Schema.Properties.Spec.Properties["image"]
+		if !ok {
+			t.Fatalf("version %s: spec.image is missing from the CRD schema", version.Name)
+		}
+		if def, ok := image["default"]; ok {
+			t.Errorf("version %s: spec.image declares a schema default (%v); the API server would stamp it into every instance and never re-evaluate it. Resolve the default in the controller instead (see DefaultPocketIDImage).",
+				version.Name, def)
+		}
+	}
+}

--- a/internal/controller/pocketidinstance_controller_test.go
+++ b/internal/controller/pocketidinstance_controller_test.go
@@ -34,6 +34,7 @@ import (
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
 	"github.com/aclerici38/pocket-id-operator/internal/controller/common"
+	instancectrl "github.com/aclerici38/pocket-id-operator/internal/controller/instance"
 )
 
 // Environment variable names used in tests (mirrors instance controller constants)
@@ -2852,6 +2853,108 @@ var _ = Describe("PocketIDInstance Controller", func() {
 			}
 			Expect(volumeNames).To(HaveKey("data"))
 			Expect(volumeNames).To(HaveKey("extra-config"))
+		})
+	})
+})
+
+// spec.image is resolved by the controller rather than by a CRD schema default. These
+// specs run against a real API server loading the generated CRD, which is the only place
+// that distinction is observable: the fake client the unit tests use never applies
+// OpenAPI defaults, so it cannot tell a stamped default from a resolved one.
+var _ = Describe("PocketIDInstance image defaulting", func() {
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	var (
+		ctx       context.Context
+		namespace string
+		inst      *pocketidinternalv1alpha1.PocketIDInstance
+	)
+
+	newInstance := func(name, image string) *pocketidinternalv1alpha1.PocketIDInstance {
+		return &pocketidinternalv1alpha1.PocketIDInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: pocketidinternalv1alpha1.PocketIDInstanceSpec{
+				Image:         image,
+				AppURL:        "https://auth.example.com",
+				EncryptionKey: &pocketidinternalv1alpha1.SensitiveValue{Value: "test-encryption-key-32chars!!!!!"},
+			},
+		}
+	}
+
+	// containerImage reports the image the operator put on the pocket-id container, once
+	// the Deployment exists.
+	containerImage := func() string {
+		deployment := &appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      inst.Name,
+			Namespace: namespace,
+		}, deployment); err != nil {
+			return ""
+		}
+		if len(deployment.Spec.Template.Spec.Containers) == 0 {
+			return ""
+		}
+		return deployment.Spec.Template.Spec.Containers[0].Image
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = defaultNamespace
+	})
+
+	AfterEach(func() {
+		if inst != nil {
+			_ = k8sClient.Delete(ctx, inst)
+			inst = nil
+		}
+	})
+
+	Context("When creating a PocketIDInstance without spec.image", func() {
+		BeforeEach(func() {
+			inst = newInstance("test-unpinned-image-instance", "")
+			Expect(k8sClient.Create(ctx, inst)).To(Succeed())
+		})
+
+		// The bug this replaced: a +kubebuilder:default on spec.image made the API server
+		// write the operator's image into the stored object at creation and never revisit
+		// it, so the instance stayed on that image through every later operator upgrade.
+		// The stored spec must come back exactly as it was submitted.
+		It("Should not have an image stamped into the stored spec", func() {
+			stored := &pocketidinternalv1alpha1.PocketIDInstance{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      inst.Name,
+					Namespace: namespace,
+				}, stored)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(stored.Spec.Image).To(BeEmpty(),
+				"the API server defaulted spec.image; it would then be frozen at this value for the life of the instance")
+		})
+
+		// Leaving spec.image empty is how an instance opts into following the operator, so
+		// the workload has to run the current release's image.
+		It("Should run the operator's default image", func() {
+			Eventually(containerImage, timeout, interval).Should(Equal(instancectrl.DefaultPocketIDImage))
+		})
+	})
+
+	Context("When creating a PocketIDInstance that pins spec.image", func() {
+		const pinned = "ghcr.io/pocket-id/pocket-id:v2.14.0-distroless"
+
+		BeforeEach(func() {
+			inst = newInstance("test-pinned-image-instance", pinned)
+			Expect(k8sClient.Create(ctx, inst)).To(Succeed())
+		})
+
+		It("Should run the pinned image rather than the operator default", func() {
+			Eventually(containerImage, timeout, interval).Should(Equal(pinned))
 		})
 	})
 })


### PR DESCRIPTION
This has always been broken/not what I expected. Apparently CRD defaults are just the values set inside the crd when they're created, never updated even when the crds are updated with a new default. 

As noted in the added docs section, existing installs relying on the default version will need to remove the value from the crd e.g. `kubectl patch pocketidinstance <name> -n <namespace> --type=json -p '[{"op":"remove","path":"/spec/image"}]'` or equivalent. 

Anyone setting `spec.image` on the instance is obviously unaffected.