### PR TITLE
fix: allow unsetting default light/dark logo url

### DIFF
--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -10443,7 +10443,7 @@
             "string",
             "null"
           ],
-          "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Unset generates no light logo.",
+          "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Set to \"\" to generate no light logo.",
           "default": "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
         },
         "defaultDarkLogoUrl": {

--- a/charts/pocket-id-operator/values.schema.json
+++ b/charts/pocket-id-operator/values.schema.json
@@ -10439,12 +10439,19 @@
           "default": true
         },
         "defaultLogoUrl": {
-          "type": "string",
-          "description": "Default URL template for light logos. Use {{name}} as placeholder. Defaults to the dashboard-icons CDN."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Unset generates no light logo.",
+          "default": "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
         },
         "defaultDarkLogoUrl": {
-          "type": "string",
-          "description": "Default URL template for dark logos. Use {{name}} as placeholder. Defaults to the dashboard-icons CDN."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URL template for auto-generated dark logos. Use {{name}} as placeholder. Unset generates no dark logo."
         }
       }
     },

--- a/charts/pocket-id-operator/values.schema.skeleton.json
+++ b/charts/pocket-id-operator/values.schema.skeleton.json
@@ -237,12 +237,13 @@
           "default": true
         },
         "defaultLogoUrl": {
-          "type": "string",
-          "description": "Default URL template for light logos. Use {{name}} as placeholder. Defaults to the dashboard-icons CDN."
+          "type": ["string", "null"],
+          "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Unset generates no light logo.",
+          "default": "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
         },
         "defaultDarkLogoUrl": {
-          "type": "string",
-          "description": "Default URL template for dark logos. Use {{name}} as placeholder. Defaults to the dashboard-icons CDN."
+          "type": ["string", "null"],
+          "description": "URL template for auto-generated dark logos. Use {{name}} as placeholder. Unset generates no dark logo."
         }
       }
     },

--- a/charts/pocket-id-operator/values.schema.skeleton.json
+++ b/charts/pocket-id-operator/values.schema.skeleton.json
@@ -238,7 +238,7 @@
         },
         "defaultLogoUrl": {
           "type": ["string", "null"],
-          "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Unset generates no light logo.",
+          "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Set to \"\" to generate no light logo.",
           "default": "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
         },
         "defaultDarkLogoUrl": {

--- a/charts/pocket-id-operator/values.yaml
+++ b/charts/pocket-id-operator/values.yaml
@@ -27,10 +27,12 @@ operator:
   # env var is left unset.
   timezone: ""
 
-  # Default URL template for light logos ({{name}} is replaced with the client name)
-  # Defaults to the dashboard-icons CDN if not set
-  # defaultLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
-  # Default URL template for dark logos
+  # URL template for auto-generated light logos, {{name}} is replaced with the client name.
+  # Unset it to generate no light logos.
+  defaultLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
+
+  # URL template for auto-generated dark logos, unset by default. dashboard-icons only
+  # publishes a -light variant for some icons, and pocket-id falls back to the light logo.
   # defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
 
   podSecurityContext:

--- a/charts/pocket-id-operator/values.yaml
+++ b/charts/pocket-id-operator/values.yaml
@@ -27,13 +27,15 @@ operator:
   # env var is left unset.
   timezone: ""
 
-  # URL template for auto-generated light logos, {{name}} is replaced with the client name.
-  # Unset it to generate no light logos.
+  # URL templates for auto-generated logos, {{name}} is replaced with the client name.
+  # The two sides are independent: set one to "" to stop generating it and the other keeps
+  # working, e.g. defaultDarkLogoUrl: "" for light logos only.
   defaultLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
 
-  # URL template for auto-generated dark logos, unset by default. dashboard-icons only
-  # publishes a -light variant for some icons, and pocket-id falls back to the light logo.
-  # defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
+  # Only about a sixth of dashboard-icons publish a -light variant. The rest 404, which costs
+  # one rejected request a day per client and leaves status.darkLogoReachable false, and
+  # pocket-id falls back to the light logo.
+  defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
 
   podSecurityContext:
     runAsNonRoot: true

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -17,6 +17,9 @@ patches:
           value: "2s"
         - name: AUTOGENERATE_LOGOS
           value: "false"
+        # The logo tests opt in per client, so they need a template to generate from.
+        - name: DEFAULT_LOGO_URL
+          value: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
     - op: replace
       path: /spec/template/spec/containers/0/args/2
       value: --zap-log-level=debug

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -11748,12 +11748,19 @@
                   "default": true
                 },
                 "defaultLogoUrl": {
-                  "type": "string",
-                  "description": "Default URL template for light logos. Use {{name}} as placeholder. Defaults to the dashboard-icons CDN."
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Unset generates no light logo.",
+                  "default": "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
                 },
                 "defaultDarkLogoUrl": {
-                  "type": "string",
-                  "description": "Default URL template for dark logos. Use {{name}} as placeholder. Defaults to the dashboard-icons CDN."
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "URL template for auto-generated dark logos. Use {{name}} as placeholder. Unset generates no dark logo."
                 }
               }
             },

--- a/dist/schemas/helmrelease_v2_pocket-id-operator.json
+++ b/dist/schemas/helmrelease_v2_pocket-id-operator.json
@@ -11752,7 +11752,7 @@
                     "string",
                     "null"
                   ],
-                  "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Unset generates no light logo.",
+                  "description": "URL template for auto-generated light logos. Use {{name}} as placeholder. Set to \"\" to generate no light logo.",
                   "default": "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
                 },
                 "defaultDarkLogoUrl": {

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -553,21 +553,27 @@ whatever `autoGenerate` says.
 
 ### Chart Configuration
 
-The chart sets the light template to the
-[dashboard-icons](https://github.com/homarr-labs/dashboard-icons) CDN and leaves the dark one
-unset:
+The chart sets both templates to the
+[dashboard-icons](https://github.com/homarr-labs/dashboard-icons) CDN:
 
 ```yaml
 operator:
   autoGenerateLogos: true
   defaultLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
-  # defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
+  defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
 ```
 
-Removing a template's value stops that side being generated. The dark one starts out removed
-because dashboard-icons publishes a `-light` variant only for the icons whose base image is
-unreadable on a dark background, so most names have none, and Pocket-ID falls back to the
-light logo when a client has no dark one.
+The sides are independent, so setting one to `""` stops it being generated and leaves the
+other alone. For light logos only:
+
+```yaml
+operator:
+  defaultDarkLogoUrl: ""
+```
+
+Dashboard-icons publishes a `-light` variant for about a sixth of its icons, so most clients resolve a dark URL that 404s: Pocket-ID falls back
+to the light logo, but each one costs a rejected request a day and logs an error.
+`status.darkLogoReachable: false`.
 
 ### Configuration
 
@@ -598,9 +604,12 @@ Within the `spec.logo` struct, any entries in `spec.logo.logoUrl` or `spec.logo.
 | `DEFAULT_LOGO_URL`        | *(unset)* | Template for light logos. Unset generates none. |
 | `DEFAULT_DARK_LOGO_URL`   | *(unset)* | Template for dark logos. Unset generates none. |
 
+These are the defaults for the operator on its own. The chart sets both, from
+`operator.defaultLogoUrl` and `operator.defaultDarkLogoUrl`.
+
 ### Examples
 
-Use the chart's light logo template (no extra configuration needed):
+Use the chart's logo templates (no extra configuration needed):
 
 ```yaml
 apiVersion: pocketid.internal/v1alpha1
@@ -611,7 +620,7 @@ spec:
   logo: {}
 ```
 
-This resolves to `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/grafana.webp`.
+This resolves to `.../webp/grafana.webp` and `.../webp/grafana-light.webp`.
 
 Override the icon name when it doesn't match the client name:
 

--- a/docs/pocketidoidcclient.md
+++ b/docs/pocketidoidcclient.md
@@ -537,39 +537,37 @@ this way, and removing an `apiAccess` entry does not revoke it.
 
 ## Logo Auto-Generation
 
-The operator can automatically set logo URLs for OIDC clients using a configurable URL template.
-By default it uses the [dashboard-icons](https://github.com/homarr-labs/dashboard-icons) CDN:
+The operator can set logo URLs for OIDC clients from a URL template. `{{name}}` in a template
+is replaced with the resource's `metadata.name`, or `spec.logo.nameOverride`.
 
-```
-https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp
-https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp
-```
+The templates come from two env vars on the operator, `DEFAULT_LOGO_URL` and
+`DEFAULT_DARK_LOGO_URL`. An unset one means no logo is generated for that variant.
 
-The `{{name}}` placeholder in templates is replaced with the resource's `metadata.name` or `spec.logo.nameOverride`.
+`spec.logo.autoGenerate` decides whether a client uses the default templates. `AUTOGENERATE_LOGOS`
+is the same switch set globally, so it does not have to be repeated on every client, and
+defaults to `true`. Setting `autoGenerate: false` on a client means the env vars are not used
+for it.
 
-### Enabling / Disabling
+`spec.logo.logoUrl` and `spec.logo.darkLogoUrl` give a client its own template, which is used
+whatever `autoGenerate` says.
 
-Logo auto-generation is controlled at two levels:
+### Chart Configuration
 
-1. **Global default** via the `AUTOGENERATE_LOGOS` env var on the operator. Defaults to `true`.
-   Set to `false` to make logo auto-generation opt-in per client.
-2. **Per-client override** via `spec.logo.autoGenerate`. When set, this takes precedence over
-   the global default.
-
-To disable auto-generation globally:
-
-```yaml
-env:
-  - name: AUTOGENERATE_LOGOS
-    value: "false"
-```
-
-Or through the chart
+The chart sets the light template to the
+[dashboard-icons](https://github.com/homarr-labs/dashboard-icons) CDN and leaves the dark one
+unset:
 
 ```yaml
 operator:
-  autoGenerateLogos: false
+  autoGenerateLogos: true
+  defaultLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
+  # defaultDarkLogoUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
 ```
+
+Removing a template's value stops that side being generated. The dark one starts out removed
+because dashboard-icons publishes a `-light` variant only for the icons whose base image is
+unreadable on a dark background, so most names have none, and Pocket-ID falls back to the
+light logo when a client has no dark one.
 
 ### Configuration
 
@@ -579,8 +577,8 @@ The `spec.logo` struct supports the following fields:
 |------------------|-----------------------------------------------------------------------------|
 | `autoGenerate`   | Override the global `AUTOGENERATE_LOGOS` default for this client.            |
 | `nameOverride`   | Override the name used in `{{name}}` substitution. Defaults to `metadata.name`. |
-| `logoUrl`        | URL for the light logo. Defaults to `DEFAULT_LOGO_URL` env var. |
-| `darkLogoUrl`    | URL for the dark logo. Defaults to `DEFAULT_DARK_LOGO_URL` env var. |
+| `logoUrl`        | Template for the light logo, used whatever `autoGenerate` says. |
+| `darkLogoUrl`    | Template for the dark logo, used whatever `autoGenerate` says. |
 
 ### Precedence
 
@@ -588,7 +586,7 @@ Logo URLs are resolved in the following order:
 
 1. **Deprecated `spec.logoUrl` / `spec.darkLogoUrl`**: if set, these are used as-is. If using these, please migrate to `spec.logo.logoUrl` and `spec.logo.darkLogoUrl`. You can still set a full URL without templating in these fields. 
 2. **`spec.logo` struct**
-3. **No logo**: if `autoGenerate` is disabled and `spec.logo.logoUrl`/`spec.logo.darkLogoUrl` are empty
+3. **No logo**: if `spec.logo.logoUrl`/`spec.logo.darkLogoUrl` are empty and either `autoGenerate` is disabled or the operator has no template for that side
 
 Within the `spec.logo` struct, any entries in `spec.logo.logoUrl` or `spec.logo.darkLogoUrl` take precedence over the defaults set by env variables
 
@@ -597,12 +595,12 @@ Within the `spec.logo` struct, any entries in `spec.logo.logoUrl` or `spec.logo.
 | Variable                  | Default | Description                                        |
 |---------------------------|---------|----------------------------------------------------|
 | `AUTOGENERATE_LOGOS`      | `true`  | Global default for `spec.logo.autoGenerate`.       |
-| `DEFAULT_LOGO_URL`        | *(dashboard-icons WebP)* | Default URL template for light logos. |
-| `DEFAULT_DARK_LOGO_URL`   | *(dashboard-icons WebP)* | Default URL template for dark logos.  |
+| `DEFAULT_LOGO_URL`        | *(unset)* | Template for light logos. Unset generates none. |
+| `DEFAULT_DARK_LOGO_URL`   | *(unset)* | Template for dark logos. Unset generates none. |
 
 ### Examples
 
-Use the default dashboard-icons logos (no extra configuration needed):
+Use the chart's light logo template (no extra configuration needed):
 
 ```yaml
 apiVersion: pocketid.internal/v1alpha1

--- a/internal/controller/oidcclient/controller.go
+++ b/internal/controller/oidcclient/controller.go
@@ -63,9 +63,6 @@ const (
 	// its metadata document ahead of the cache TTL.
 	refreshClientMetadataAnnotation = "pocketid.internal/refresh-client-metadata"
 
-	defaultLogoTemplate     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
-	defaultDarkLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}-light.webp"
-
 	// failedLogoURLTTL is how long a URL Pocket-ID refused stays suppressed.
 	failedLogoURLTTL = 24 * time.Hour
 )
@@ -86,9 +83,10 @@ type Reconciler struct {
 
 	// DefaultAutoGenerateLogos is the default for logo.autoGenerate when not set per-client (from AUTOGENERATE_LOGOS env var).
 	DefaultAutoGenerateLogos bool
-	// DefaultLogoTemplate is the default URL template for light logos (from DEFAULT_LOGO_URL env var).
+	// DefaultLogoTemplate is the URL template for light logos (from DEFAULT_LOGO_URL env var).
+	// Empty means no light logo is generated.
 	DefaultLogoTemplate string
-	// DefaultDarkLogoTemplate is the default URL template for dark logos (from DEFAULT_DARK_LOGO_URL env var).
+	// DefaultDarkLogoTemplate is the same for dark logos (from DEFAULT_DARK_LOGO_URL env var).
 	DefaultDarkLogoTemplate string
 
 	// failedLogoURLs records logo URLs Pocket-ID refused, which are not retried until the whole set is dropped on the failedLogoURLTTL deadline below.
@@ -916,18 +914,10 @@ func (r *Reconciler) resolveLogoURLs(oidcClient *pocketidinternalv1alpha1.Pocket
 		darkLogoTemplate = logo.DarkLogoURL
 	}
 	if logoTemplate == "" && autoGenerate {
-		if r.DefaultLogoTemplate != "" {
-			logoTemplate = r.DefaultLogoTemplate
-		} else {
-			logoTemplate = defaultLogoTemplate
-		}
+		logoTemplate = r.DefaultLogoTemplate
 	}
 	if darkLogoTemplate == "" && autoGenerate {
-		if r.DefaultDarkLogoTemplate != "" {
-			darkLogoTemplate = r.DefaultDarkLogoTemplate
-		} else {
-			darkLogoTemplate = defaultDarkLogoTemplate
-		}
+		darkLogoTemplate = r.DefaultDarkLogoTemplate
 	}
 
 	if logoTemplate != "" {

--- a/internal/controller/oidcclient/push_state_test.go
+++ b/internal/controller/oidcclient/push_state_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	grafanaLogoURL     = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/grafana.webp"
-	grafanaDarkLogoURL = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/grafana-light.webp"
+	grafanaLogoTemplate = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/{{name}}.webp"
+	grafanaLogoURL      = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/grafana.webp"
 )
 
 // pocketIDOIDCClientAPIResponse is the JSON shape returned by Pocket-ID OIDC client
@@ -211,7 +211,7 @@ func TestResolveLogoURLs_EnvVarFallback(t *testing.T) {
 	}
 }
 
-func TestResolveLogoURLs_HardcodedDefaults(t *testing.T) {
+func TestResolveLogoURLs_NoTemplatesConfigured(t *testing.T) {
 	r := &Reconciler{}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
 		ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: testNamespace},
@@ -222,11 +222,19 @@ func TestResolveLogoURLs_HardcodedDefaults(t *testing.T) {
 		},
 	}
 	logoURL, darkLogoURL := r.resolveLogoURLs(oidcClient)
-	if logoURL != grafanaLogoURL {
-		t.Errorf("expected hardcoded default logo template, got %q", logoURL)
+	if logoURL != "" || darkLogoURL != "" {
+		t.Errorf("expected no URLs when no templates are configured, got %q %q", logoURL, darkLogoURL)
 	}
-	if darkLogoURL != grafanaDarkLogoURL {
-		t.Errorf("expected hardcoded default dark logo template, got %q", darkLogoURL)
+}
+
+func TestResolveLogoURLs_LightTemplateOnly(t *testing.T) {
+	r := &Reconciler{DefaultAutoGenerateLogos: true, DefaultLogoTemplate: grafanaLogoTemplate}
+	logoURL, darkLogoURL := r.resolveLogoURLs(namedClient("grafana"))
+	if logoURL != grafanaLogoURL {
+		t.Errorf("expected the light template to be used, got %q", logoURL)
+	}
+	if darkLogoURL != "" {
+		t.Errorf("expected no dark logo with no dark template, got %q", darkLogoURL)
 	}
 }
 
@@ -275,26 +283,37 @@ func TestResolveLogoURLs_NilLogoSpecEnvFalse(t *testing.T) {
 }
 
 func TestResolveLogoURLs_NilLogoSpecEnvTrue(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: true}
-	logoURL, darkLogoURL := r.resolveLogoURLs(namedClient("my-app"))
-	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/my-app.webp" {
-		t.Errorf("expected hardcoded default when logo spec is nil and env is true, got %q", logoURL)
+	r := &Reconciler{DefaultAutoGenerateLogos: true, DefaultLogoTemplate: grafanaLogoTemplate}
+	logoURL, _ := r.resolveLogoURLs(namedClient("grafana"))
+	if logoURL != grafanaLogoURL {
+		t.Errorf("expected the light template when logo spec is nil and env is true, got %q", logoURL)
 	}
-	if darkLogoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/my-app-light.webp" {
-		t.Errorf("expected hardcoded dark default when logo spec is nil and env is true, got %q", darkLogoURL)
+}
+
+func TestResolveLogoURLs_PerClientTemplateWithNoDefaults(t *testing.T) {
+	r := &Reconciler{DefaultAutoGenerateLogos: true}
+	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
+		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
+			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{LogoURL: "https://cdn.example.com/{{name}}.png"},
+		},
+	}
+	logoURL, _ := r.resolveLogoURLs(oidcClient)
+	if logoURL != "https://cdn.example.com/my-app.png" {
+		t.Errorf("expected the per-client template to be used, got %q", logoURL)
 	}
 }
 
 func TestResolveLogoURLs_AutoGenerateNilDefaultsToEnvTrue(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: true}
+	r := &Reconciler{DefaultAutoGenerateLogos: true, DefaultLogoTemplate: grafanaLogoTemplate}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: "grafana", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{
 			Logo: &pocketidinternalv1alpha1.OIDCClientLogoSpec{},
 		},
 	}
 	logoURL, _ := r.resolveLogoURLs(oidcClient)
-	if logoURL != "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/my-app.webp" {
+	if logoURL != grafanaLogoURL {
 		t.Errorf("expected nil autoGenerate to follow env default true, got %q", logoURL)
 	}
 }
@@ -314,7 +333,7 @@ func TestResolveLogoURLs_AutoGenerateNilDefaultsToEnvFalse(t *testing.T) {
 }
 
 func TestResolveLogoURLs_ExplicitTrueOverridesEnvFalse(t *testing.T) {
-	r := &Reconciler{DefaultAutoGenerateLogos: false}
+	r := &Reconciler{DefaultAutoGenerateLogos: false, DefaultLogoTemplate: grafanaLogoTemplate}
 	oidcClient := &pocketidinternalv1alpha1.PocketIDOIDCClient{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: testNamespace},
 		Spec: pocketidinternalv1alpha1.PocketIDOIDCClientSpec{


### PR DESCRIPTION
This should be a little easier to use and silence the errors in the logs when a logo is unavailable. Initially the default templates were all or nothing, now unsetting either env var means that template url is not validated. This allows someone to only use a light or dark logo template if they'd like, as there aren't too many logos with proper dark variants.