### PR TITLE
refactor: refactor logo reconciliation

### DIFF
--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -544,9 +544,19 @@ type PocketIDOIDCClientStatus struct {
 	// +optional
 	LogoURL string `json:"logoUrl,omitempty"`
 
+	// LogoReachable reports whether Pocket-ID could fetch and store the light logo from the
+	// URL the spec resolves to. Unset when the spec asks for no light logo.
+	// +optional
+	LogoReachable *bool `json:"logoReachable,omitempty"`
+
 	// DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
 	// +optional
 	DarkLogoURL string `json:"darkLogoUrl,omitempty"`
+
+	// DarkLogoReachable reports whether Pocket-ID could fetch and store the dark logo from the
+	// URL the spec resolves to. Unset when the spec asks for no dark logo.
+	// +optional
+	DarkLogoReachable *bool `json:"darkLogoReachable,omitempty"`
 
 	// SCIMProviderID is the pocket-id ID of the SCIM service provider for this client, if configured.
 	// +optional

--- a/api/v1alpha1/pocketidoidcclient_types.go
+++ b/api/v1alpha1/pocketidoidcclient_types.go
@@ -540,21 +540,13 @@ type PocketIDOIDCClientStatus struct {
 	// +optional
 	PKCESupported *bool `json:"pkceSupported,omitempty"`
 
-	// LogoURL is the last resolved light logo URL that was applied to Pocket-ID.
+	// LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
 	// +optional
 	LogoURL string `json:"logoUrl,omitempty"`
 
-	// LogoReachable indicates whether the light logo URL was reachable when last checked.
-	// +optional
-	LogoReachable *bool `json:"logoReachable,omitempty"`
-
-	// DarkLogoURL is the last resolved dark logo URL that was applied to Pocket-ID.
+	// DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
 	// +optional
 	DarkLogoURL string `json:"darkLogoUrl,omitempty"`
-
-	// DarkLogoReachable indicates whether the dark logo URL was reachable when last checked.
-	// +optional
-	DarkLogoReachable *bool `json:"darkLogoReachable,omitempty"`
 
 	// SCIMProviderID is the pocket-id ID of the SCIM service provider for this client, if configured.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1082,16 +1082,6 @@ func (in *PocketIDOIDCClientStatus) DeepCopyInto(out *PocketIDOIDCClientStatus) 
 		*out = new(bool)
 		**out = **in
 	}
-	if in.LogoReachable != nil {
-		in, out := &in.LogoReachable, &out.LogoReachable
-		*out = new(bool)
-		**out = **in
-	}
-	if in.DarkLogoReachable != nil {
-		in, out := &in.DarkLogoReachable, &out.DarkLogoReachable
-		*out = new(bool)
-		**out = **in
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1082,6 +1082,16 @@ func (in *PocketIDOIDCClientStatus) DeepCopyInto(out *PocketIDOIDCClientStatus) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.LogoReachable != nil {
+		in, out := &in.LogoReachable, &out.LogoReachable
+		*out = new(bool)
+		**out = **in
+	}
+	if in.DarkLogoReachable != nil {
+		in, out := &in.DarkLogoReachable, &out.DarkLogoReachable
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -729,9 +729,8 @@ spec:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
               darkLogoUrl:
-                description: |-
-                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the dark logo.
+                description: DarkLogoURL is the dark logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -740,10 +739,8 @@ spec:
                 format: date-time
                 type: string
               logoUrl:
-                description: |-
-                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the light logo: either no URL resolves for this
-                  client, or the logo it has was uploaded out of band.
+                description: LogoURL is the light logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -728,13 +728,10 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
-              darkLogoReachable:
-                description: DarkLogoReachable indicates whether the dark logo URL
-                  was reachable when last checked.
-                type: boolean
               darkLogoUrl:
-                description: DarkLogoURL is the last resolved dark logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the dark logo.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -742,13 +739,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
-              logoReachable:
-                description: LogoReachable indicates whether the light logo URL was
-                  reachable when last checked.
-                type: boolean
               logoUrl:
-                description: LogoURL is the last resolved light logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the light logo: either no URL resolves for this
+                  client, or the logo it has was uploaded out of band.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
+++ b/charts/pocket-id-operator/crds/pocketid.internal_pocketidoidcclients.yaml
@@ -728,6 +728,11 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
+              darkLogoReachable:
+                description: |-
+                  DarkLogoReachable reports whether Pocket-ID could fetch and store the dark logo from the
+                  URL the spec resolves to. Unset when the spec asks for no dark logo.
+                type: boolean
               darkLogoUrl:
                 description: DarkLogoURL is the dark logo URL the operator last successfully
                   applied to Pocket-ID.
@@ -738,6 +743,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
+              logoReachable:
+                description: |-
+                  LogoReachable reports whether Pocket-ID could fetch and store the light logo from the
+                  URL the spec resolves to. Unset when the spec asks for no light logo.
+                type: boolean
               logoUrl:
                 description: LogoURL is the light logo URL the operator last successfully
                   applied to Pocket-ID.

--- a/charts/pocket-id-operator/values.yaml
+++ b/charts/pocket-id-operator/values.yaml
@@ -29,9 +29,9 @@ operator:
 
   # Default URL template for light logos ({{name}} is replaced with the client name)
   # Defaults to the dashboard-icons CDN if not set
-  # defaultLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}.png"
+  # defaultLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
   # Default URL template for dark logos
-  # defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}-dark.png"
+  # defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
 
   podSecurityContext:
     runAsNonRoot: true

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -729,9 +729,8 @@ spec:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
               darkLogoUrl:
-                description: |-
-                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the dark logo.
+                description: DarkLogoURL is the dark logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -740,10 +739,8 @@ spec:
                 format: date-time
                 type: string
               logoUrl:
-                description: |-
-                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the light logo: either no URL resolves for this
-                  client, or the logo it has was uploaded out of band.
+                description: LogoURL is the light logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -728,13 +728,10 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
-              darkLogoReachable:
-                description: DarkLogoReachable indicates whether the dark logo URL
-                  was reachable when last checked.
-                type: boolean
               darkLogoUrl:
-                description: DarkLogoURL is the last resolved dark logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the dark logo.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -742,13 +739,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
-              logoReachable:
-                description: LogoReachable indicates whether the light logo URL was
-                  reachable when last checked.
-                type: boolean
               logoUrl:
-                description: LogoURL is the last resolved light logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the light logo: either no URL resolves for this
+                  client, or the logo it has was uploaded out of band.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+++ b/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
@@ -728,6 +728,11 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
+              darkLogoReachable:
+                description: |-
+                  DarkLogoReachable reports whether Pocket-ID could fetch and store the dark logo from the
+                  URL the spec resolves to. Unset when the spec asks for no dark logo.
+                type: boolean
               darkLogoUrl:
                 description: DarkLogoURL is the dark logo URL the operator last successfully
                   applied to Pocket-ID.
@@ -738,6 +743,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
+              logoReachable:
+                description: |-
+                  LogoReachable reports whether Pocket-ID could fetch and store the light logo from the
+                  URL the spec resolves to. Unset when the spec asks for no light logo.
+                type: boolean
               logoUrl:
                 description: LogoURL is the light logo URL the operator last successfully
                   applied to Pocket-ID.

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -4057,13 +4057,10 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
-              darkLogoReachable:
-                description: DarkLogoReachable indicates whether the dark logo URL
-                  was reachable when last checked.
-                type: boolean
               darkLogoUrl:
-                description: DarkLogoURL is the last resolved dark logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the dark logo.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -4071,13 +4068,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
-              logoReachable:
-                description: LogoReachable indicates whether the light logo URL was
-                  reachable when last checked.
-                type: boolean
               logoUrl:
-                description: LogoURL is the last resolved light logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the light logo: either no URL resolves for this
+                  client, or the logo it has was uploaded out of band.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -4057,6 +4057,11 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
+              darkLogoReachable:
+                description: |-
+                  DarkLogoReachable reports whether Pocket-ID could fetch and store the dark logo from the
+                  URL the spec resolves to. Unset when the spec asks for no dark logo.
+                type: boolean
               darkLogoUrl:
                 description: DarkLogoURL is the dark logo URL the operator last successfully
                   applied to Pocket-ID.
@@ -4067,6 +4072,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
+              logoReachable:
+                description: |-
+                  LogoReachable reports whether Pocket-ID could fetch and store the light logo from the
+                  URL the spec resolves to. Unset when the spec asks for no light logo.
+                type: boolean
               logoUrl:
                 description: LogoURL is the light logo URL the operator last successfully
                   applied to Pocket-ID.

--- a/dist/crds.yaml
+++ b/dist/crds.yaml
@@ -4058,9 +4058,8 @@ spec:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
               darkLogoUrl:
-                description: |-
-                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the dark logo.
+                description: DarkLogoURL is the dark logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -4069,10 +4068,8 @@ spec:
                 format: date-time
                 type: string
               logoUrl:
-                description: |-
-                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the light logo: either no URL resolves for this
-                  client, or the logo it has was uploaded out of band.
+                description: LogoURL is the light logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -4067,9 +4067,8 @@ spec:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
               darkLogoUrl:
-                description: |-
-                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the dark logo.
+                description: DarkLogoURL is the dark logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -4078,10 +4077,8 @@ spec:
                 format: date-time
                 type: string
               logoUrl:
-                description: |-
-                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
-                  Empty means the operator does not own the light logo: either no URL resolves for this
-                  client, or the logo it has was uploaded out of band.
+                description: LogoURL is the light logo URL the operator last successfully
+                  applied to Pocket-ID.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -4066,6 +4066,11 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
+              darkLogoReachable:
+                description: |-
+                  DarkLogoReachable reports whether Pocket-ID could fetch and store the dark logo from the
+                  URL the spec resolves to. Unset when the spec asks for no dark logo.
+                type: boolean
               darkLogoUrl:
                 description: DarkLogoURL is the dark logo URL the operator last successfully
                   applied to Pocket-ID.
@@ -4076,6 +4081,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
+              logoReachable:
+                description: |-
+                  LogoReachable reports whether Pocket-ID could fetch and store the light logo from the
+                  URL the spec resolves to. Unset when the spec asks for no light logo.
+                type: boolean
               logoUrl:
                 description: LogoURL is the light logo URL the operator last successfully
                   applied to Pocket-ID.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -4066,13 +4066,10 @@ spec:
               createdAt:
                 description: CreatedAt is the creation timestamp from Pocket-ID
                 type: string
-              darkLogoReachable:
-                description: DarkLogoReachable indicates whether the dark logo URL
-                  was reachable when last checked.
-                type: boolean
               darkLogoUrl:
-                description: DarkLogoURL is the last resolved dark logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the dark logo.
                 type: string
               lastRotatedAt:
                 description: |-
@@ -4080,13 +4077,11 @@ spec:
                   operator. Used to determine when the next scheduled rotation is due.
                 format: date-time
                 type: string
-              logoReachable:
-                description: LogoReachable indicates whether the light logo URL was
-                  reachable when last checked.
-                type: boolean
               logoUrl:
-                description: LogoURL is the last resolved light logo URL that was
-                  applied to Pocket-ID.
+                description: |-
+                  LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.
+                  Empty means the operator does not own the light logo: either no URL resolves for this
+                  client, or the logo it has was uploaded out of band.
                 type: string
               logoutCallbackUrls:
                 description: LogoutCallbackURLs are the current logout callback URLs

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -938,7 +938,7 @@
           ]
         },
         "darkLogoUrl": {
-          "description": "DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.\nEmpty means the operator does not own the dark logo.",
+          "description": "DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.",
           "type": [
             "string",
             "null"
@@ -953,7 +953,7 @@
           ]
         },
         "logoUrl": {
-          "description": "LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.\nEmpty means the operator does not own the light logo: either no URL resolves for this\nclient, or the logo it has was uploaded out of band.",
+          "description": "LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.",
           "type": [
             "string",
             "null"

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -937,6 +937,13 @@
             "null"
           ]
         },
+        "darkLogoReachable": {
+          "description": "DarkLogoReachable reports whether Pocket-ID could fetch and store the dark logo from the\nURL the spec resolves to. Unset when the spec asks for no dark logo.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "darkLogoUrl": {
           "description": "DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.",
           "type": [
@@ -949,6 +956,13 @@
           "format": "date-time",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "logoReachable": {
+          "description": "LogoReachable reports whether Pocket-ID could fetch and store the light logo from the\nURL the spec resolves to. Unset when the spec asks for no light logo.",
+          "type": [
+            "boolean",
             "null"
           ]
         },

--- a/dist/schemas/pocketidoidcclient_v1alpha1.json
+++ b/dist/schemas/pocketidoidcclient_v1alpha1.json
@@ -937,15 +937,8 @@
             "null"
           ]
         },
-        "darkLogoReachable": {
-          "description": "DarkLogoReachable indicates whether the dark logo URL was reachable when last checked.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "darkLogoUrl": {
-          "description": "DarkLogoURL is the last resolved dark logo URL that was applied to Pocket-ID.",
+          "description": "DarkLogoURL is the dark logo URL the operator last successfully applied to Pocket-ID.\nEmpty means the operator does not own the dark logo.",
           "type": [
             "string",
             "null"
@@ -959,15 +952,8 @@
             "null"
           ]
         },
-        "logoReachable": {
-          "description": "LogoReachable indicates whether the light logo URL was reachable when last checked.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "logoUrl": {
-          "description": "LogoURL is the last resolved light logo URL that was applied to Pocket-ID.",
+          "description": "LogoURL is the light logo URL the operator last successfully applied to Pocket-ID.\nEmpty means the operator does not own the light logo: either no URL resolves for this\nclient, or the logo it has was uploaded out of band.",
           "type": [
             "string",
             "null"

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -456,8 +456,8 @@ The operator can automatically set logo URLs for OIDC clients using a configurab
 By default it uses the [dashboard-icons](https://github.com/homarr-labs/dashboard-icons) CDN:
 
 ```
-https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}.png
-https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}-dark.png
+https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp
+https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp
 ```
 
 The `{{name}}` placeholder in templates is replaced with the resource's `metadata.name` or `spec.logo.nameOverride`.
@@ -512,8 +512,8 @@ Within the `spec.logo` struct, any entries in `spec.logo.logoUrl` or `spec.logo.
 | Variable                  | Default | Description                                        |
 |---------------------------|---------|----------------------------------------------------|
 | `AUTOGENERATE_LOGOS`      | `true`  | Global default for `spec.logo.autoGenerate`.       |
-| `DEFAULT_LOGO_URL`        | *(dashboard-icons PNG)* | Default URL template for light logos. |
-| `DEFAULT_DARK_LOGO_URL`   | *(dashboard-icons PNG)* | Default URL template for dark logos.  |
+| `DEFAULT_LOGO_URL`        | *(dashboard-icons WebP)* | Default URL template for light logos. |
+| `DEFAULT_DARK_LOGO_URL`   | *(dashboard-icons WebP)* | Default URL template for dark logos.  |
 
 ### Examples
 
@@ -528,7 +528,7 @@ spec:
   logo: {}
 ```
 
-This resolves to `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/grafana.png`.
+This resolves to `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/grafana.webp`.
 
 Override the icon name when it doesn't match the client name:
 
@@ -563,9 +563,9 @@ The operator takes ownership of a light or dark logo only while a URL resolves f
 
 ```yaml
 status:
-  darkLogoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/immich-dark.png
+  darkLogoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/immich-light.webp
   darkLogoReachable: true
-  logoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/immich.png
+  logoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/immich.webp
   logoReachable: true
 ```
 

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -564,7 +564,9 @@ The operator takes ownership of a light or dark logo only while a URL resolves f
 ```yaml
 status:
   darkLogoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/immich-dark.png
+  darkLogoReachable: true
   logoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/immich.png
+  logoReachable: true
 ```
 
 - A logo uploaded through the Pocket-ID UI has no applied record, so the operator never

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -572,12 +572,14 @@ status:
   logo by hand on the side you care about.
 - When a light or dark logo stops resolving a URL but its applied record is set in the status, the operator deletes the
   logo it put there. It never deletes one it did not apply.
+- The same applies when the spec moves to a URL Pocket-ID refuses: the logo the operator
+  applied from the old URL is deleted rather than left in place, since no later reconcile would replace it. A refused URL that is still the one in the applied record is left alone.
 - Ownership is per side, so a client that resolves only a light URL keeps an uploaded dark
   logo.
 
 ### Unusable logo URLs
 
-For simplicity, each url rejected by pocket-id is remembered in memory and not attempted again. To retry a url simply restart the operator.
+A URL Pocket-ID rejects is remembered in memory and not attempted again for 24 hours, so a permanently missing icon costs one download attempt a day rather than one every resync. Restarting the operator also clears it.
 
 ## Generated Secret
 

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -556,18 +556,28 @@ spec:
     autoGenerate: false
 ```
 
-The final URLs and status of the logos are displayed under `status` in the `PocketIDOIDCClient` resource
+### Ownership
+
+The operator takes ownership of a light or dark logo only while a URL resolves for it.
+`status.logoUrl` and `status.darkLogoUrl` record the URL the operator last successfully applied for that side:
 
 ```yaml
 status:
-  darkLogoReachable: false
   darkLogoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/immich-dark.png
-  logoReachable: true
   logoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/immich.png
 ```
 
-Logs for the logos are set to `debug` by default to prevent spamming the console with unavailable logos.
-To view the logs add the `--zap-log-level=debug` arg on the operator container.
+- A logo uploaded through the Pocket-ID UI has no applied record, so the operator never
+  touches it. Set `logo.autoGenerate: false` (with no explicit URL) to manage a client's
+  logo by hand on the side you care about.
+- When a light or dark logo stops resolving a URL but its applied record is set in the status, the operator deletes the
+  logo it put there. It never deletes one it did not apply.
+- Ownership is per side, so a client that resolves only a light URL keeps an uploaded dark
+  logo.
+
+### Unusable logo URLs
+
+For simplicity, each url rejected by pocket-id is remembered in memory and not attempted again. To retry a url simply restart the operator.
 
 ## Generated Secret
 

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
-	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -83,12 +82,14 @@ type Reconciler struct {
 
 	// DefaultAutoGenerateLogos is the default for logo.autoGenerate when not set per-client (from AUTOGENERATE_LOGOS env var).
 	DefaultAutoGenerateLogos bool
-	// IsLogoReachable checks if a logo URL is reachable. Defaults to isURLReachable.
-	IsLogoReachable func(string) bool
 	// DefaultLogoTemplate is the default URL template for light logos (from DEFAULT_LOGO_URL env var).
 	DefaultLogoTemplate string
 	// DefaultDarkLogoTemplate is the default URL template for dark logos (from DEFAULT_DARK_LOGO_URL env var).
 	DefaultDarkLogoTemplate string
+
+	// failedLogoURLs records logo URLs Pocket-ID refused and will mnot be retried during the lifecycle of this container.
+	// This is safe as long as max concurrent reconciles is 1
+	failedLogoURLs map[string]struct{}
 
 	// pendingInitialMint marks clients created (not adopted) by the operator whose client
 	// secret has not yet been stored. It lets storeClientSecret=false permit the one-time
@@ -291,6 +292,7 @@ type PocketIDOIDCClientAPI interface {
 	RefreshOIDCClientMetadata(ctx context.Context, id string) error
 	CreateOIDCClientSecret(ctx context.Context, id, secret string) (pocketid.OIDCClientSecret, string, error)
 	DeleteOIDCClientSecret(ctx context.Context, id, secretID string) error
+	DeleteOIDCClientLogo(ctx context.Context, id string, light bool) error
 	GetOIDCClientSCIMServiceProvider(ctx context.Context, oidcClientID string) (*pocketid.SCIMServiceProvider, error)
 	CreateSCIMServiceProvider(ctx context.Context, input pocketid.SCIMServiceProviderInput) (*pocketid.SCIMServiceProvider, error)
 	UpdateSCIMServiceProvider(ctx context.Context, id string, input pocketid.SCIMServiceProviderInput) (*pocketid.SCIMServiceProvider, error)
@@ -374,12 +376,9 @@ func (r *Reconciler) FindExistingOIDCClient(ctx context.Context, apiClient Pocke
 func (r *Reconciler) createOrAdoptOIDCClient(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, apiClient *pocketid.Client) (bool, error) {
 	log := logf.FromContext(ctx)
 
-	logoURL, darkLogoURL, err := r.resolveAndUpdateLogoStatus(ctx, oidcClient)
-	if err != nil {
-		return false, fmt.Errorf("resolve logos: %w", err)
-	}
-
-	input := r.OidcClientInput(oidcClient, nil, logoURL, darkLogoURL)
+	// No logo is sent at creation: Pocket-ID downloads it only after the client row is
+	// committed, so a rejected URL would fail the response that carries the new client's ID.
+	input := r.OidcClientInput(oidcClient, nil, "", "")
 
 	// Aggregate all allowed groups
 	groupIDs, err := r.aggregateAllowedUserGroupIDs(ctx, oidcClient, apiClient)
@@ -499,13 +498,12 @@ func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocket
 	}
 	metrics.OIDCClientAllowedGroupCount.WithLabelValues(oidcClient.Namespace, oidcClient.Name).Set(float64(len(groupIDs)))
 
-	// Resolve logos, update CR status, and get reachable URLs for the API payload
-	logoURL, darkLogoURL, err := r.resolveAndUpdateLogoStatus(ctx, oidcClient)
+	logos, err := r.reconcileLogos(ctx, oidcClient, apiClient, current)
 	if err != nil {
-		return false, fmt.Errorf("resolve logos: %w", err)
+		return false, fmt.Errorf("reconcile logos: %w", err)
 	}
 
-	desired := r.OidcClientInput(oidcClient, current, logoURL, darkLogoURL)
+	desired := r.OidcClientInput(oidcClient, current, logos.pushLight, logos.pushDark)
 	desired.IsGroupRestricted = len(groupIDs) > 0
 	if current.IsCIMD() {
 		preserveMetadataOwnedFields(&desired, current)
@@ -525,20 +523,41 @@ func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocket
 	}
 	shouldPushCredentials := hasCredentials || firstReconcile
 
-	if !clientChanged && !shouldPushCredentials && !groupsChanged {
+	if !clientChanged && !shouldPushCredentials && !groupsChanged && !logos.hasPush() {
 		log.V(1).Info("OIDC client state is in sync, skipping update")
-		return false, nil
+		return false, r.applyLogoStatus(ctx, oidcClient, logos)
 	}
 
 	log.Info("Updating OIDC client", "name", oidcClient.Name)
 
+	// Pocket-ID fetches the light logo first and gives up before the
+	// dark one, reporting both under the same code, so an update carrying both cannot say
+	// which side failed. A dark URL that 404s would disown a light logo that landed.
+	desired.DarkLogoURL = ""
+
 	// Always push when credentials are present since they
 	// are write-only and cannot be compared against the fetched state.
-	if clientChanged || shouldPushCredentials {
-		if _, err := apiClient.UpdateOIDCClient(ctx, oidcClient.Status.ClientID, desired); err != nil {
-			return false, fmt.Errorf("update OIDC client: %w", err)
+	if clientChanged || shouldPushCredentials || logos.pushLight != "" {
+		ok, err := r.pushClientUpdate(ctx, apiClient, oidcClient.Status.ClientID, desired)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			logos.pushLight = ""
 		}
 	}
+
+	if logos.pushDark != "" {
+		desired.LogoURL, desired.DarkLogoURL = "", logos.pushDark
+		ok, err := r.pushClientUpdate(ctx, apiClient, oidcClient.Status.ClientID, desired)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			logos.pushDark = ""
+		}
+	}
+	logos.commit()
 
 	if groupsChanged {
 		if groupIDs == nil {
@@ -549,8 +568,29 @@ func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocket
 		}
 	}
 
+	if err := r.applyLogoStatus(ctx, oidcClient, logos); err != nil {
+		return true, fmt.Errorf("record applied logos: %w", err)
+	}
+
 	metrics.ResourceOperations.WithLabelValues("PocketIDOIDCClient", "updated").Inc()
 
+	return true, nil
+}
+
+// pushClientUpdate issues the client update and reports whether the logo it carried was
+// accepted. Pocket-ID commits the configuration before fetching the logo, so a rejected logo
+// leaves the client correctly configured; failing the reconcile would re-push every resync
+// and never let the CR go Ready.
+func (r *Reconciler) pushClientUpdate(ctx context.Context, apiClient *pocketid.Client, id string, desired pocketid.OIDCClientInput) (bool, error) {
+	if _, err := apiClient.UpdateOIDCClient(ctx, id, desired); err != nil {
+		if !pocketid.IsLogoError(err) {
+			return false, fmt.Errorf("update OIDC client: %w", err)
+		}
+		logf.FromContext(ctx).Info("Pocket-ID rejected the logo; the client was configured without it",
+			"error", err.Error(), "logoUrl", desired.LogoURL, "darkLogoUrl", desired.DarkLogoURL)
+		r.markLogoURLsFailed(desired.LogoURL, desired.DarkLogoURL)
+		return false, nil
+	}
 	return true, nil
 }
 
@@ -643,7 +683,7 @@ func oidcClientName(oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) str
 }
 
 // OidcClientInput builds an OIDCClientInput from the CR spec.
-// logoURL/darkLogoURL should only contain reachable URLs to send to Pocket-ID.
+// logoURL/darkLogoURL are attach-only instructions: empty leaves the stored logo alone.
 // When current is provided, it is used as the fallback for callback URLs not set in the spec.
 func (r *Reconciler) OidcClientInput(oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, current *pocketid.OIDCClient, logoURL, darkLogoURL string) pocketid.OIDCClientInput {
 	name := oidcClientName(oidcClient)
@@ -689,8 +729,6 @@ func (r *Reconciler) OidcClientInput(oidcClient *pocketidinternalv1alpha1.Pocket
 		LaunchURL:                           oidcClient.Spec.LaunchURL,
 		LogoURL:                             logoURL,
 		DarkLogoURL:                         darkLogoURL,
-		HasLogo:                             logoURL != "",
-		HasDarkLogo:                         darkLogoURL != "",
 		IsPublic:                            oidcClient.Spec.IsPublic,
 		IsGroupRestricted:                   len(oidcClient.Spec.AllowedUserGroups) > 0,
 		PKCEEnabled:                         oidcClient.Spec.PKCEEnabled,
@@ -703,33 +741,108 @@ func (r *Reconciler) OidcClientInput(oidcClient *pocketidinternalv1alpha1.Pocket
 	}
 }
 
-// resolveAndUpdateLogoStatus resolves logo URLs, checks reachability, updates the CR status,
-// and returns the reachable URLs to include in the Pocket-ID API payload.
-func (r *Reconciler) resolveAndUpdateLogoStatus(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) (logoURL, darkLogoURL string, err error) {
-	resolvedLogo, logoReachable, resolvedDark, darkReachable := r.resolveLogoURLs(ctx, oidcClient, oidcClient.Name)
-
-	if err := r.updateLogoStatus(ctx, oidcClient, resolvedLogo, logoReachable, resolvedDark, darkReachable); err != nil {
-		return "", "", err
-	}
-
-	if logoReachable {
-		logoURL = resolvedLogo
-	}
-	if darkReachable {
-		darkLogoURL = resolvedDark
-	}
-	return logoURL, darkLogoURL, nil
+// logoPlan is the outcome of reconcileLogos: the URLs to attach to the client update and
+// the record of what the operator has applied.
+type logoPlan struct {
+	pushLight, pushDark       string
+	appliedLight, appliedDark string
 }
 
-// resolveLogoURLs determines the final logo URLs for the OIDC client.
+func (p *logoPlan) hasPush() bool { return p.pushLight != "" || p.pushDark != "" }
+
+func (p *logoPlan) commit() {
+	if p.pushLight != "" {
+		p.appliedLight = p.pushLight
+	}
+	if p.pushDark != "" {
+		p.appliedDark = p.pushDark
+	}
+}
+
+// reconcileLogos decides what each logo side needs and issues any deletion. Ownership is
+// per side and lasts only as long as a URL resolves for it, so a logo uploaded through the
+// UI — which never gets an applied record — is never deleted, and a client that resolves
+// only a light URL keeps its uploaded dark logo.
+func (r *Reconciler) reconcileLogos(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, apiClient PocketIDOIDCClientAPI, current *pocketid.OIDCClient) (logoPlan, error) {
+	light, dark := r.resolveLogoURLs(oidcClient)
+
+	var plan logoPlan
+	var err error
+	plan.pushLight, plan.appliedLight, err = r.reconcileLogoSide(
+		ctx, apiClient, current.ID, true, light, oidcClient.Status.LogoURL, current.HasLogo)
+	if err != nil {
+		return logoPlan{}, err
+	}
+	plan.pushDark, plan.appliedDark, err = r.reconcileLogoSide(
+		ctx, apiClient, current.ID, false, dark, oidcClient.Status.DarkLogoURL, current.HasDarkLogo)
+	if err != nil {
+		return logoPlan{}, err
+	}
+	return plan, nil
+}
+
+// reconcileLogoSide resolves one side of the logo state, deleting a logo the operator
+// applied and the spec has stopped asking for. It returns the URL to send with the client
+// update ("" sends nothing) and the applied record as it stands after any deletion.
+func (r *Reconciler) reconcileLogoSide(ctx context.Context, apiClient PocketIDOIDCClientAPI, clientID string, light bool, resolved, applied string, serverHasLogo bool) (push, stillApplied string, err error) {
+	switch {
+	case resolved == "" && applied == "":
+		// Nothing resolves and nothing was applied: this side is not the operator's.
+		return "", "", nil
+	case resolved == "":
+		logf.FromContext(ctx).Info("Removing logo the spec no longer asks for", "url", applied, "light", light)
+		if err := apiClient.DeleteOIDCClientLogo(ctx, clientID, light); err != nil {
+			return "", "", fmt.Errorf("delete OIDC client logo: %w", err)
+		}
+		return "", "", nil
+	case r.logoURLFailed(resolved):
+		// Pocket-ID already refused this URL. Re-sending it costs a download attempt per
+		// resync and converges on nothing.
+		return "", applied, nil
+	case resolved != applied || !serverHasLogo:
+		return resolved, applied, nil
+	default:
+		return "", applied, nil
+	}
+}
+
+func (r *Reconciler) logoURLFailed(url string) bool {
+	_, failed := r.failedLogoURLs[url]
+	return failed
+}
+
+func (r *Reconciler) markLogoURLsFailed(urls ...string) {
+	for _, url := range urls {
+		if url == "" {
+			continue
+		}
+		if r.failedLogoURLs == nil {
+			r.failedLogoURLs = make(map[string]struct{})
+		}
+		r.failedLogoURLs[url] = struct{}{}
+	}
+}
+
+// applyLogoStatus records which logo URLs the operator has successfully applied.
+func (r *Reconciler) applyLogoStatus(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, plan logoPlan) error {
+	if plan.appliedLight == oidcClient.Status.LogoURL && plan.appliedDark == oidcClient.Status.DarkLogoURL {
+		return nil
+	}
+	base := oidcClient.DeepCopy()
+	oidcClient.Status.LogoURL = plan.appliedLight
+	oidcClient.Status.DarkLogoURL = plan.appliedDark
+	return r.Status().Patch(ctx, oidcClient, client.MergeFrom(base))
+}
+
+// resolveLogoURLs determines the logo URL desired for each side of the OIDC client.
 // The name used for {{name}} substitution is metadata.name, overridable via logo.nameOverride.
 // Precedence: deprecated spec.logoUrl/darkLogoUrl > logo struct template resolution > empty.
-// Always returns the resolved URL. Reachability is checked only when the URL changed or was
-// previously unreachable; otherwise the cached reachability from status is reused.
-func (r *Reconciler) resolveLogoURLs(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, name string) (logoURL string, logoReachable bool, darkLogoURL string, darkLogoReachable bool) {
+// An empty side means the spec asks for no logo there, which is not the same as asserting
+// the client has none: only reconcileLogos decides what that absence implies.
+func (r *Reconciler) resolveLogoURLs(oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) (logoURL, darkLogoURL string) {
 	// Deprecated fields take precedence for backwards compatibility
 	if oidcClient.Spec.LogoURL != "" || oidcClient.Spec.DarkLogoURL != "" {
-		return oidcClient.Spec.LogoURL, oidcClient.Spec.LogoURL != "", oidcClient.Spec.DarkLogoURL, oidcClient.Spec.DarkLogoURL != ""
+		return oidcClient.Spec.LogoURL, oidcClient.Spec.DarkLogoURL
 	}
 
 	logo := oidcClient.Spec.Logo
@@ -739,7 +852,7 @@ func (r *Reconciler) resolveLogoURLs(ctx context.Context, oidcClient *pocketidin
 		autoGenerate = *logo.AutoGenerate
 	}
 
-	logoName := name
+	logoName := oidcClient.Name
 	if logo != nil && logo.NameOverride != "" {
 		logoName = logo.NameOverride
 	}
@@ -767,47 +880,13 @@ func (r *Reconciler) resolveLogoURLs(ctx context.Context, oidcClient *pocketidin
 		}
 	}
 
-	log := logf.FromContext(ctx)
-	checkReachable := r.IsLogoReachable
-	if checkReachable == nil {
-		checkReachable = isURLReachable
-	}
-
-	status := oidcClient.Status
-
 	if logoTemplate != "" {
 		logoURL = strings.ReplaceAll(logoTemplate, "{{name}}", logoName)
-		if status.LogoReachable != nil && *status.LogoReachable && logoURL == status.LogoURL {
-			logoReachable = true
-		} else if checkReachable(logoURL) {
-			logoReachable = true
-		} else {
-			log.V(1).Info("Logo URL is not reachable", "url", logoURL)
-		}
 	}
 	if darkLogoTemplate != "" {
 		darkLogoURL = strings.ReplaceAll(darkLogoTemplate, "{{name}}", logoName)
-		if status.DarkLogoReachable != nil && *status.DarkLogoReachable && darkLogoURL == status.DarkLogoURL {
-			darkLogoReachable = true
-		} else if checkReachable(darkLogoURL) {
-			darkLogoReachable = true
-		} else {
-			log.V(1).Info("Dark logo URL is not reachable", "url", darkLogoURL)
-		}
 	}
-
-	return logoURL, logoReachable, darkLogoURL, darkLogoReachable
-}
-
-// isURLReachable performs a HEAD request to check if a URL is reachable (2xx status).
-func isURLReachable(url string) bool {
-	httpClient := &http.Client{Timeout: 5 * time.Second}
-	resp, err := httpClient.Head(url)
-	if err != nil {
-		return false
-	}
-	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
+	return logoURL, darkLogoURL
 }
 
 // clearClientStatus clears the ClientID from status, triggering recreation on next reconcile.
@@ -924,16 +1003,6 @@ func (r *Reconciler) clearSCIMProviderID(ctx context.Context, oidcClient *pocket
 	return r.ClearStatusField(ctx, oidcClient, func() {
 		oidcClient.Status.SCIMProviderID = ""
 	})
-}
-
-// updateLogoStatus persists the resolved logo URLs and their reachability state to the CR status.
-func (r *Reconciler) updateLogoStatus(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, logoURL string, logoReachable bool, darkLogoURL string, darkLogoReachable bool) error {
-	base := oidcClient.DeepCopy()
-	oidcClient.Status.LogoURL = logoURL
-	oidcClient.Status.LogoReachable = &logoReachable
-	oidcClient.Status.DarkLogoURL = darkLogoURL
-	oidcClient.Status.DarkLogoReachable = &darkLogoReachable
-	return r.Status().Patch(ctx, oidcClient, client.MergeFrom(base))
 }
 
 // UpdateOIDCClientStatus updates the OIDCClient status with values returned from pocket-id

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -263,6 +263,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	_ = r.SetReadyCondition(ctx, oidcClient, metav1.ConditionTrue, "Reconciled", "OIDC client is in sync")
 
+	if r.logoDeletePending(oidcClient) {
+		return ctrl.Result{RequeueAfter: common.RequeueImmediate}, nil
+	}
+
 	return common.ApplyResync(ctrl.Result{}), nil
 }
 
@@ -797,7 +801,7 @@ func (r *Reconciler) reconcileLogoSide(ctx context.Context, apiClient PocketIDOI
 	switch {
 	case resolved == "" || r.logoURLFailed(resolved):
 		// Nothing will be pushed here: the spec asks for no logo, or for a URL Pocket-ID already refused
-		if applied == "" || applied == resolved {
+		if !logoStranded(resolved, applied) {
 			return "", applied, nil
 		}
 		logf.FromContext(ctx).Info("Removing logo the spec no longer asks for", "url", applied, "light", light)
@@ -819,6 +823,19 @@ func (r *Reconciler) expireFailedLogoURLs() {
 	}
 	r.failedLogoURLs = nil
 	r.failedLogoURLsResetAt = time.Now()
+}
+
+// logoStranded reports an applied logo the spec has moved away from. A refused URL that is
+// still the applied one leaves nothing stranded.
+func logoStranded(resolved, applied string) bool {
+	return applied != "" && applied != resolved
+}
+
+// logoDeletePending reports a logo stranded by a URL refused during this pass.
+func (r *Reconciler) logoDeletePending(oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient) bool {
+	light, dark := r.resolveLogoURLs(oidcClient)
+	return (r.logoURLFailed(light) && logoStranded(light, oidcClient.Status.LogoURL)) ||
+		(r.logoURLFailed(dark) && logoStranded(dark, oidcClient.Status.DarkLogoURL))
 }
 
 func (r *Reconciler) logoURLFailed(url string) bool {

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -785,23 +785,20 @@ func (r *Reconciler) reconcileLogos(ctx context.Context, oidcClient *pocketidint
 }
 
 // reconcileLogoSide resolves one side of the logo state, deleting a logo the operator
-// applied and the spec has stopped asking for. It returns the URL to send with the client
+// applied that no later pass can replace. It returns the URL to send with the client
 // update ("" sends nothing) and the applied record as it stands after any deletion.
 func (r *Reconciler) reconcileLogoSide(ctx context.Context, apiClient PocketIDOIDCClientAPI, clientID string, light bool, resolved, applied string, serverHasLogo bool) (push, stillApplied string, err error) {
 	switch {
-	case resolved == "" && applied == "":
-		// Nothing resolves and nothing was applied: this side is not the operator's.
-		return "", "", nil
-	case resolved == "":
+	case resolved == "" || r.logoURLFailed(resolved):
+		// Nothing will be pushed here: the spec asks for no logo, or for a URL Pocket-ID already refused
+		if applied == "" || applied == resolved {
+			return "", applied, nil
+		}
 		logf.FromContext(ctx).Info("Removing logo the spec no longer asks for", "url", applied, "light", light)
 		if err := apiClient.DeleteOIDCClientLogo(ctx, clientID, light); err != nil {
 			return "", applied, fmt.Errorf("delete OIDC client logo: %w", err)
 		}
 		return "", "", nil
-	case r.logoURLFailed(resolved):
-		// Pocket-ID already refused this URL. Re-sending it costs a download attempt per
-		// resync and converges on nothing.
-		return "", applied, nil
 	case resolved != applied || !serverHasLogo:
 		return resolved, applied, nil
 	default:

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -63,8 +63,8 @@ const (
 	// its metadata document ahead of the cache TTL.
 	refreshClientMetadataAnnotation = "pocketid.internal/refresh-client-metadata"
 
-	defaultLogoTemplate     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}.png"
-	defaultDarkLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}-dark.png"
+	defaultLogoTemplate     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
+	defaultDarkLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
 
 	// failedLogoURLTTL is how long a URL Pocket-ID refused stays suppressed.
 	failedLogoURLTTL = 24 * time.Hour

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -525,7 +525,7 @@ func (r *Reconciler) pushOIDCClientState(ctx context.Context, oidcClient *pocket
 
 	if !clientChanged && !shouldPushCredentials && !groupsChanged && !logos.hasPush() {
 		log.V(1).Info("OIDC client state is in sync, skipping update")
-		return false, r.applyLogoStatus(ctx, oidcClient, logos)
+		return false, nil
 	}
 
 	log.Info("Updating OIDC client", "name", oidcClient.Name)
@@ -766,19 +766,22 @@ func (p *logoPlan) commit() {
 func (r *Reconciler) reconcileLogos(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, apiClient PocketIDOIDCClientAPI, current *pocketid.OIDCClient) (logoPlan, error) {
 	light, dark := r.resolveLogoURLs(oidcClient)
 
-	var plan logoPlan
+	plan := logoPlan{appliedLight: oidcClient.Status.LogoURL, appliedDark: oidcClient.Status.DarkLogoURL}
 	var err error
 	plan.pushLight, plan.appliedLight, err = r.reconcileLogoSide(
-		ctx, apiClient, current.ID, true, light, oidcClient.Status.LogoURL, current.HasLogo)
-	if err != nil {
-		return logoPlan{}, err
+		ctx, apiClient, current.ID, true, light, plan.appliedLight, current.HasLogo)
+	if err == nil {
+		plan.pushDark, plan.appliedDark, err = r.reconcileLogoSide(
+			ctx, apiClient, current.ID, false, dark, plan.appliedDark, current.HasDarkLogo)
 	}
-	plan.pushDark, plan.appliedDark, err = r.reconcileLogoSide(
-		ctx, apiClient, current.ID, false, dark, oidcClient.Status.DarkLogoURL, current.HasDarkLogo)
-	if err != nil {
-		return logoPlan{}, err
+
+	// A deletion cannot be taken back, so drop the applied record now rather than after the
+	// push. Anything failing in between would otherwise leave status owning a logo that is
+	// gone, and delete whatever was uploaded in its place on the next pass.
+	if statusErr := r.applyLogoStatus(ctx, oidcClient, plan); err == nil {
+		err = statusErr
 	}
-	return plan, nil
+	return plan, err
 }
 
 // reconcileLogoSide resolves one side of the logo state, deleting a logo the operator
@@ -792,7 +795,7 @@ func (r *Reconciler) reconcileLogoSide(ctx context.Context, apiClient PocketIDOI
 	case resolved == "":
 		logf.FromContext(ctx).Info("Removing logo the spec no longer asks for", "url", applied, "light", light)
 		if err := apiClient.DeleteOIDCClientLogo(ctx, clientID, light); err != nil {
-			return "", "", fmt.Errorf("delete OIDC client logo: %w", err)
+			return "", applied, fmt.Errorf("delete OIDC client logo: %w", err)
 		}
 		return "", "", nil
 	case r.logoURLFailed(resolved):

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -753,8 +754,17 @@ func (r *Reconciler) OidcClientInput(oidcClient *pocketidinternalv1alpha1.Pocket
 // logoPlan is the outcome of reconcileLogos: the URLs to attach to the client update and
 // the record of what the operator has applied.
 type logoPlan struct {
-	pushLight, pushDark       string
-	appliedLight, appliedDark string
+	resolvedLight, resolvedDark string
+	pushLight, pushDark         string
+	appliedLight, appliedDark   string
+}
+
+// logoReachable reports whether Pocket-ID holds the logo the spec asks for on one side.
+func logoReachable(resolved, applied string) *bool {
+	if resolved == "" {
+		return nil
+	}
+	return ptr.To(applied == resolved)
 }
 
 func (p *logoPlan) hasPush() bool { return p.pushLight != "" || p.pushDark != "" }
@@ -776,7 +786,10 @@ func (r *Reconciler) reconcileLogos(ctx context.Context, oidcClient *pocketidint
 	r.expireFailedLogoURLs()
 	light, dark := r.resolveLogoURLs(oidcClient)
 
-	plan := logoPlan{appliedLight: oidcClient.Status.LogoURL, appliedDark: oidcClient.Status.DarkLogoURL}
+	plan := logoPlan{
+		resolvedLight: light, resolvedDark: dark,
+		appliedLight: oidcClient.Status.LogoURL, appliedDark: oidcClient.Status.DarkLogoURL,
+	}
 	var err error
 	plan.pushLight, plan.appliedLight, err = r.reconcileLogoSide(
 		ctx, apiClient, current.ID, true, light, plan.appliedLight, current.HasLogo)
@@ -857,12 +870,17 @@ func (r *Reconciler) markLogoURLsFailed(urls ...string) {
 
 // applyLogoStatus records which logo URLs the operator has successfully applied.
 func (r *Reconciler) applyLogoStatus(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, plan logoPlan) error {
-	if plan.appliedLight == oidcClient.Status.LogoURL && plan.appliedDark == oidcClient.Status.DarkLogoURL {
+	light := logoReachable(plan.resolvedLight, plan.appliedLight)
+	dark := logoReachable(plan.resolvedDark, plan.appliedDark)
+	if plan.appliedLight == oidcClient.Status.LogoURL && plan.appliedDark == oidcClient.Status.DarkLogoURL &&
+		ptr.Equal(light, oidcClient.Status.LogoReachable) && ptr.Equal(dark, oidcClient.Status.DarkLogoReachable) {
 		return nil
 	}
 	base := oidcClient.DeepCopy()
 	oidcClient.Status.LogoURL = plan.appliedLight
+	oidcClient.Status.LogoReachable = light
 	oidcClient.Status.DarkLogoURL = plan.appliedDark
+	oidcClient.Status.DarkLogoReachable = dark
 	return r.Status().Patch(ctx, oidcClient, client.MergeFrom(base))
 }
 

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -778,8 +778,8 @@ func (r *Reconciler) reconcileLogos(ctx context.Context, oidcClient *pocketidint
 	// A deletion cannot be taken back, so drop the applied record now rather than after the
 	// push. Anything failing in between would otherwise leave status owning a logo that is
 	// gone, and delete whatever was uploaded in its place on the next pass.
-	if statusErr := r.applyLogoStatus(ctx, oidcClient, plan); err == nil {
-		err = statusErr
+	if statusErr := r.applyLogoStatus(ctx, oidcClient, plan); statusErr != nil {
+		err = stderrors.Join(err, statusErr)
 	}
 	return plan, err
 }

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -64,6 +64,9 @@ const (
 
 	defaultLogoTemplate     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}.png"
 	defaultDarkLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/{{name}}-dark.png"
+
+	// failedLogoURLTTL is how long a URL Pocket-ID refused stays suppressed.
+	failedLogoURLTTL = 24 * time.Hour
 )
 
 // errAwaitingCIMD reports that a metadata-document client does not exist in Pocket-ID yet.
@@ -87,9 +90,11 @@ type Reconciler struct {
 	// DefaultDarkLogoTemplate is the default URL template for dark logos (from DEFAULT_DARK_LOGO_URL env var).
 	DefaultDarkLogoTemplate string
 
-	// failedLogoURLs records logo URLs Pocket-ID refused and will mnot be retried during the lifecycle of this container.
+	// failedLogoURLs records logo URLs Pocket-ID refused, which are not retried until the whole set is dropped on the failedLogoURLTTL deadline below.
 	// This is safe as long as max concurrent reconciles is 1
 	failedLogoURLs map[string]struct{}
+	// failedLogoURLsResetAt is when failedLogoURLs was last dropped. The zero value expires immediately, so the first reconcile after startup stamps it.
+	failedLogoURLsResetAt time.Time
 
 	// pendingInitialMint marks clients created (not adopted) by the operator whose client
 	// secret has not yet been stored. It lets storeClientSecret=false permit the one-time
@@ -764,6 +769,7 @@ func (p *logoPlan) commit() {
 // UI — which never gets an applied record — is never deleted, and a client that resolves
 // only a light URL keeps its uploaded dark logo.
 func (r *Reconciler) reconcileLogos(ctx context.Context, oidcClient *pocketidinternalv1alpha1.PocketIDOIDCClient, apiClient PocketIDOIDCClientAPI, current *pocketid.OIDCClient) (logoPlan, error) {
+	r.expireFailedLogoURLs()
 	light, dark := r.resolveLogoURLs(oidcClient)
 
 	plan := logoPlan{appliedLight: oidcClient.Status.LogoURL, appliedDark: oidcClient.Status.DarkLogoURL}
@@ -804,6 +810,15 @@ func (r *Reconciler) reconcileLogoSide(ctx context.Context, apiClient PocketIDOI
 	default:
 		return "", applied, nil
 	}
+}
+
+// expireFailedLogoURLs drops the whole refusal set once per TTL.
+func (r *Reconciler) expireFailedLogoURLs() {
+	if time.Since(r.failedLogoURLsResetAt) < failedLogoURLTTL {
+		return
+	}
+	r.failedLogoURLs = nil
+	r.failedLogoURLsResetAt = time.Now()
 }
 
 func (r *Reconciler) logoURLFailed(url string) bool {

--- a/internal/controller/oidcclient/controller_test.go
+++ b/internal/controller/oidcclient/controller_test.go
@@ -76,11 +76,11 @@ func TestOidcClientInput(t *testing.T) {
 	if input.Description != "a test client" {
 		t.Errorf("expected Description %q, got %q", "a test client", input.Description)
 	}
-	if !input.HasLogo {
-		t.Error("expected HasLogo to be true")
+	if input.LogoURL != "https://example.com/logo.png" {
+		t.Errorf("expected LogoURL to pass through, got %q", input.LogoURL)
 	}
-	if !input.HasDarkLogo {
-		t.Error("expected HasDarkLogo to be true")
+	if input.DarkLogoURL != "https://example.com/logo-dark.png" {
+		t.Errorf("expected DarkLogoURL to pass through, got %q", input.DarkLogoURL)
 	}
 	if !input.IsGroupRestricted {
 		t.Error("expected IsGroupRestricted to be true")
@@ -2639,6 +2639,9 @@ func (f *fakeSCIMAPI) CreateOIDCClientSecret(_ context.Context, _, _ string) (po
 	panic("not implemented")
 }
 func (f *fakeSCIMAPI) DeleteOIDCClientSecret(_ context.Context, _, _ string) error {
+	panic("not implemented")
+}
+func (f *fakeSCIMAPI) DeleteOIDCClientLogo(_ context.Context, _ string, _ bool) error {
 	panic("not implemented")
 }
 func (f *fakeSCIMAPI) GetOIDCClientSCIMServiceProvider(_ context.Context, oidcClientID string) (*pocketid.SCIMServiceProvider, error) {

--- a/internal/controller/oidcclient/existence_test.go
+++ b/internal/controller/oidcclient/existence_test.go
@@ -79,6 +79,10 @@ func (m *mockPocketIDOIDCClientClient) DeleteOIDCClientSecret(_ context.Context,
 	return nil
 }
 
+func (m *mockPocketIDOIDCClientClient) DeleteOIDCClientLogo(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+
 func (m *mockPocketIDOIDCClientClient) GetOIDCClientSCIMServiceProvider(_ context.Context, _ string) (*pocketid.SCIMServiceProvider, error) {
 	return nil, nil
 }

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -3,9 +3,10 @@ package oidcclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"slices"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -131,11 +132,12 @@ func TestOidcClientInput_SpecCallbackURLsTakePrecedenceOverCurrent(t *testing.T)
 
 func boolPtr(b bool) *bool { return &b }
 
-func alwaysReachable(_ string) bool { return true }
-
-func neverReachable(_ string) bool { return false }
-
-func onlyLightReachable(url string) bool { return !strings.Contains(url, "-dark") }
+// namedClient builds a bare CR whose metadata.name drives {{name}} substitution.
+func namedClient(name string) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+	return &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+	}
+}
 
 func TestResolveLogoURLs_DeprecatedFieldsTakePrecedence(t *testing.T) {
 	r := &Reconciler{DefaultLogoTemplate: "https://cdn.example.com/{{name}}.png"}
@@ -147,39 +149,28 @@ func TestResolveLogoURLs_DeprecatedFieldsTakePrecedence(t *testing.T) {
 			Logo:        &pocketidinternalv1alpha1.OIDCClientLogoSpec{AutoGenerate: boolPtr(true)},
 		},
 	}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, darkLogoURL := r.resolveLogoURLs(oidcClient)
 	if logoURL != "https://explicit.example.com/logo.png" {
 		t.Errorf("expected deprecated logoUrl to win, got %q", logoURL)
-	}
-	if !logoReachable {
-		t.Error("expected logoReachable to be true for deprecated field")
 	}
 	if darkLogoURL != "https://explicit.example.com/logo-dark.png" {
 		t.Errorf("expected deprecated darkLogoUrl to win, got %q", darkLogoURL)
 	}
-	if !darkLogoReachable {
-		t.Error("expected darkLogoReachable to be true for deprecated field")
-	}
 
-	// Verify OidcClientInput correctly passes through reachable logo URLs
+	// Verify OidcClientInput passes the resolved URLs through to the payload
 	input := r.OidcClientInput(oidcClient, nil, logoURL, darkLogoURL)
-	if input.LogoURL != "https://explicit.example.com/logo.png" {
+	if input.LogoURL != logoURL {
 		t.Errorf("expected logoUrl in OidcClientInput, got %q", input.LogoURL)
 	}
-	if input.DarkLogoURL != "https://explicit.example.com/logo-dark.png" {
+	if input.DarkLogoURL != darkLogoURL {
 		t.Errorf("expected darkLogoUrl in OidcClientInput, got %q", input.DarkLogoURL)
-	}
-	if !input.HasLogo {
-		t.Error("expected HasLogo to be true")
-	}
-	if !input.HasDarkLogo {
-		t.Error("expected HasDarkLogo to be true")
 	}
 }
 
 func TestResolveLogoURLs_NameOverride(t *testing.T) {
-	r := &Reconciler{IsLogoReachable: alwaysReachable}
+	r := &Reconciler{}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
 				AutoGenerate: boolPtr(true),
@@ -188,7 +179,7 @@ func TestResolveLogoURLs_NameOverride(t *testing.T) {
 			},
 		},
 	}
-	logoURL, _, _, _ := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, _ := r.resolveLogoURLs(oidcClient)
 	if logoURL != "https://cdn.example.com/custom-icon.png" {
 		t.Errorf("expected nameOverride to be used, got %q", logoURL)
 	}
@@ -198,16 +189,16 @@ func TestResolveLogoURLs_EnvVarFallback(t *testing.T) {
 	r := &Reconciler{
 		DefaultLogoTemplate:     "https://cdn.example.com/{{name}}.png",
 		DefaultDarkLogoTemplate: "https://cdn.example.com/{{name}}-dark.png",
-		IsLogoReachable:         alwaysReachable,
 	}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
 				AutoGenerate: boolPtr(true),
 			},
 		},
 	}
-	logoURL, _, darkLogoURL, _ := r.resolveLogoURLs(context.Background(), oidcClient, "grafana")
+	logoURL, darkLogoURL := r.resolveLogoURLs(oidcClient)
 	if logoURL != "https://cdn.example.com/grafana.png" {
 		t.Errorf("expected env var fallback, got %q", logoURL)
 	}
@@ -217,15 +208,16 @@ func TestResolveLogoURLs_EnvVarFallback(t *testing.T) {
 }
 
 func TestResolveLogoURLs_HardcodedDefaults(t *testing.T) {
-	r := &Reconciler{IsLogoReachable: alwaysReachable}
+	r := &Reconciler{}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
 				AutoGenerate: boolPtr(true),
 			},
 		},
 	}
-	logoURL, _, darkLogoURL, _ := r.resolveLogoURLs(context.Background(), oidcClient, "grafana")
+	logoURL, darkLogoURL := r.resolveLogoURLs(oidcClient)
 	if logoURL != grafanaLogoURL {
 		t.Errorf("expected hardcoded default logo template, got %q", logoURL)
 	}
@@ -237,24 +229,23 @@ func TestResolveLogoURLs_HardcodedDefaults(t *testing.T) {
 func TestResolveLogoURLs_AutoGenerateFalse(t *testing.T) {
 	r := &Reconciler{}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
 				AutoGenerate: boolPtr(false),
 			},
 		},
 	}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, darkLogoURL := r.resolveLogoURLs(oidcClient)
 	if logoURL != "" || darkLogoURL != "" {
 		t.Errorf("expected empty URLs when autoGenerate=false, got %q %q", logoURL, darkLogoURL)
-	}
-	if logoReachable || darkLogoReachable {
-		t.Error("expected reachable to be false when autoGenerate=false")
 	}
 }
 
 func TestResolveLogoURLs_ExplicitURLIgnoresAutoGenerateFalse(t *testing.T) {
-	r := &Reconciler{IsLogoReachable: alwaysReachable}
+	r := &Reconciler{}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
 				AutoGenerate: boolPtr(false),
@@ -262,37 +253,26 @@ func TestResolveLogoURLs_ExplicitURLIgnoresAutoGenerateFalse(t *testing.T) {
 			},
 		},
 	}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, darkLogoURL := r.resolveLogoURLs(oidcClient)
 	if logoURL != "https://cdn.example.com/my-app.png" {
 		t.Errorf("expected explicit logoUrl to be used despite autoGenerate=false, got %q", logoURL)
 	}
-	if !logoReachable {
-		t.Error("expected logoReachable to be true")
-	}
 	if darkLogoURL != "" {
 		t.Errorf("expected dark logo to be empty when not set and autoGenerate=false, got %q", darkLogoURL)
-	}
-	if darkLogoReachable {
-		t.Error("expected darkLogoReachable to be false")
 	}
 }
 
 func TestResolveLogoURLs_NilLogoSpecEnvFalse(t *testing.T) {
 	r := &Reconciler{DefaultAutoGenerateLogos: false}
-	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, darkLogoURL := r.resolveLogoURLs(namedClient("my-app"))
 	if logoURL != "" || darkLogoURL != "" {
 		t.Errorf("expected empty URLs when logo spec is nil and env is false, got %q %q", logoURL, darkLogoURL)
-	}
-	if logoReachable || darkLogoReachable {
-		t.Error("expected reachable to be false when env is false")
 	}
 }
 
 func TestResolveLogoURLs_NilLogoSpecEnvTrue(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: true, IsLogoReachable: alwaysReachable}
-	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
-	logoURL, _, darkLogoURL, _ := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	r := &Reconciler{DefaultAutoGenerateLogos: true}
+	logoURL, darkLogoURL := r.resolveLogoURLs(namedClient("my-app"))
 	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/my-app.png" {
 		t.Errorf("expected hardcoded default when logo spec is nil and env is true, got %q", logoURL)
 	}
@@ -302,13 +282,14 @@ func TestResolveLogoURLs_NilLogoSpecEnvTrue(t *testing.T) {
 }
 
 func TestResolveLogoURLs_AutoGenerateNilDefaultsToEnvTrue(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: true, IsLogoReachable: alwaysReachable}
+	r := &Reconciler{DefaultAutoGenerateLogos: true}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{},
 		},
 	}
-	logoURL, _, _, _ := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, _ := r.resolveLogoURLs(oidcClient)
 	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/my-app.png" {
 		t.Errorf("expected nil autoGenerate to follow env default true, got %q", logoURL)
 	}
@@ -317,82 +298,37 @@ func TestResolveLogoURLs_AutoGenerateNilDefaultsToEnvTrue(t *testing.T) {
 func TestResolveLogoURLs_AutoGenerateNilDefaultsToEnvFalse(t *testing.T) {
 	r := &Reconciler{DefaultAutoGenerateLogos: false}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{},
 		},
 	}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, darkLogoURL := r.resolveLogoURLs(oidcClient)
 	if logoURL != "" || darkLogoURL != "" {
 		t.Errorf("expected empty URLs when env default is false, got %q %q", logoURL, darkLogoURL)
-	}
-	if logoReachable || darkLogoReachable {
-		t.Error("expected reachable to be false when env default is false")
 	}
 }
 
 func TestResolveLogoURLs_ExplicitTrueOverridesEnvFalse(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: false, IsLogoReachable: alwaysReachable}
+	r := &Reconciler{DefaultAutoGenerateLogos: false}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
 				AutoGenerate: boolPtr(true),
 			},
 		},
 	}
-	logoURL, logoReachable, _, _ := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, _ := r.resolveLogoURLs(oidcClient)
 	if logoURL == "" {
 		t.Error("expected explicit autoGenerate=true to override env default false")
-	}
-	if !logoReachable {
-		t.Error("expected logoReachable to be true")
-	}
-}
-
-func TestResolveLogoURLs_UnreachableLogosStillReturnURL(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: true, IsLogoReachable: neverReachable}
-	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
-		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
-			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
-				AutoGenerate: boolPtr(true),
-			},
-		},
-	}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
-	if logoURL == "" || darkLogoURL == "" {
-		t.Errorf("expected URLs to still be returned when unreachable, got %q %q", logoURL, darkLogoURL)
-	}
-	if logoReachable || darkLogoReachable {
-		t.Error("expected reachable to be false when logos are unreachable")
-	}
-}
-
-func TestResolveLogoURLs_OnlyLightReachable(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: true, IsLogoReachable: onlyLightReachable}
-	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
-		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
-			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
-				AutoGenerate: boolPtr(true),
-			},
-		},
-	}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "grafana")
-	if logoURL != grafanaLogoURL {
-		t.Errorf("expected light logo URL, got %q", logoURL)
-	}
-	if !logoReachable {
-		t.Error("expected light logo to be reachable")
-	}
-	if darkLogoURL != grafanaDarkLogoURL {
-		t.Errorf("expected dark logo URL to still be returned, got %q", darkLogoURL)
-	}
-	if darkLogoReachable {
-		t.Error("expected dark logo to be unreachable")
 	}
 }
 
 func TestResolveLogoURLs_PerClientTemplateOverridesEnvVar(t *testing.T) {
-	r := &Reconciler{DefaultLogoTemplate: "https://default.example.com/{{name}}.png", IsLogoReachable: alwaysReachable}
+	r := &Reconciler{DefaultLogoTemplate: "https://default.example.com/{{name}}.png"}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{
 				AutoGenerate: boolPtr(true),
@@ -400,110 +336,194 @@ func TestResolveLogoURLs_PerClientTemplateOverridesEnvVar(t *testing.T) {
 			},
 		},
 	}
-	logoURL, _, _, _ := r.resolveLogoURLs(context.Background(), oidcClient, "my-app")
+	logoURL, _ := r.resolveLogoURLs(oidcClient)
 	if logoURL != "https://custom.example.com/my-app.png" {
 		t.Errorf("expected per-client template to override env var, got %q", logoURL)
 	}
 }
 
-func TestResolveLogoURLs_SkipsHEADWhenStatusMatchesAndReachable(t *testing.T) {
-	headCalled := false
-	r := &Reconciler{
-		DefaultAutoGenerateLogos: true,
-		IsLogoReachable: func(string) bool {
-			headCalled = true
-			return true
-		},
+// --- reconcileLogos ---
+
+// fakeLogoAPI records logo deletions. The embedded interface leaves every other method nil,
+// so an unexpected call panics rather than silently passing.
+type fakeLogoAPI struct {
+	PocketIDOIDCClientAPI
+	deleted []bool // one entry per delete, true for the light side
+	err     error
+}
+
+func (f *fakeLogoAPI) DeleteOIDCClientLogo(_ context.Context, _ string, light bool) error {
+	if f.err != nil {
+		return f.err
 	}
-	expectedLogo := grafanaLogoURL
-	expectedDark := grafanaDarkLogoURL
-	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+	f.deleted = append(f.deleted, light)
+	return nil
+}
+
+// logoClient builds a CR whose spec resolves to the given URLs via the deprecated fields,
+// with appliedLight/appliedDark already recorded in status.
+func logoClient(light, dark, appliedLight, appliedDark string) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+	return &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			LogoURL:     light,
+			DarkLogoURL: dark,
+			Logo:        &pocketidinternalv1alpha1.OIDCClientLogoSpec{AutoGenerate: boolPtr(false)},
+		},
 		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
-			LogoURL:           expectedLogo,
-			LogoReachable:     boolPtr(true),
-			DarkLogoURL:       expectedDark,
-			DarkLogoReachable: boolPtr(true),
+			LogoURL:     appliedLight,
+			DarkLogoURL: appliedDark,
 		},
-	}
-	logoURL, logoReachable, darkLogoURL, darkLogoReachable := r.resolveLogoURLs(context.Background(), oidcClient, "grafana")
-	if headCalled {
-		t.Error("expected HEAD check to be skipped when status matches and logo was reachable")
-	}
-	if logoURL != expectedLogo {
-		t.Errorf("expected %q, got %q", expectedLogo, logoURL)
-	}
-	if !logoReachable {
-		t.Error("expected logoReachable to be true")
-	}
-	if darkLogoURL != expectedDark {
-		t.Errorf("expected %q, got %q", expectedDark, darkLogoURL)
-	}
-	if !darkLogoReachable {
-		t.Error("expected darkLogoReachable to be true")
 	}
 }
 
-func TestResolveLogoURLs_RunsHEADWhenURLChanges(t *testing.T) {
-	headCalled := false
-	r := &Reconciler{
-		DefaultAutoGenerateLogos: true,
-		IsLogoReachable: func(string) bool {
-			headCalled = true
-			return true
+func TestReconcileLogos_BehaviorTable(t *testing.T) {
+	const url = "https://cdn.example.com/logo.png"
+
+	tests := []struct {
+		name                  string
+		resolved, applied     string
+		serverHasLogo         bool
+		failed                bool
+		wantPush, wantApplied string
+		wantDelete            bool
+	}{
+		{
+			name: "unowned side is left alone",
+		},
+		{
+			name:          "uploaded logo is never deleted",
+			serverHasLogo: true,
+		},
+		{
+			name:    "applied logo the spec dropped is deleted",
+			applied: url, serverHasLogo: true, wantDelete: true,
+		},
+		{
+			name:     "a URL Pocket-ID refused is not retried",
+			resolved: url, failed: true,
+		},
+		{
+			name:     "a new URL is pushed",
+			resolved: url, wantPush: url, wantApplied: url,
+		},
+		{
+			name:     "a changed URL is pushed",
+			resolved: url, applied: "https://cdn.example.com/old.png", serverHasLogo: true,
+			wantPush: url, wantApplied: url,
+		},
+		{
+			name:     "an applied logo deleted server-side is re-pushed",
+			resolved: url, applied: url, wantPush: url, wantApplied: url,
+		},
+		{
+			name:     "an applied logo still in place is left alone",
+			resolved: url, applied: url, serverHasLogo: true, wantApplied: url,
 		},
 	}
-	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
-		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
-			LogoURL:       "https://old-cdn.example.com/grafana.png",
-			LogoReachable: boolPtr(true),
-		},
-	}
-	logoURL, logoReachable, _, _ := r.resolveLogoURLs(context.Background(), oidcClient, "grafana")
-	if !headCalled {
-		t.Error("expected HEAD check when resolved URL differs from status URL")
-	}
-	if logoURL != grafanaLogoURL {
-		t.Errorf("unexpected logo URL: %q", logoURL)
-	}
-	if !logoReachable {
-		t.Error("expected logoReachable to be true")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{}
+			if tt.failed {
+				r.markLogoURLsFailed(tt.resolved)
+			}
+			api := &fakeLogoAPI{}
+
+			// Run each row on both sides so neither is special-cased.
+			for _, light := range []bool{true, false} {
+				oidcClient := logoClient("", "", "", "")
+				current := &pocketid.OIDCClient{ID: "client-id"}
+				if light {
+					oidcClient.Spec.LogoURL, oidcClient.Status.LogoURL, current.HasLogo = tt.resolved, tt.applied, tt.serverHasLogo
+				} else {
+					oidcClient.Spec.DarkLogoURL, oidcClient.Status.DarkLogoURL, current.HasDarkLogo = tt.resolved, tt.applied, tt.serverHasLogo
+				}
+
+				api.deleted = nil
+				plan, err := r.reconcileLogos(context.Background(), oidcClient, api, current)
+				if err != nil {
+					t.Fatalf("light=%v: reconcileLogos: %v", light, err)
+				}
+				plan.commit()
+
+				push, applied := plan.pushDark, plan.appliedDark
+				if light {
+					push, applied = plan.pushLight, plan.appliedLight
+				}
+				if push != tt.wantPush {
+					t.Errorf("light=%v: push: got %q, want %q", light, push, tt.wantPush)
+				}
+				if applied != tt.wantApplied {
+					t.Errorf("light=%v: applied: got %q, want %q", light, applied, tt.wantApplied)
+				}
+				if want := []bool(nil); !tt.wantDelete && !slices.Equal(api.deleted, want) {
+					t.Errorf("light=%v: expected no deletions, got %v", light, api.deleted)
+				}
+				if tt.wantDelete && !slices.Equal(api.deleted, []bool{light}) {
+					t.Errorf("light=%v: expected one deletion of that side, got %v", light, api.deleted)
+				}
+			}
+		})
 	}
 }
 
-func TestResolveLogoURLs_RunsHEADWhenNotReachable(t *testing.T) {
-	headCalled := false
-	r := &Reconciler{
-		DefaultAutoGenerateLogos: true,
-		IsLogoReachable: func(string) bool {
-			headCalled = true
-			return true
-		},
+// A client that resolves only a light URL must not disturb an uploaded dark logo.
+func TestReconcileLogos_OnlyLightResolvedLeavesUploadedDarkLogo(t *testing.T) {
+	r := &Reconciler{}
+	api := &fakeLogoAPI{}
+	oidcClient := logoClient("https://cdn.example.com/logo.png", "", "", "")
+	current := &pocketid.OIDCClient{ID: "client-id", HasDarkLogo: true}
+
+	plan, err := r.reconcileLogos(context.Background(), oidcClient, api, current)
+	if err != nil {
+		t.Fatalf("reconcileLogos: %v", err)
 	}
-	expectedLogo := grafanaLogoURL
-	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
-		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
-			LogoURL:       expectedLogo,
-			LogoReachable: boolPtr(false),
-		},
+	if len(api.deleted) != 0 {
+		t.Errorf("expected no deletions, got %v", api.deleted)
 	}
-	logoURL, logoReachable, _, _ := r.resolveLogoURLs(context.Background(), oidcClient, "grafana")
-	if !headCalled {
-		t.Error("expected HEAD check when logo URL matches but was not reachable")
+	if plan.pushDark != "" {
+		t.Errorf("expected no dark push, got %q", plan.pushDark)
 	}
-	if logoURL != expectedLogo {
-		t.Errorf("expected %q, got %q", expectedLogo, logoURL)
-	}
-	if !logoReachable {
-		t.Error("expected logoReachable to be true after successful HEAD check")
+	if plan.pushLight != "https://cdn.example.com/logo.png" {
+		t.Errorf("expected the light URL to be pushed, got %q", plan.pushLight)
 	}
 }
 
-func TestUpdateLogoStatus_SetsReachableFalseExplicitly(t *testing.T) {
+func TestReconcileLogos_DeleteFailurePropagates(t *testing.T) {
+	r := &Reconciler{}
+	api := &fakeLogoAPI{err: errors.New("boom")}
+	oidcClient := logoClient("", "", "https://cdn.example.com/logo.png", "")
+
+	if _, err := r.reconcileLogos(context.Background(), oidcClient, api, &pocketid.OIDCClient{ID: "client-id"}); err == nil {
+		t.Fatal("expected the delete failure to propagate")
+	}
+}
+
+func TestMarkLogoURLsFailed_IgnoresEmptyAndKeysByURL(t *testing.T) {
+	r := &Reconciler{}
+	r.markLogoURLsFailed("", "https://cdn.example.com/logo.png")
+	if r.logoURLFailed("") {
+		t.Error("an empty URL must not be recorded")
+	}
+	if !r.logoURLFailed("https://cdn.example.com/logo.png") {
+		t.Error("expected the URL to be recorded as failed")
+	}
+	if r.logoURLFailed("https://cdn.example.com/other.png") {
+		t.Error("a different URL must not inherit the failure")
+	}
+}
+
+func TestApplyLogoStatus_PersistsAppliedURLs(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
 
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-client", Namespace: testNamespace},
+		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
+			LogoURL:     "https://example.com/old.png",
+			DarkLogoURL: "https://example.com/old-dark.png",
+		},
 	}
 
 	fc := fake.NewClientBuilder().
@@ -516,32 +536,21 @@ func TestUpdateLogoStatus_SetsReachableFalseExplicitly(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Simulate: light logo reachable, dark logo not reachable
-	err := r.updateLogoStatus(ctx, oidcClient, "https://example.com/logo.png", true, "https://example.com/logo-dark.png", false)
-	if err != nil {
-		t.Fatalf("updateLogoStatus failed: %v", err)
+	// Light logo newly applied, dark logo released back to Pocket-ID.
+	plan := logoPlan{appliedLight: "https://example.com/logo.png"}
+	if err := r.applyLogoStatus(ctx, oidcClient, plan); err != nil {
+		t.Fatalf("applyLogoStatus failed: %v", err)
 	}
 
-	// Re-fetch from the fake API server
 	fetched := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
 	if err := fc.Get(ctx, client.ObjectKeyFromObject(oidcClient), fetched); err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
-
 	if fetched.Status.LogoURL != "https://example.com/logo.png" {
-		t.Errorf("expected logoUrl to be set, got %q", fetched.Status.LogoURL)
+		t.Errorf("expected logoUrl to be recorded, got %q", fetched.Status.LogoURL)
 	}
-	if fetched.Status.LogoReachable == nil || *fetched.Status.LogoReachable != true {
-		t.Error("expected logoReachable to be explicitly true")
-	}
-	if fetched.Status.DarkLogoURL != "https://example.com/logo-dark.png" {
-		t.Errorf("expected darkLogoUrl to be set, got %q", fetched.Status.DarkLogoURL)
-	}
-	if fetched.Status.DarkLogoReachable == nil {
-		t.Fatal("expected darkLogoReachable to be explicitly set, got nil")
-	}
-	if *fetched.Status.DarkLogoReachable != false {
-		t.Error("expected darkLogoReachable to be false")
+	if fetched.Status.DarkLogoURL != "" {
+		t.Errorf("expected darkLogoUrl to be cleared, got %q", fetched.Status.DarkLogoURL)
 	}
 }
 
@@ -866,5 +875,193 @@ func TestPushOIDCClientState_IsGroupRestrictedReflectsAggregation(t *testing.T) 
 	}
 	if !groupsUpdateSent {
 		t.Error("expected group update when UserGroup reverse-references the OIDC client")
+	}
+}
+
+// --- Logo push behaviour ---
+
+// Issue #603: autoGenerate=false against a client whose logo was uploaded through the UI
+// used to diff hasLogo forever, re-issuing a PUT that could never converge.
+func TestPushOIDCClientState_UploadedLogoWithAutoGenerateOffMakesNoCalls(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	oidcClientCR := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "sync-client", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			CallbackURLs: []string{"https://example.com/cb"},
+			Logo:         &pocketidinternalv1alpha1.OIDCClientLogoSpec{AutoGenerate: boolPtr(false)},
+		},
+		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
+			ClientID:   "sync-id",
+			Conditions: readyCondition(),
+		},
+	}
+	current := &pocketid.OIDCClient{
+		ID:           "sync-id",
+		Name:         "sync-client",
+		CallbackURLs: []string{"https://example.com/cb"},
+		HasLogo:      true,
+		HasDarkLogo:  true,
+	}
+
+	r := newPushStateOIDCReconciler(scheme, oidcClientCR)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected %s %s: an uploaded logo is not the operator's to manage", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	apiClient, _ := pocketid.NewClient(ts.URL, "")
+
+	updated, err := r.pushOIDCClientState(ctx, oidcClientCR, apiClient, current)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated {
+		t.Error("expected no update")
+	}
+	if oidcClientCR.Status.LogoURL != "" || oidcClientCR.Status.DarkLogoURL != "" {
+		t.Errorf("expected no applied record for an uploaded logo, got %q %q",
+			oidcClientCR.Status.LogoURL, oidcClientCR.Status.DarkLogoURL)
+	}
+}
+
+// A logo Pocket-ID cannot fetch must not hold the client back: the configuration is already
+// committed by the time the download runs, and failing here would re-push every resync.
+func TestPushOIDCClientState_LogoErrorIsNonFatalAndNotRetried(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	oidcClientCR := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "logo-client", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			LogoURL: "https://cdn.example.com/missing.png",
+		},
+		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
+			ClientID:   "logo-id",
+			Conditions: readyCondition(),
+		},
+	}
+	current := &pocketid.OIDCClient{ID: "logo-id", Name: "logo-client"}
+
+	r := newPushStateOIDCReconciler(scheme, oidcClientCR)
+	var puts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPut {
+			t.Errorf("unexpected %s %s", req.Method, req.URL.Path)
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+			return
+		}
+		puts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "Logo could not be downloaded", "code": "logo_download_failed", "request_id": "req-1",
+		})
+	}))
+	defer ts.Close()
+	apiClient, _ := pocketid.NewClient(ts.URL, "")
+
+	if _, err := r.pushOIDCClientState(ctx, oidcClientCR, apiClient, current); err != nil {
+		t.Fatalf("expected a logo failure to be non-fatal, got %v", err)
+	}
+	if puts != 1 {
+		t.Fatalf("expected exactly one PUT, got %d", puts)
+	}
+	if oidcClientCR.Status.LogoURL != "" {
+		t.Errorf("a rejected URL must not be recorded as applied, got %q", oidcClientCR.Status.LogoURL)
+	}
+
+	// Same URL: skipped entirely on the next pass.
+	if _, err := r.pushOIDCClientState(ctx, oidcClientCR, apiClient, current); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if puts != 1 {
+		t.Errorf("expected the failed URL not to be retried, got %d PUTs", puts)
+	}
+
+	// A different URL is a different key, so it is tried once.
+	oidcClientCR.Spec.LogoURL = "https://cdn.example.com/other.png"
+	if _, err := r.pushOIDCClientState(ctx, oidcClientCR, apiClient, current); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if puts != 2 {
+		t.Errorf("expected a changed URL to be attempted, got %d PUTs", puts)
+	}
+}
+
+// The default templates resolve a dark URL that dashboard-icons often does not have, so a
+// dark failure must leave the light logo owned, applied and retryable.
+func TestPushOIDCClientState_DarkLogoFailureLeavesLightLogoIntact(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	const lightURL = "https://cdn.example.com/app.png"
+	const darkURL = "https://cdn.example.com/app-dark.png"
+
+	oidcClientCR := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "logo-client", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			LogoURL:     lightURL,
+			DarkLogoURL: darkURL,
+		},
+		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
+			ClientID:   "logo-id",
+			Conditions: readyCondition(),
+		},
+	}
+	current := &pocketid.OIDCClient{ID: "logo-id", Name: "logo-client"}
+
+	r := newPushStateOIDCReconciler(scheme, oidcClientCR)
+	var sent []string // darkLogoUrl of each PUT, so the two updates are distinguishable
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		dark, _ := body["darkLogoUrl"].(string)
+		sent = append(sent, dark)
+
+		if dark == "" { // the light update
+			okOIDCClientResponse(w, "logo-id", "logo-client")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": "Logo could not be downloaded", "code": "logo_download_failed",
+		})
+	}))
+	defer ts.Close()
+	apiClient, _ := pocketid.NewClient(ts.URL, "")
+
+	if _, err := r.pushOIDCClientState(ctx, oidcClientCR, apiClient, current); err != nil {
+		t.Fatalf("expected the dark failure to be non-fatal, got %v", err)
+	}
+	if len(sent) != 2 || sent[0] != "" || sent[1] != darkURL {
+		t.Fatalf("expected one update per side, got %q", sent)
+	}
+	if oidcClientCR.Status.LogoURL != lightURL {
+		t.Errorf("light logo should stay applied, got %q", oidcClientCR.Status.LogoURL)
+	}
+	if oidcClientCR.Status.DarkLogoURL != "" {
+		t.Errorf("rejected dark logo must not be recorded, got %q", oidcClientCR.Status.DarkLogoURL)
+	}
+	if r.logoURLFailed(lightURL) {
+		t.Error("the light URL must not inherit the dark failure")
+	}
+	if !r.logoURLFailed(darkURL) {
+		t.Error("the dark URL should be remembered as failed")
+	}
+
+	// Next pass: light is in place and dark is skipped, so nothing is sent at all.
+	current.HasLogo = true
+	sent = nil
+	if _, err := r.pushOIDCClientState(ctx, oidcClientCR, apiClient, current); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sent) != 0 {
+		t.Errorf("expected no further updates, got %q", sent)
 	}
 }

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -487,6 +487,56 @@ func TestReconcileLogos_BehaviorTable(t *testing.T) {
 	}
 }
 
+func TestLogoDeletePending(t *testing.T) {
+	const url = "https://cdn.example.com/logo.png"
+
+	tests := []struct {
+		name              string
+		resolved, applied string
+		failed            bool
+		want              bool
+	}{
+		{
+			name:     "a URL still in play strands nothing",
+			resolved: url, applied: "https://cdn.example.com/old.png",
+		},
+		{
+			name:     "a refused URL stranding an applied logo",
+			resolved: url, applied: "https://cdn.example.com/old.png", failed: true, want: true,
+		},
+		{
+			name:     "a refused URL that is itself the applied one",
+			resolved: url, applied: url, failed: true,
+		},
+		{
+			name:     "a refused URL with nothing applied",
+			resolved: url, failed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run each row on both sides so neither is special-cased.
+			for _, light := range []bool{true, false} {
+				oidcClient := logoClient("", "", "")
+				if light {
+					oidcClient.Spec.LogoURL, oidcClient.Status.LogoURL = tt.resolved, tt.applied
+				} else {
+					oidcClient.Spec.DarkLogoURL, oidcClient.Status.DarkLogoURL = tt.resolved, tt.applied
+				}
+
+				r := &Reconciler{}
+				if tt.failed {
+					r.markLogoURLsFailed(tt.resolved)
+				}
+				if got := r.logoDeletePending(oidcClient); got != tt.want {
+					t.Errorf("light=%v: got %v, want %v", light, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
 // A client that resolves only a light URL must not disturb an uploaded dark logo.
 func TestReconcileLogos_OnlyLightResolvedLeavesUploadedDarkLogo(t *testing.T) {
 	r := &Reconciler{}

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	pocketidinternalv1alpha1 "github.com/aclerici38/pocket-id-operator/api/v1alpha1"
 	"github.com/aclerici38/pocket-id-operator/internal/pocketid"
@@ -1104,5 +1106,34 @@ func TestReconcileLogos_RecordsDeletionWhenTheOtherSideFails(t *testing.T) {
 	}
 	if fetched.Status.DarkLogoURL != "https://cdn.example.com/dark.png" {
 		t.Errorf("the failed deletion must keep its record, got %q", fetched.Status.DarkLogoURL)
+	}
+}
+
+// Neither failure should hide the other: the delete failure explains the reconcile, and the
+// status failure explains why the completed deletion was not recorded.
+func TestReconcileLogos_ReportsBothDeleteAndStatusFailures(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	oidcClient := logoClient("", "https://cdn.example.com/logo.png", "https://cdn.example.com/dark.png")
+	r := newPushStateOIDCReconciler(scheme, oidcClient)
+	r.Client = interceptor.NewClient(r.Client.(client.WithWatch), interceptor.Funcs{
+		SubResourcePatch: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+			return errors.New("simulated status patch failure")
+		},
+	})
+	r.EnsureClient(r.Client)
+
+	api := &fakeLogoAPI{errOn: map[bool]error{false: errors.New("delete refused")}}
+
+	_, err := r.reconcileLogos(context.Background(), oidcClient, api, &pocketid.OIDCClient{ID: "client-id"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "delete refused") {
+		t.Errorf("delete failure missing from %v", err)
+	}
+	if !strings.Contains(err.Error(), "simulated status patch failure") {
+		t.Errorf("status failure missing from %v", err)
 	}
 }

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -348,27 +348,30 @@ func TestResolveLogoURLs_PerClientTemplateOverridesEnvVar(t *testing.T) {
 // so an unexpected call panics rather than silently passing.
 type fakeLogoAPI struct {
 	PocketIDOIDCClientAPI
-	deleted []bool // one entry per delete, true for the light side
-	err     error
+	deleted []bool         // one entry per delete, true for the light side
+	err     error          // fails every delete
+	errOn   map[bool]error // fails one side, keyed the same way as deleted
 }
 
 func (f *fakeLogoAPI) DeleteOIDCClientLogo(_ context.Context, _ string, light bool) error {
 	if f.err != nil {
 		return f.err
 	}
+	if err := f.errOn[light]; err != nil {
+		return err
+	}
 	f.deleted = append(f.deleted, light)
 	return nil
 }
 
-// logoClient builds a CR whose spec resolves to the given URLs via the deprecated fields,
-// with appliedLight/appliedDark already recorded in status.
-func logoClient(light, dark, appliedLight, appliedDark string) *pocketidinternalv1alpha1.PocketIDOIDCClient {
+// logoClient builds a CR resolving light via the deprecated field, with appliedLight and
+// appliedDark already recorded in status. Callers needing a dark URL set it on the spec.
+func logoClient(light, appliedLight, appliedDark string) *pocketidinternalv1alpha1.PocketIDOIDCClient {
 	return &pocketidinternalv1alpha1.PocketIDOIDCClient{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
-			LogoURL:     light,
-			DarkLogoURL: dark,
-			Logo:        &pocketidinternalv1alpha1.OIDCClientLogoSpec{AutoGenerate: boolPtr(false)},
+			LogoURL: light,
+			Logo:    &pocketidinternalv1alpha1.OIDCClientLogoSpec{AutoGenerate: boolPtr(false)},
 		},
 		Status: pocketidinternalv1alpha1.PocketIDOIDCClientStatus{
 			LogoURL:     appliedLight,
@@ -422,17 +425,16 @@ func TestReconcileLogos_BehaviorTable(t *testing.T) {
 		},
 	}
 
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &Reconciler{}
-			if tt.failed {
-				r.markLogoURLsFailed(tt.resolved)
-			}
 			api := &fakeLogoAPI{}
 
 			// Run each row on both sides so neither is special-cased.
 			for _, light := range []bool{true, false} {
-				oidcClient := logoClient("", "", "", "")
+				oidcClient := logoClient("", "", "")
 				current := &pocketid.OIDCClient{ID: "client-id"}
 				if light {
 					oidcClient.Spec.LogoURL, oidcClient.Status.LogoURL, current.HasLogo = tt.resolved, tt.applied, tt.serverHasLogo
@@ -440,6 +442,10 @@ func TestReconcileLogos_BehaviorTable(t *testing.T) {
 					oidcClient.Spec.DarkLogoURL, oidcClient.Status.DarkLogoURL, current.HasDarkLogo = tt.resolved, tt.applied, tt.serverHasLogo
 				}
 
+				r := newPushStateOIDCReconciler(scheme, oidcClient)
+				if tt.failed {
+					r.markLogoURLsFailed(tt.resolved)
+				}
 				api.deleted = nil
 				plan, err := r.reconcileLogos(context.Background(), oidcClient, api, current)
 				if err != nil {
@@ -472,7 +478,7 @@ func TestReconcileLogos_BehaviorTable(t *testing.T) {
 func TestReconcileLogos_OnlyLightResolvedLeavesUploadedDarkLogo(t *testing.T) {
 	r := &Reconciler{}
 	api := &fakeLogoAPI{}
-	oidcClient := logoClient("https://cdn.example.com/logo.png", "", "", "")
+	oidcClient := logoClient("https://cdn.example.com/logo.png", "", "")
 	current := &pocketid.OIDCClient{ID: "client-id", HasDarkLogo: true}
 
 	plan, err := r.reconcileLogos(context.Background(), oidcClient, api, current)
@@ -493,7 +499,7 @@ func TestReconcileLogos_OnlyLightResolvedLeavesUploadedDarkLogo(t *testing.T) {
 func TestReconcileLogos_DeleteFailurePropagates(t *testing.T) {
 	r := &Reconciler{}
 	api := &fakeLogoAPI{err: errors.New("boom")}
-	oidcClient := logoClient("", "", "https://cdn.example.com/logo.png", "")
+	oidcClient := logoClient("", "https://cdn.example.com/logo.png", "")
 
 	if _, err := r.reconcileLogos(context.Background(), oidcClient, api, &pocketid.OIDCClient{ID: "client-id"}); err == nil {
 		t.Fatal("expected the delete failure to propagate")
@@ -1063,5 +1069,40 @@ func TestPushOIDCClientState_DarkLogoFailureLeavesLightLogoIntact(t *testing.T) 
 	}
 	if len(sent) != 0 {
 		t.Errorf("expected no further updates, got %q", sent)
+	}
+}
+
+// A deletion that succeeded must be recorded even when the pass later fails, or the next
+// one deletes whatever was uploaded in its place.
+func TestReconcileLogos_RecordsDeletionWhenTheOtherSideFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	oidcClient := logoClient("", "https://cdn.example.com/logo.png", "https://cdn.example.com/dark.png")
+	r := newPushStateOIDCReconciler(scheme, oidcClient)
+
+	// Light deletes cleanly; dark fails.
+	api := &fakeLogoAPI{errOn: map[bool]error{false: errors.New("boom")}}
+
+	plan, err := r.reconcileLogos(context.Background(), oidcClient, api, &pocketid.OIDCClient{ID: "client-id"})
+	if err == nil {
+		t.Fatal("expected the dark deletion failure to propagate")
+	}
+	if plan.appliedLight != "" {
+		t.Errorf("light was deleted, so it must be disowned: got %q", plan.appliedLight)
+	}
+	if plan.appliedDark != "https://cdn.example.com/dark.png" {
+		t.Errorf("dark deletion failed, so it stays owned: got %q", plan.appliedDark)
+	}
+
+	fetched := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(oidcClient), fetched); err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if fetched.Status.LogoURL != "" {
+		t.Errorf("the completed deletion must be persisted, got %q", fetched.Status.LogoURL)
+	}
+	if fetched.Status.DarkLogoURL != "https://cdn.example.com/dark.png" {
+		t.Errorf("the failed deletion must keep its record, got %q", fetched.Status.DarkLogoURL)
 	}
 }

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	grafanaLogoURL     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/grafana.png"
-	grafanaDarkLogoURL = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/grafana-dark.png"
+	grafanaLogoURL     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/grafana.webp"
+	grafanaDarkLogoURL = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/grafana-light.webp"
 )
 
 // pocketIDOIDCClientAPIResponse is the JSON shape returned by Pocket-ID OIDC client
@@ -277,10 +277,10 @@ func TestResolveLogoURLs_NilLogoSpecEnvFalse(t *testing.T) {
 func TestResolveLogoURLs_NilLogoSpecEnvTrue(t *testing.T) {
 	r := &Reconciler{DefaultAutoGenerateLogos: true}
 	logoURL, darkLogoURL := r.resolveLogoURLs(namedClient("my-app"))
-	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/my-app.png" {
+	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/my-app.webp" {
 		t.Errorf("expected hardcoded default when logo spec is nil and env is true, got %q", logoURL)
 	}
-	if darkLogoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/my-app-dark.png" {
+	if darkLogoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/my-app-light.webp" {
 		t.Errorf("expected hardcoded dark default when logo spec is nil and env is true, got %q", darkLogoURL)
 	}
 }
@@ -294,7 +294,7 @@ func TestResolveLogoURLs_AutoGenerateNilDefaultsToEnvTrue(t *testing.T) {
 		},
 	}
 	logoURL, _ := r.resolveLogoURLs(oidcClient)
-	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/my-app.png" {
+	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/my-app.webp" {
 		t.Errorf("expected nil autoGenerate to follow env default true, got %q", logoURL)
 	}
 }

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -409,6 +409,15 @@ func TestReconcileLogos_BehaviorTable(t *testing.T) {
 			resolved: url, failed: true,
 		},
 		{
+			name:     "an applied logo the spec replaced with a refused URL is deleted",
+			resolved: url, applied: "https://cdn.example.com/old.png", serverHasLogo: true,
+			failed: true, wantDelete: true,
+		},
+		{
+			name:     "an applied logo whose own URL is refused is kept",
+			resolved: url, applied: url, serverHasLogo: true, failed: true, wantApplied: url,
+		},
+		{
 			name:     "a new URL is pushed",
 			resolved: url, wantPush: url, wantApplied: url,
 		},

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -456,6 +457,7 @@ func TestReconcileLogos_BehaviorTable(t *testing.T) {
 				r := newPushStateOIDCReconciler(scheme, oidcClient)
 				if tt.failed {
 					r.markLogoURLsFailed(tt.resolved)
+					r.failedLogoURLsResetAt = time.Now()
 				}
 				api.deleted = nil
 				plan, err := r.reconcileLogos(context.Background(), oidcClient, api, current)
@@ -528,6 +530,43 @@ func TestMarkLogoURLsFailed_IgnoresEmptyAndKeysByURL(t *testing.T) {
 	}
 	if r.logoURLFailed("https://cdn.example.com/other.png") {
 		t.Error("a different URL must not inherit the failure")
+	}
+}
+
+// A URL refused once must be retried after the TTL, so a logo Pocket-ID lost is restored
+// without an operator restart.
+func TestReconcileLogos_RefusedURLIsRetriedAfterTTL(t *testing.T) {
+	const url = "https://cdn.example.com/logo.png"
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
+	oidcClient := logoClient(url, url, "")
+	r := newPushStateOIDCReconciler(scheme, oidcClient)
+	r.markLogoURLsFailed(url)
+	r.failedLogoURLsResetAt = time.Now()
+
+	current := &pocketid.OIDCClient{ID: "client-id"}
+	plan, err := r.reconcileLogos(context.Background(), oidcClient, &fakeLogoAPI{}, current)
+	if err != nil {
+		t.Fatalf("reconcileLogos: %v", err)
+	}
+	if plan.pushLight != "" {
+		t.Errorf("expected the refused URL to stay suppressed, got %q", plan.pushLight)
+	}
+
+	r.failedLogoURLsResetAt = time.Now().Add(-failedLogoURLTTL - time.Minute)
+	plan, err = r.reconcileLogos(context.Background(), oidcClient, &fakeLogoAPI{}, current)
+	if err != nil {
+		t.Fatalf("reconcileLogos after TTL: %v", err)
+	}
+	if plan.pushLight != url {
+		t.Errorf("expected the URL to be retried after the TTL, got %q", plan.pushLight)
+	}
+	if r.logoURLFailed(url) {
+		t.Error("the refusal set should have been dropped")
+	}
+	if time.Since(r.failedLogoURLsResetAt) > time.Minute {
+		t.Error("expected the reset deadline to be restamped, not expired every reconcile")
 	}
 }
 

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -13,6 +13,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -487,6 +488,36 @@ func TestReconcileLogos_BehaviorTable(t *testing.T) {
 	}
 }
 
+func TestLogoReachable(t *testing.T) {
+	const url = "https://cdn.example.com/logo.png"
+
+	tests := []struct {
+		name              string
+		resolved, applied string
+		want              *bool
+	}{
+		{name: "no logo asked for", want: nil},
+		{name: "applied is what the spec asks for", resolved: url, applied: url, want: ptr.To(true)},
+		{name: "refused, old logo still stranded", resolved: url, applied: "https://cdn.example.com/old.png", want: ptr.To(false)},
+		{name: "refused, stranded logo deleted", resolved: url, want: ptr.To(false)},
+		{name: "spec dropped a logo the operator applied", applied: url, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := logoReachable(tt.resolved, tt.applied)
+			switch {
+			case tt.want == nil && got != nil:
+				t.Errorf("got %v, want nil", *got)
+			case tt.want != nil && got == nil:
+				t.Errorf("got nil, want %v", *tt.want)
+			case tt.want != nil && *got != *tt.want:
+				t.Errorf("got %v, want %v", *got, *tt.want)
+			}
+		})
+	}
+}
+
 func TestLogoDeletePending(t *testing.T) {
 	const url = "https://cdn.example.com/logo.png"
 
@@ -539,9 +570,12 @@ func TestLogoDeletePending(t *testing.T) {
 
 // A client that resolves only a light URL must not disturb an uploaded dark logo.
 func TestReconcileLogos_OnlyLightResolvedLeavesUploadedDarkLogo(t *testing.T) {
-	r := &Reconciler{}
+	scheme := runtime.NewScheme()
+	_ = pocketidinternalv1alpha1.AddToScheme(scheme)
+
 	api := &fakeLogoAPI{}
 	oidcClient := logoClient("https://cdn.example.com/logo.png", "", "")
+	r := newPushStateOIDCReconciler(scheme, oidcClient)
 	current := &pocketid.OIDCClient{ID: "client-id", HasDarkLogo: true}
 
 	plan, err := r.reconcileLogos(context.Background(), oidcClient, api, current)

--- a/internal/controller/pocketidoidcclient_controller_test.go
+++ b/internal/controller/pocketidoidcclient_controller_test.go
@@ -1041,38 +1041,4 @@ var _ = Describe("PocketIDOIDCClient Controller", func() {
 		})
 	})
 
-	Context("Logo status reachability", func() {
-		It("should persist logoReachable=false explicitly in the API server", func() {
-			clientName := "logo-reachable-test"
-			resource := &pocketidinternalv1alpha1.PocketIDOIDCClient{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clientName,
-					Namespace: namespace,
-				},
-			}
-			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			// Patch status with light=true, dark=false
-			base := resource.DeepCopy()
-			logoTrue := true
-			darkFalse := false
-			resource.Status.LogoURL = "https://example.com/logo.png"
-			resource.Status.LogoReachable = &logoTrue
-			resource.Status.DarkLogoURL = "https://example.com/logo-dark.png"
-			resource.Status.DarkLogoReachable = &darkFalse
-			Expect(k8sClient.Status().Patch(ctx, resource, client.MergeFrom(base))).To(Succeed())
-
-			// Re-fetch from the real API server
-			fetched := &pocketidinternalv1alpha1.PocketIDOIDCClient{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: clientName, Namespace: namespace}, fetched)).To(Succeed())
-
-			Expect(fetched.Status.LogoURL).To(Equal("https://example.com/logo.png"))
-			Expect(fetched.Status.LogoReachable).NotTo(BeNil())
-			Expect(*fetched.Status.LogoReachable).To(BeTrue())
-
-			Expect(fetched.Status.DarkLogoURL).To(Equal("https://example.com/logo-dark.png"))
-			Expect(fetched.Status.DarkLogoReachable).NotTo(BeNil(), "darkLogoReachable should be explicitly set, not nil")
-			Expect(*fetched.Status.DarkLogoReachable).To(BeFalse())
-		})
-	})
 })

--- a/internal/pocketid/client.go
+++ b/internal/pocketid/client.go
@@ -177,8 +177,8 @@ func clientIDPathParam(id string) string {
 // ToInput converts an OIDCClient into an OIDCClientInput for comparison with desired state.
 // ID and Credentials are not included: federated identities aren't returned by the GET API, and
 // the secrets it carries have their own endpoints.
-// LogoURL and DarkLogoURL are write-only (not returned by the API); logo presence is
-// tracked via HasLogo/HasDarkLogo instead.
+// LogoURL and DarkLogoURL are write-only (not returned by the API) and are reconciled
+// separately, so they are left zero here.
 // AllowedUserGroupIDs is managed separately and excluded from the input.
 // PKCESupported is read-only (set by Pocket-ID, never pushed) and excluded from the input.
 func (c *OIDCClient) ToInput() OIDCClientInput {
@@ -188,8 +188,6 @@ func (c *OIDCClient) ToInput() OIDCClientInput {
 		CallbackURLs:                        c.CallbackURLs,
 		LogoutCallbackURLs:                  c.LogoutCallbackURLs,
 		LaunchURL:                           c.LaunchURL,
-		HasLogo:                             c.HasLogo,
-		HasDarkLogo:                         c.HasDarkLogo,
 		IsPublic:                            c.IsPublic,
 		IsGroupRestricted:                   c.IsGroupRestricted,
 		PKCEEnabled:                         c.PKCEEnabled,
@@ -225,8 +223,6 @@ type OIDCClientInput struct {
 	LaunchURL                           string
 	LogoURL                             string
 	DarkLogoURL                         string
-	HasLogo                             bool
-	HasDarkLogo                         bool
 	IsPublic                            bool
 	IsGroupRestricted                   bool
 	PKCEEnabled                         bool
@@ -239,15 +235,13 @@ type OIDCClientInput struct {
 }
 
 // Equal compares two OIDCClientInputs for equality on the fields that can be
-// compared (excludes ID and Credentials which are create-time or write-only,
-// and excludes LogoURL/DarkLogoURL which are not returned by the GET API —
-// logo presence is compared via HasLogo/HasDarkLogo instead).
+// compared (excludes ID and Credentials which are create-time or write-only, and
+// LogoURL/DarkLogoURL, which are attach-only instructions the GET API never echoes —
+// logos are reconciled separately against OIDCClient.HasLogo/HasDarkLogo).
 func (i OIDCClientInput) Equal(other OIDCClientInput) bool {
 	if i.Name != other.Name ||
 		i.Description != other.Description ||
 		i.LaunchURL != other.LaunchURL ||
-		i.HasLogo != other.HasLogo ||
-		i.HasDarkLogo != other.HasDarkLogo ||
 		i.IsPublic != other.IsPublic ||
 		i.IsGroupRestricted != other.IsGroupRestricted ||
 		i.PKCEEnabled != other.PKCEEnabled ||
@@ -706,8 +700,6 @@ func (c *Client) CreateOIDCClient(ctx context.Context, input OIDCClientInput) (*
 		LaunchURL:                           input.LaunchURL,
 		LogoURL:                             input.LogoURL,
 		DarkLogoURL:                         input.DarkLogoURL,
-		HasLogo:                             input.HasLogo,
-		HasDarkLogo:                         input.HasDarkLogo,
 		IsPublic:                            input.IsPublic,
 		IsGroupRestricted:                   input.IsGroupRestricted,
 		PkceEnabled:                         input.PKCEEnabled,
@@ -748,8 +740,6 @@ func (c *Client) UpdateOIDCClient(ctx context.Context, id string, input OIDCClie
 			LaunchURL:                           input.LaunchURL,
 			LogoURL:                             input.LogoURL,
 			DarkLogoURL:                         input.DarkLogoURL,
-			HasLogo:                             input.HasLogo,
-			HasDarkLogo:                         input.HasDarkLogo,
 			IsPublic:                            input.IsPublic,
 			IsGroupRestricted:                   input.IsGroupRestricted,
 			PkceEnabled:                         input.PKCEEnabled,
@@ -885,6 +875,23 @@ func (c *Client) DeleteOIDCClientSecret(ctx context.Context, id, secretID string
 	recordCall("delete_oidc_client_secret", err, time.Since(start))
 	if err != nil && !IsNotFoundError(err) {
 		return fmt.Errorf("delete OIDC client secret failed: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteOIDCClientLogo removes the stored logo for one side of a client. One already gone
+// counts as deleted, so a retried removal converges.
+func (c *Client) DeleteOIDCClientLogo(ctx context.Context, id string, light bool) error {
+	params := oidc.NewDeleteAPIOidcClientsIDLogoParams().
+		WithID(clientIDPathParam(id)).
+		WithLight(&light)
+
+	start := time.Now()
+	_, err := c.raw.OIDc.DeleteAPIOidcClientsIDLogoContext(ctx, params)
+	recordCall("delete_oidc_client_logo", err, time.Since(start))
+	if err != nil && !IsNotFoundError(err) {
+		return fmt.Errorf("delete OIDC client logo failed: %w", err)
 	}
 
 	return nil

--- a/internal/pocketid/client_secrets_test.go
+++ b/internal/pocketid/client_secrets_test.go
@@ -229,3 +229,50 @@ func TestDeleteOIDCClientSecret(t *testing.T) {
 		}
 	})
 }
+
+func TestDeleteOIDCClientLogo(t *testing.T) {
+	t.Run("targets the requested side", func(t *testing.T) {
+		var path, query string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			path, query = r.URL.Path, r.URL.RawQuery
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer ts.Close()
+
+		client, _ := NewClient(ts.URL, "")
+		if err := client.DeleteOIDCClientLogo(context.Background(), "client-123", false); err != nil {
+			t.Fatalf("DeleteOIDCClientLogo: %v", err)
+		}
+		if path != "/api/oidc/clients/client-123/logo" {
+			t.Errorf("path: got %q", path)
+		}
+		if query != "light=false" {
+			t.Errorf("query: got %q, want light=false", query)
+		}
+	})
+
+	// Removal is retried until it sticks, so a logo already gone is the desired end state.
+	t.Run("treats an already-deleted logo as deleted", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		client, _ := NewClient(ts.URL, "")
+		if err := client.DeleteOIDCClientLogo(context.Background(), "client-123", true); err != nil {
+			t.Fatalf("expected a missing logo to count as deleted, got %v", err)
+		}
+	})
+
+	t.Run("propagates other failures", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		client, _ := NewClient(ts.URL, "")
+		if err := client.DeleteOIDCClientLogo(context.Background(), "client-123", true); err == nil {
+			t.Fatal("expected a server error to propagate rather than count as deleted")
+		}
+	})
+}

--- a/internal/pocketid/client_test.go
+++ b/internal/pocketid/client_test.go
@@ -551,12 +551,6 @@ func TestOIDCClientToInput_MapsAllFields(t *testing.T) {
 	if input.LaunchURL != "https://app.example.com" {
 		t.Errorf("LaunchURL: got %q", input.LaunchURL)
 	}
-	if !input.HasLogo {
-		t.Error("HasLogo: expected true")
-	}
-	if !input.HasDarkLogo {
-		t.Error("HasDarkLogo: expected true")
-	}
 	if !input.IsPublic {
 		t.Error("IsPublic: expected true")
 	}
@@ -924,7 +918,7 @@ func TestUserGroupToInput_MapsAllFields(t *testing.T) {
 // --- OIDCClientInput.Equal() ---
 
 func TestOIDCClientInputEqual_IdenticalInputsAreEqual(t *testing.T) {
-	a := OIDCClientInput{Name: "test", CallbackURLs: []string{"https://a.example.com/cb"}, HasLogo: true}
+	a := OIDCClientInput{Name: "test", CallbackURLs: []string{"https://a.example.com/cb"}}
 	b := a
 	if !a.Equal(b) {
 		t.Error("expected identical inputs to be equal")

--- a/internal/pocketid/errors.go
+++ b/internal/pocketid/errors.go
@@ -61,6 +61,20 @@ func (e *APIError) Error() string {
 
 func (e *APIError) Unwrap() error { return e.err }
 
+// HasFieldError reports whether a validation failure blames any of fields. The envelope
+// carries them as {"details": {"fields": [{"field": "logoUrl", "message": "..."}]}}.
+func (e *APIError) HasFieldError(fields ...string) bool {
+	entries, _ := e.Details["fields"].([]any)
+	for _, entry := range entries {
+		object, _ := entry.(map[string]any)
+		name, _ := object["field"].(string)
+		if slices.Contains(fields, name) {
+			return true
+		}
+	}
+	return false
+}
+
 // AsAPIError returns the *APIError in err's chain, or nil if the call never got a response.
 func AsAPIError(err error) *APIError {
 	var apiErr *APIError
@@ -102,6 +116,25 @@ var validationCodes = []models.ApperrorCode{
 	models.ApperrorCodeReservedClaim,
 	models.ApperrorCodeDuplicateClaim,
 	models.ApperrorCodeInvalidAPIKeyExpiration,
+}
+
+var logoCodes = []models.ApperrorCode{
+	models.ApperrorCodeLogoDownloadFailed,
+	models.ApperrorCodeLogoTypeNotSupported,
+	models.ApperrorCodeLogoTooLarge,
+}
+
+// IsLogoError reports a failure Pocket-ID blames on a logo URL rather than on the client
+// configuration, which it has already committed by the time it fetches the logo. A URL it
+// rejects outright — not http/https, no host, a private address — is reported as a plain
+// validation failure, so that case is recognised by the field it names instead of by a code.
+func IsLogoError(err error) bool {
+	if classify(err, logoCodes) {
+		return true
+	}
+	apiErr := AsAPIError(err)
+	return apiErr != nil && apiErr.Code == models.ApperrorCodeValidationFailed &&
+		apiErr.HasFieldError("logoUrl", "darkLogoUrl")
 }
 
 func IsNotFoundError(err error) bool {

--- a/internal/pocketid/errors_test.go
+++ b/internal/pocketid/errors_test.go
@@ -243,3 +243,84 @@ func TestErrorMessageCarriesRequestID(t *testing.T) {
 		t.Errorf("Error():\n got %q\nwant %q", got, want)
 	}
 }
+
+// Pocket-ID commits the client update before it fetches the logo, so these codes have to be
+// separable from a failure that rejected the configuration itself.
+func TestIsLogoError(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		envelope errorEnvelope
+		want     bool
+	}{
+		{
+			name:   "download failed",
+			status: http.StatusUnprocessableEntity,
+			envelope: errorEnvelope{Error: "Logo could not be downloaded",
+				Code: string(models.ApperrorCodeLogoDownloadFailed)},
+			want: true,
+		},
+		{
+			name:   "unsupported type",
+			status: http.StatusUnprocessableEntity,
+			envelope: errorEnvelope{Error: "Logo type not supported",
+				Code: string(models.ApperrorCodeLogoTypeNotSupported)},
+			want: true,
+		},
+		{
+			name:   "too large",
+			status: http.StatusUnprocessableEntity,
+			envelope: errorEnvelope{Error: "Logo too large",
+				Code: string(models.ApperrorCodeLogoTooLarge)},
+			want: true,
+		},
+		{
+			// An unusable URL has no code of its own; the blamed field is the only signal.
+			name:   "invalid URL blamed on logoUrl",
+			status: http.StatusBadRequest,
+			envelope: errorEnvelope{Error: "Validation failed",
+				Code:    string(models.ApperrorCodeValidationFailed),
+				Details: map[string]any{"fields": []any{map[string]any{"field": "logoUrl", "message": "invalid"}}}},
+			want: true,
+		},
+		{
+			name:   "invalid URL blamed on darkLogoUrl",
+			status: http.StatusBadRequest,
+			envelope: errorEnvelope{Error: "Validation failed",
+				Code:    string(models.ApperrorCodeValidationFailed),
+				Details: map[string]any{"fields": []any{map[string]any{"field": "darkLogoUrl", "message": "invalid"}}}},
+			want: true,
+		},
+		{
+			name:   "validation failure on another field is not a logo error",
+			status: http.StatusBadRequest,
+			envelope: errorEnvelope{Error: "Validation failed",
+				Code:    string(models.ApperrorCodeValidationFailed),
+				Details: map[string]any{"fields": []any{map[string]any{"field": "callbackURLs"}}}},
+		},
+		{
+			name:     "validation failure with no details is not a logo error",
+			status:   http.StatusBadRequest,
+			envelope: errorEnvelope{Error: "Validation failed", Code: string(models.ApperrorCodeValidationFailed)},
+		},
+		{
+			// No envelope means no attribution, so the whole update has to be treated as failed.
+			name:   "envelope-less failure is not a logo error",
+			status: http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := envelopeServer(t, tt.status, tt.envelope, nil)
+			_, err := newTestClient(t, ts.URL).UpdateOIDCClient(context.Background(), "client-id",
+				OIDCClientInput{Name: "client", LogoURL: "https://cdn.example.com/logo.png"})
+			if err == nil {
+				t.Fatal("UpdateOIDCClient: expected an error")
+			}
+			if got := IsLogoError(err); got != tt.want {
+				t.Errorf("IsLogoError: got %v, want %v (%v)", got, tt.want, err)
+			}
+		})
+	}
+}

--- a/internal/pocketid/oidc_write_dto_test.go
+++ b/internal/pocketid/oidc_write_dto_test.go
@@ -20,13 +20,18 @@ import (
 // regen fails here instead of silently never being pushed. Keys Pocket-ID
 // documents as read-only are exempt and listed as such.
 
+// Pocket-ID derives logo presence from the files it has stored and ignores what a write
+// claims, so these keys are never sent. Logos are attached with logoUrl/darkLogoUrl and
+// removed through the logo endpoint.
+var logoPresenceKeys = []string{"hasLogo", "hasDarkLogo"}
+
 func TestCreateOIDCClient_PayloadCoversWriteDTO(t *testing.T) {
 	body := captureOIDCClientWrite(t, http.MethodPost, "/api/oidc/clients", func(c *Client, input OIDCClientInput) error {
 		_, err := c.CreateOIDCClient(context.Background(), input)
 		return err
 	})
 
-	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientCreateDto{}, body, "")
+	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientCreateDto{}, body, "", logoPresenceKeys...)
 	assertFederatedIdentityFieldsSet(t, body)
 }
 
@@ -36,7 +41,7 @@ func TestUpdateOIDCClient_PayloadCoversWriteDTO(t *testing.T) {
 		return err
 	})
 
-	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientUpdateDto{}, body, "")
+	assertDTOFieldsSet(t, models.GithubComPocketIDPocketIDBackendInternalDtoOidcClientUpdateDto{}, body, "", logoPresenceKeys...)
 	assertFederatedIdentityFieldsSet(t, body)
 }
 
@@ -75,8 +80,6 @@ func captureOIDCClientWrite(t *testing.T, method, path string, write func(*Clien
 		LaunchURL:                           "https://example.com",
 		LogoURL:                             "https://example.com/logo.png",
 		DarkLogoURL:                         "https://example.com/logo-dark.png",
-		HasLogo:                             true,
-		HasDarkLogo:                         true,
 		IsPublic:                            true,
 		IsGroupRestricted:                   true,
 		PKCEEnabled:                         true,

--- a/test/e2e/logo_test.go
+++ b/test/e2e/logo_test.go
@@ -4,8 +4,13 @@
 package e2e
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,12 +45,25 @@ var _ = Describe("Logo Auto-Generation", Ordered, func() {
 				g.Expect(hasLogo).To(Equal("true"))
 			}).Should(Succeed())
 
-			By("verifying the logo status fields are set")
+			By("verifying the applied logo URL is recorded in status")
 			logoURL := getField("pocketidoidcclient", clientName, userNS, ".status.logoUrl")
 			Expect(logoURL).To(ContainSubstring("grafana"))
+		})
 
-			logoReachable := getField("pocketidoidcclient", clientName, userNS, ".status.logoReachable")
-			Expect(logoReachable).To(Equal("true"))
+		It("should remove the logo it applied once the spec stops asking for one", func() {
+			oidcClientID := getField("pocketidoidcclient", clientName, userNS, ".status.clientID")
+
+			By("disabling auto-generation on the existing client")
+			applyYAML(buildOIDCClientYAML(OIDCClientOptions{
+				Name: clientName,
+				Logo: &OIDCLogoConfig{AutoGenerate: boolPtr(false)},
+			}))
+
+			By("verifying the logo is deleted from Pocket-ID and the applied record cleared")
+			Eventually(func(g Gomega) {
+				g.Expect(getOIDCClientField(oidcClientID, "hasLogo")).To(Equal("false"))
+				g.Expect(getField("pocketidoidcclient", clientName, userNS, ".status.logoUrl")).To(BeEmpty())
+			}).Should(Succeed())
 		})
 
 		AfterAll(func() {
@@ -80,7 +98,80 @@ var _ = Describe("Logo Auto-Generation", Ordered, func() {
 			waitForResourceDeleted("pocketidoidcclient", clientName, userNS)
 		})
 	})
+
+	// Issue #603: a logo the operator never applied is not the operator's to manage, so it
+	// must survive every resync untouched rather than driving an update that cannot converge.
+	Context("Logo uploaded out of band", func() {
+		const clientName = "test-logo-uploaded"
+
+		It("should leave an uploaded logo alone when autoGenerate is false", func() {
+			By("creating an OIDC client with logo auto-generation disabled")
+			applyYAML(buildOIDCClientYAML(OIDCClientOptions{
+				Name: clientName,
+				Logo: &OIDCLogoConfig{AutoGenerate: boolPtr(false)},
+			}))
+			waitForReady("pocketidoidcclient", clientName, userNS)
+			oidcClientID := waitForStatusFieldNotEmpty("pocketidoidcclient", clientName, userNS, ".status.clientID")
+
+			By("uploading a logo directly to Pocket-ID, as the UI would")
+			uploadLogoToPocketID(oidcClientID, true)
+			Expect(getOIDCClientField(oidcClientID, "hasLogo")).To(Equal("true"))
+
+			By("forcing a reconcile and verifying the upload survives")
+			Expect(annotateObject("pocketidoidcclient", clientName, userNS, "test/trigger-reconcile=1")).To(Succeed())
+			Consistently(func(g Gomega) {
+				g.Expect(getOIDCClientField(oidcClientID, "hasLogo")).To(Equal("true"))
+				g.Expect(getField("pocketidoidcclient", clientName, userNS, ".status.logoUrl")).To(BeEmpty())
+			}, 20*time.Second, 4*time.Second).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			deleteObject("pocketidoidcclient", clientName, userNS)
+			waitForResourceDeleted("pocketidoidcclient", clientName, userNS)
+		})
+	})
 })
+
+// onePixelPNG is the smallest valid PNG, used as a stand-in for a logo a user uploaded.
+var onePixelPNG = []byte{
+	0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+	0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00,
+	0x1f, 0x15, 0xc4, 0x89,
+	0x00, 0x00, 0x00, 0x0a, 'I', 'D', 'A', 'T',
+	0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01,
+	0x0d, 0x0a, 0x2d, 0xb4,
+	0x00, 0x00, 0x00, 0x00, 'I', 'E', 'N', 'D', 0xae, 0x42, 0x60, 0x82,
+}
+
+// uploadLogoToPocketID attaches a logo to a client the way the UI does — a multipart upload
+// to the logo endpoint, leaving no logoUrl for the operator to have recorded as applied.
+func uploadLogoToPocketID(oidcClientID string, light bool) {
+	GinkgoHelper()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", "logo.png")
+	Expect(err).NotTo(HaveOccurred(), "building multipart form")
+	_, err = part.Write(onePixelPNG)
+	Expect(err).NotTo(HaveOccurred(), "writing logo bytes")
+	Expect(writer.Close()).To(Succeed())
+
+	ctx, cancel := testCtx()
+	defer cancel()
+
+	apiPath := fmt.Sprintf("/api/oidc/clients/%s/logo?light=%t", oidcClientID, light)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, pocketIDBaseURL()+apiPath, &buf)
+	Expect(err).NotTo(HaveOccurred(), "building logo upload request")
+	req.Header.Set("X-API-KEY", staticAPIKey())
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).NotTo(HaveOccurred(), "uploading logo")
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	Expect(resp.StatusCode).To(BeNumerically("<", 300), "POST %s returned %d: %s", apiPath, resp.StatusCode, body)
+}
 
 // getOIDCClientField returns one top-level field of an OIDC client as Pocket-ID reports
 // it, rendered the way the previous shell version did: bare scalars, so a boolean reads


### PR DESCRIPTION
In-part fixes https://github.com/aclerici38/pocket-id-operator/issues/603. Any oidcclient with `autoGenerate=false` and no explicit logo url set in the spec doesn't touch the logos inside pocket-id, allowing manual uploads to persist. This was the existing behavior but not explicit in the controller code which would try to update each reconcile under those conditions as the returned DTO had a logo but the CR did not.

Splits the logo reconciliation into 2 branches, one for light and dark. This along with the recent structured error messages added to pocket-id allow the operator to leverage pocket-id's logic for downloading the logos rather than running a HEAD to each configured url each reconcile.
Also adds ownership to the operator for any logo it manages (url sent and successfully added to the oidcclient) so if the logo url is deleted from the oidcclient the logo is also deleted in pocket-id. 

A side-effect of this is each logo needs to be sent in a separate request to know if the light or dark one failed independent of the other. That is an extra request to pocket-id for each failing logo INSIDE each oidcclent each time the operator is rolled out or an oidcclient is created. I think that is a good tradeoff as logos will only be reattempted on operator startup.